### PR TITLE
chore: make stream is send

### DIFF
--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-type InterStreamType = Pin<Box<dyn Stream<Item = crate::Result<InterStreamEvent>>>>;
+type InterStreamType = Pin<Box<dyn Stream<Item = crate::Result<InterStreamEvent>> + Send>>;
 
 /// ChatStream is a Rust Future Stream that iterates through the events of a chat stream request.
 pub struct ChatStream {
@@ -19,7 +19,7 @@ impl ChatStream {
 
 	pub fn from_inter_stream<T>(inter_stream: T) -> Self
 	where
-		T: Stream<Item = crate::Result<InterStreamEvent>> + Unpin + 'static,
+		T: Stream<Item = crate::Result<InterStreamEvent>> + Send + Unpin + 'static,
 	{
 		let boxed_stream: InterStreamType = Box::pin(inter_stream);
 		ChatStream::new(boxed_stream)

--- a/src/webc/web_stream.rs
+++ b/src/webc/web_stream.rs
@@ -17,8 +17,8 @@ use std::task::{Context, Poll};
 pub struct WebStream {
 	stream_mode: StreamMode,
 	reqwest_builder: Option<RequestBuilder>,
-	response_future: Option<Pin<Box<dyn Future<Output = Result<Response, Box<dyn Error>>>>>>,
-	bytes_stream: Option<Pin<Box<dyn Stream<Item = Result<Bytes, Box<dyn Error>>>>>>,
+	response_future: Option<Pin<Box<dyn Future<Output = Result<Response, Box<dyn Error>>> + Send>>>,
+	bytes_stream: Option<Pin<Box<dyn Stream<Item = Result<Bytes, Box<dyn Error>>> + Send>>>,
 	// If a poll was a partial message, so we kept the previous part
 	partial_message: Option<String>,
 	// If a poll retrieved multiple messages, we keep to be sent in next poll


### PR DESCRIPTION
This PR makes the stream with Send.

Why we need this: It allows us to use the stream inside a Tokio-spawned task without local_set.