### PR TITLE
feat: Add a simple implementation of Provider Options.

### DIFF
--- a/examples/c04-provider-options.rs
+++ b/examples/c04-provider-options.rs
@@ -1,0 +1,45 @@
+use genai::chat::{ChatMessage, ChatRequest, ChatRequestOptions, OpenAIOptions, ProviderOptions};
+use genai::client::Client;
+use genai::utils::print_chat_stream;
+
+const MODEL: &str = "gpt-3.5-turbo";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let questions = &[
+		// follow-up questions
+		"Why is the sky blue?",
+		"Why is it red sometime?",
+	];
+
+	let client = Client::default();
+
+	// OpenAI options
+	let openai_opts = OpenAIOptions {
+		temperature: Some(0.2),
+		max_tokens: Some(50),
+		..Default::default()
+	};
+
+	let req_opts = ChatRequestOptions {
+		provider_options: Some(ProviderOptions::OpenAI(openai_opts)),
+		..Default::default()
+	};
+
+	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
+	// Similar to put a first System Chat Message(s) (will be cummulative with sytem chat messages)
+
+	for &question in questions {
+		chat_req = chat_req.append_message(ChatMessage::user(question));
+
+		println!("\n--- Question:\n{question}");
+		let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), Some(&req_opts)).await?;
+
+		println!("\n--- Answer: (streaming)");
+		let assistant_answer = print_chat_stream(chat_res, None).await?;
+
+		chat_req = chat_req.append_message(ChatMessage::assistant(assistant_answer));
+	}
+
+	Ok(())
+}

--- a/src/adapter/adapters/ollama/adapter_impl.rs
+++ b/src/adapter/adapters/ollama/adapter_impl.rs
@@ -36,11 +36,20 @@ impl Adapter for OllamaAdapter {
 		service_type: ServiceType,
 		model: &str,
 		chat_req: ChatRequest,
-		_chat_req_options: Option<&ChatRequestOptions>,
+		chat_req_options: Option<&ChatRequestOptions>,
 	) -> Result<WebRequestData> {
 		let url = Self::get_service_url(kind, service_type);
 
-		OpenAIAdapter::util_to_web_request_data(kind, url, model, chat_req, service_type, "ollama", true)
+		OpenAIAdapter::util_to_web_request_data(
+			kind,
+			url,
+			model,
+			chat_req,
+			service_type,
+			"ollama",
+			true,
+			chat_req_options,
+		)
 	}
 
 	fn to_chat_response(kind: AdapterKind, web_response: WebResponse) -> Result<ChatResponse> {

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -4,6 +4,9 @@
 //!
 //! IMPORTANT: These are not implemented yet, but here to show some of the directions and start having them part of the client APIs.
 
+use serde::Serialize;
+
+#[derive(Default)]
 pub struct ChatRequestOptions {
 	/// Will capture the `MetaUsage`
 	/// - In the `ChatResponse` for `exec_chat`
@@ -14,4 +17,23 @@ pub struct ChatRequestOptions {
 	/// Tell the chat stream executor to capture and concatenate all of the text chunk
 	/// to the last `StreamEvent::End(StreamEnd)` event as `StreamEnd.captured_content` (so, will be `Some(concatenated_chunks)`)
 	pub capture_content: Option<bool>,
+
+	/// Provider specific options
+	pub provider_options: Option<ProviderOptions>,
+}
+
+// ProviderOptions is a struct that can be passed into the `ChatRequestOptions` to customize the behavior of the provider.
+pub enum ProviderOptions {
+	OpenAI(OpenAIOptions),
+}
+
+#[derive(Default, Serialize)]
+/// Represents the options for generating text using OpenAI. https://platform.openai.com/docs/api-reference/chat/create
+pub struct OpenAIOptions {
+	/// The temperature parameter controls the randomness of the generated text.
+	pub temperature: Option<f32>,
+	/// The max_tokens parameter specifies the maximum number of tokens to generate.
+	pub max_tokens: Option<u32>,
+	/// The top_p parameter, also known as nucleus sampling, controls the diversity of the generated text.
+	pub top_p: Option<f32>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,9 @@ pub enum Error {
 	AdapterAuthResolverNoAuthData {
 		adapter_kind: AdapterKind,
 	},
+	AdapterInvalidOptions {
+		adapter_kind: AdapterKind,
+	},
 
 	// -- Stream
 	StreamParse(serde_json::Error),


### PR DESCRIPTION
First of all, thanks so much for this project; it's pretty amazing and also very useful. Currently, I am integrating it into a tool that solves some personal use cases, and I need to play with some fields for OpenAI like `temperature` and `max_tokens`. This is a tiny proposal to have the possibility to pass these values to specific providers. It's a pretty simple implementation.

Let me know what you think, and if the proposal is okay with you. If any extra work is needed, I will be happy to do it.

Thanks