### PR TITLE
Allow default model and api key

### DIFF
--- a/examples/c00-readme.rs
+++ b/examples/c00-readme.rs
@@ -59,11 +59,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		println!("\n--- Question:\n{question}");
 
 		println!("\n--- Answer:");
-		let chat_res = client.exec_chat(model, chat_req.clone(), None).await?;
+		let chat_res = client.exec_chat(Some(model), chat_req.clone(), None).await?;
 		println!("{}", chat_res.content_text_as_str().unwrap_or("NO ANSWER"));
 
 		println!("\n--- Answer: (streaming)");
-		let chat_res = client.exec_chat_stream(model, chat_req.clone(), None).await?;
+		let chat_res = client.exec_chat_stream(Some(model), chat_req.clone(), None).await?;
 		print_chat_stream(chat_res, Some(&print_options)).await?;
 
 		println!();

--- a/examples/c01-conv.rs
+++ b/examples/c01-conv.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		chat_req = chat_req.append_message(ChatMessage::user(question));
 
 		println!("\n--- Question:\n{question}");
-		let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), None).await?;
+		let chat_res = client.exec_chat_stream(Some(MODEL), chat_req.clone(), None).await?;
 
 		println!("\n--- Answer: (streaming)");
 		let assistant_answer = print_chat_stream(chat_res, None).await?;

--- a/examples/c02-auth.rs
+++ b/examples/c02-auth.rs
@@ -1,9 +1,8 @@
 use genai::adapter::{AdapterConfig, AdapterKind};
+use genai::chat::printer::print_chat_stream;
 use genai::chat::{ChatMessage, ChatRequest};
 use genai::resolver::{AuthData, AuthResolver};
-use genai::chat::printer::print_chat_stream;
-use genai::Client;
-use genai::ConfigSet;
+use genai::{Client, ConfigSet};
 
 const MODEL: &str = "gpt-4o-mini";
 
@@ -38,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		chat_req = chat_req.append_message(ChatMessage::user(question));
 
 		println!("\n--- Question:\n{question}");
-		let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), None).await?;
+		let chat_res = client.exec_chat_stream(Some(MODEL), chat_req.clone(), None).await?;
 
 		println!("\n--- Answer: (streaming)");
 		let assistant_answer = print_chat_stream(chat_res, None).await?;

--- a/examples/c03-kind.rs
+++ b/examples/c03-kind.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		chat_req = chat_req.append_message(ChatMessage::user(question));
 
 		println!("\n--- Question:\n{question}");
-		let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), None).await?;
+		let chat_res = client.exec_chat_stream(Some(MODEL), chat_req.clone(), None).await?;
 
 		println!("\n--- Answer: ({MODEL})");
 		let assistant_answer = print_chat_stream(chat_res, None).await?;

--- a/examples/c04-chat-options.rs
+++ b/examples/c04-chat-options.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	// -- Exec and print
 	println!("\n--- Question:\n{question}");
-	let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), Some(&options)).await?;
+	let chat_res = client.exec_chat_stream(Some(MODEL), chat_req.clone(), Some(&options)).await?;
 
 	let adapter_kind = client.resolve_model_info(MODEL)?.adapter_kind;
 	println!("\n--- Answer: ({MODEL} - {adapter_kind})");

--- a/src/adapter/adapter_config.rs
+++ b/src/adapter/adapter_config.rs
@@ -19,6 +19,12 @@ impl AdapterConfig {
 		self.auth_resolver = Some(AuthResolver::from_env_name(auth_env_name));
 		self
 	}
