### PR TITLE
Fix typo in adapter_impl.rs

### DIFF
--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -123,7 +123,7 @@ impl OpenAIAdapter {
 
 		// -- Add supported ChatOptions
 		if let Some(temperature) = options_set.temperature() {
-			payload.x_insert("tdsemperature", temperature)?;
+			payload.x_insert("temperature", temperature)?;
 		}
 		if let Some(max_tokens) = options_set.max_tokens() {
 			payload.x_insert("max_tokens", max_tokens)?;


### PR DESCRIPTION
A typo in adapters for OpenAI makes the temperature chat option unusable.