### PR TITLE
Add json mode for openai type models

### DIFF
--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -116,9 +116,11 @@ impl OpenAIAdapter {
 			payload["response_format"] = json!({"type": "json_object"});
 
 			// Check if "JSON" appears in the context
-			let json_in_context = messages
-				.iter()
-				.any(|msg| msg["content"].as_str().map_or(false, |content| content.contains("JSON")));
+			let json_in_context = messages.iter().any(|msg| {
+				msg["content"]
+					.as_str()
+					.map_or(false, |content| content.to_lowercase().contains("json"))
+			});
 
 			if !json_in_context {
 				return Err(Error::JsonModeWithoutInstruction);

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -111,20 +111,9 @@ impl OpenAIAdapter {
 			"stream": stream
 		});
 
-		// -- Add options
+		// Add JSON mode if enabled
 		if let Some(true) = options_set.json_mode() {
-			payload["response_format"] = json!({"type": "json_object"});
-
-			// Check if "JSON" appears in the context
-			let json_in_context = messages.iter().any(|msg| {
-				msg["content"]
-					.as_str()
-					.map_or(false, |content| content.to_lowercase().contains("json"))
-			});
-
-			if !json_in_context {
-				return Err(Error::JsonModeWithoutInstruction);
-			}
+			payload.x_insert("response_format", json!({"type": "json_object"}))?;
 		}
 
 		// --

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -24,7 +24,12 @@ pub struct ChatOptions {
 	/// `StreamEnd` from `StreamEvent::End(StreamEnd)` will contain `StreamEnd.captured_content`
 	pub capture_content: Option<bool>,
 
-	/// Enable JSON mode for supported models
+	/// Enable JSON mode for supported models (OpenAI and Groq)
+	///
+	/// IMPORTANT: When using JSON mode, you must also instruct the model to produce JSON via a
+	/// system or user message. Without this instruction, the model may generate an unending
+	/// stream of whitespace until the generation reaches the token limit, resulting in a
+	/// long-running and seemingly "stuck" request.
 	pub json_mode: Option<bool>,
 }
 

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -23,6 +23,9 @@ pub struct ChatOptions {
 	/// (for stream only) Capture/concatenate the full message content from all content chunk
 	/// `StreamEnd` from `StreamEvent::End(StreamEnd)` will contain `StreamEnd.captured_content`
 	pub capture_content: Option<bool>,
+
+	/// Enable JSON mode for supported models
+	pub json_mode: Option<bool>,
 }
 
 /// Chainable Setters
@@ -54,6 +57,12 @@ impl ChatOptions {
 	/// Set the `capture_content` for this request.
 	pub fn with_capture_content(mut self, value: bool) -> Self {
 		self.capture_content = Some(value);
+		self
+	}
+
+	/// Set the `json_mode` for this request.
+	pub fn with_json_mode(mut self, value: bool) -> Self {
+		self.json_mode = Some(value);
 		self
 	}
 }
@@ -110,6 +119,12 @@ impl ChatOptionsSet<'_, '_> {
 		self.chat
 			.and_then(|chat| chat.capture_content)
 			.or_else(|| self.client.and_then(|client| client.capture_content))
+	}
+
+	pub fn json_mode(&self) -> Option<bool> {
+		self.chat
+			.and_then(|chat| chat.json_mode)
+			.or_else(|| self.client.and_then(|client| client.json_mode))
 	}
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use crate::adapter::AdapterKind;
 use crate::chat::ChatRole;
-use crate::ModelInfo;
-use crate::{resolver, webc};
+use crate::{resolver, webc, ModelInfo};
 use derive_more::From;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -20,6 +19,7 @@ pub enum Error {
 		model_info: ModelInfo,
 		role: ChatRole,
 	},
+	JsonModeWithoutInstruction,
 
 	// -- Chat Output
 	NoChatResponse {

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,6 @@ pub enum Error {
 		model_info: ModelInfo,
 		role: ChatRole,
 	},
-	JsonModeWithoutInstruction,
 
 	// -- Chat Output
 	NoChatResponse {


### PR DESCRIPTION
Support json_mode which forces model to respond with valid json

https://platform.openai.com/docs/guides/json-mode?lang=curl

https://console.groq.com/docs/api-reference#chat-create