+
+	/// Convenient setter to set a pass through AuthResolver
+	pub fn with_pass_through_auth(mut self) -> Self {
+		self.auth_resolver = Some(AuthResolver::pass_through());
+		self
+	}
 }
 
 /// Getters (as ref/deref)

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -29,6 +29,7 @@ impl ClientBuilder {
 	}
 
 	pub fn insert_adapter_config(mut self, kind: AdapterKind, adapter_config: AdapterConfig) -> Self {
+		let adapter_config = adapter_config.with_pass_through_auth();
 		self.apapter_config_by_kind
 			.get_or_insert_with(HashMap::new)
 			.insert(kind, adapter_config);
@@ -54,6 +55,24 @@ impl ClientBuilder {
 	pub fn with_adapter_kind_resolver(mut self, resolver: AdapterKindResolver) -> Self {
 		let client_config = self.config.get_or_insert_with(ClientConfig::default);
 		client_config.adapter_kind_resolver = Some(resolver);
+		self
+	}
+
+	/// Set the default model for the ClientConfig of this ClientBuilder.
+	/// Will create the ClientConfig if not present.
+	/// Otherwise, will just set the `client_config.default_model`
+	pub fn with_default_model(mut self, model: impl Into<String>) -> Self {
+		let config = self.config.get_or_insert_with(ClientConfig::default);
+		config.default_model = Some(model.into());
+		self
+	}
+
+	/// Set the default API key for the ClientConfig of this ClientBuilder.
+	/// Will create the ClientConfig if not present.
+	/// Otherwise, will just set the `client_config.default_api_key`
+	pub fn with_default_api_key(mut self, api_key: impl Into<String>) -> Self {
+		let config = self.config.get_or_insert_with(ClientConfig::default);
+		config.default_api_key = Some(api_key.into());
 		self
 	}
 }

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -1,5 +1,5 @@
 use crate::adapter::{Adapter, AdapterDispatcher, AdapterKind, ServiceType, WebRequestData};
-use crate::chat::{ChatOptions, ChatRequest, ChatOptionsSet, ChatResponse, ChatStreamResponse};
+use crate::chat::{ChatOptions, ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
 use crate::client::Client;
 use crate::{ConfigSet, Error, ModelInfo, Result};
 
@@ -42,11 +42,12 @@ impl Client {
 	/// Execute a chat
 	pub async fn exec_chat(
 		&self,
-		model: &str,
+		model: Option<&str>,
 		chat_req: ChatRequest,
 		// options not implemented yet
 		options: Option<&ChatOptions>,
 	) -> Result<ChatResponse> {
+		let model = model.or(self.default_model()).ok_or(Error::NoModelProvided)?;
 		let model_info = self.resolve_model_info(model)?;
 
 		let adapter_kind = model_info.adapter_kind;
@@ -85,10 +86,11 @@ impl Client {
 
 	pub async fn exec_chat_stream(
 		&self,
-		model: &str,
+		model: Option<&str>,
 		chat_req: ChatRequest, // options not implemented yet
 		options: Option<&ChatOptions>,
 	) -> Result<ChatStreamResponse> {
+		let model = model.or(self.default_model()).ok_or(Error::NoModelProvided)?;
 		let model_info = self.resolve_model_info(model)?;
 		let adapter_kind = model_info.adapter_kind;
 

--- a/src/client/client_types.rs
+++ b/src/client/client_types.rs
@@ -41,6 +41,10 @@ impl Client {
 	pub(crate) fn custom_adapter_config(&self, adapter_kind: AdapterKind) -> Option<&AdapterConfig> {
 		self.inner.apapter_config_by_kind.as_ref()?.get(&adapter_kind)
 	}
+
+	pub(crate) fn default_model(&self) -> Option<&str> {
+		self.inner.config.default_model()
+	}
 }
 
 // endregion: --- Client Getters

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -7,6 +7,8 @@ use crate::resolver::AdapterKindResolver;
 pub struct ClientConfig {
 	pub(in crate::client) adapter_kind_resolver: Option<AdapterKindResolver>,
 	pub(in crate::client) chat_options: Option<ChatOptions>,
+	pub(in crate::client) default_model: Option<String>,
+	pub(in crate::client) default_api_key: Option<String>,
 }
 
 /// Adapter Related Chainable Setters
@@ -22,6 +24,18 @@ impl ClientConfig {
 		self.chat_options = Some(options);
 		self
 	}
+
+	/// Default model to use for chat requests
+	pub fn with_default_model(mut self, model: impl Into<String>) -> Self {
+		self.default_model = Some(model.into());
+		self
+	}
+
+	/// Default API key to use for chat requests
+	pub fn with_default_api_key(mut self, api_key: impl Into<String>) -> Self {
+		self.default_api_key = Some(api_key.into());
+		self
+	}
 }
 
 /// Getters (as ref/deref)
@@ -32,5 +46,13 @@ impl ClientConfig {
 
 	pub fn chat_options(&self) -> Option<&ChatOptions> {
 		self.chat_options.as_ref()
+	}
+
+	pub fn default_model(&self) -> Option<&str> {
+		self.default_model.as_deref()
+	}
+
+	pub fn default_api_key(&self) -> Option<&str> {
+		self.default_api_key.as_deref()
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use crate::adapter::AdapterKind;
 use crate::chat::ChatRole;
-use crate::ModelInfo;
-use crate::{resolver, webc};
+use crate::{resolver, webc, ModelInfo};
 use derive_more::From;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -20,6 +19,7 @@ pub enum Error {
 		model_info: ModelInfo,
 		role: ChatRole,
 	},
+	NoModelProvided,
 
 	// -- Chat Output
 	NoChatResponse {

--- a/src/resolver/auth_resolver.rs
+++ b/src/resolver/auth_resolver.rs
@@ -35,6 +35,12 @@ impl AuthResolver {
 			inner: AuthResolverInner::SyncResolverFn(resolver_fn.into_sync_resolver_fn()),
 		}
 	}
+
+	pub fn pass_through() -> Self {
+		AuthResolver {
+			inner: AuthResolverInner::PassThrough,
+		}
+	}
 }
 
 // region:    --- AuthDataProvider & IntoAuthDataProvider
@@ -90,6 +96,7 @@ impl AuthResolver {
 			AuthResolverInner::SyncResolverFn(sync_provider) => {
 				sync_provider.exec_sync_resolver_fn(adapter_kind, config_set)
 			}
+			AuthResolverInner::PassThrough => Ok(None),
 		}
 	}
 }
@@ -98,6 +105,7 @@ enum AuthResolverInner {
 	EnvName(String),
 	Fixed(AuthData),
 	SyncResolverFn(Arc<dyn SyncAuthResolverFn>),
+	PassThrough,
 }
 
 // impl debug for AuthResolverInner
@@ -107,6 +115,7 @@ impl std::fmt::Debug for AuthResolverInner {
 			AuthResolverInner::EnvName(env_name) => write!(f, "AuthResolverInner::EnvName({})", env_name),
 			AuthResolverInner::Fixed(auth_data) => write!(f, "AuthResolverInner::Fixed({:?})", auth_data),
 			AuthResolverInner::SyncResolverFn(_) => write!(f, "AuthResolverInner::FnSync(...)"),
+			AuthResolverInner::PassThrough => write!(f, "AuthResolverInner::PassThrough"),
 		}
 	}
 }

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -50,7 +50,7 @@ pub async fn common_test_chat_json_ok(model: &str, test_token: bool) -> Result<(
 	let chat_options = ChatOptions::default().with_json_mode(true);
 
 	// -- Exec
-	let chat_res = client.exec_chat(model, chat_req, Some(&chat_options)).await?;
+	let chat_res = client.exec_chat(Some(model), chat_req, Some(&chat_options)).await?;
 
 	// -- Check
 	// Make sure tokens still get counted

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -11,7 +11,7 @@ pub async fn common_test_chat_simple_ok(model: &str) -> Result<()> {
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
-	let chat_res = client.exec_chat(model, chat_req, None).await?;
+	let chat_res = client.exec_chat(Some(model), chat_req, None).await?;
 
 	// -- Check
 	assert!(
@@ -42,7 +42,7 @@ pub async fn common_test_chat_stream_simple_ok(model: &str) -> Result<()> {
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
-	let chat_res = client.exec_chat_stream(model, chat_req.clone(), None).await?;
+	let chat_res = client.exec_chat_stream(Some(model), chat_req.clone(), None).await?;
 
 	// -- Check StreamEnd
 	let stream_end = extract_stream_end(chat_res.stream).await?;
@@ -65,7 +65,7 @@ pub async fn common_test_chat_stream_capture_content_ok(model: &str) -> Result<(
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
-	let chat_res = client.exec_chat_stream(model, chat_req.clone(), None).await?;
+	let chat_res = client.exec_chat_stream(Some(model), chat_req.clone(), None).await?;
 
 	// -- Check StreamEnd
 	let stream_end = extract_stream_end(chat_res.stream).await?;
@@ -89,7 +89,7 @@ pub async fn common_test_chat_stream_capture_all_ok(model: &str) -> Result<()> {
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
-	let chat_res = client.exec_chat_stream(model, chat_req.clone(), None).await?;
+	let chat_res = client.exec_chat_stream(Some(model), chat_req.clone(), None).await?;
 
 	// -- Check StreamEnd
 	let stream_end = extract_stream_end(chat_res.stream).await?;


### PR DESCRIPTION
Allows something like this:

```rs
let client = Client::builder()
    .with_default_model("gpt-3.5-turbo")
    .with_default_api_key("my_key")
    .build();
```

so users don't have to pass it at every call site of `exec_chat`