### PR TITLE
Make all structs serializable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 tokio-stream = "0.1"
 # -- Json
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] } # Opted to rc for Arc<T> serialization
 serde_json = "1"
 # -- Web
 reqwest = {version = "0.12", features = ["json"]}

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -1,8 +1,9 @@
 use super::groq::MODELS as GROQ_MODELS;
 use crate::Result;
 use derive_more::Display;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Display, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Display, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum AdapterKind {
 	OpenAI,
 	Ollama,

--- a/src/adapter/adapter_types.rs
+++ b/src/adapter/adapter_types.rs
@@ -4,6 +4,7 @@ use crate::webc::WebResponse;
 use crate::Result;
 use crate::{ClientConfig, ModelIden};
 use reqwest::RequestBuilder;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub trait Adapter {
@@ -38,7 +39,7 @@ pub trait Adapter {
 
 // region:    --- ServiceType
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum ServiceType {
 	Chat,
 	ChatStream,
@@ -49,7 +50,7 @@ pub enum ServiceType {
 // region:    --- WebRequestData
 
 // NOTE: This cannot really move to `webc` because it has to be public with the adapter and `webc` is private for now.
-
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebRequestData {
 	pub url: String,
 	pub headers: Vec<(String, String)>,

--- a/src/adapter/inter_stream.rs
+++ b/src/adapter/inter_stream.rs
@@ -5,9 +5,11 @@
 //!
 //! NOTE: This might be removed at some point as it might not be needed, and going directly to the genai stream.
 
+use serde::{Deserialize, Serialize};
+
 use crate::chat::MetaUsage;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct InterStreamEnd {
 	// When `ChatOptions..capture_usage == true`
 	pub captured_usage: Option<MetaUsage>,
@@ -17,6 +19,7 @@ pub struct InterStreamEnd {
 }
 
 /// Intermediary StreamEvent
+#[derive(Debug, Serialize, Deserialize)]
 pub enum InterStreamEvent {
 	Start,
 	Chunk(String),

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -4,7 +4,10 @@
 //!
 //! Note 1: Later, we will probably allow to set the client
 //! Note 2: Splitting it out of the `ChatRequest` object allows for better reusability of each component.
-#[derive(Debug, Clone, Default)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ChatOptions {
 	/// Will be set for this request if Adapter/providers supports it.
 	pub temperature: Option<f64>,

--- a/src/chat/chat_req.rs
+++ b/src/chat/chat_req.rs
@@ -1,10 +1,11 @@
 //! This module contains all the types related to a Chat Request (except ChatOptions, which has its own file).
 
 use crate::chat::MessageContent;
+use serde::{Serialize, Deserialize};
 
 // region:    --- ChatRequest
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ChatRequest {
 	pub system: Option<String>,
 	pub messages: Vec<ChatMessage>,
@@ -84,7 +85,7 @@ impl ChatRequest {
 
 // region:    --- ChatMessage
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
 	pub role: ChatRole,
 	pub content: MessageContent,
@@ -118,7 +119,7 @@ impl ChatMessage {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ChatRole {
 	System,
 	User,
@@ -126,13 +127,13 @@ pub enum ChatRole {
 	Tool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MessageExtra {
 	Tool(ToolExtra),
 }
 
 #[allow(unused)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolExtra {
 	tool_id: String,
 }

--- a/src/chat/chat_res.rs
+++ b/src/chat/chat_res.rs
@@ -1,11 +1,13 @@
 //! This module contains all the types related to a Chat Response (except ChatStream which has it file).
 
+use serde::{Deserialize, Serialize};
+
 use crate::chat::{ChatStream, MessageContent};
 use crate::ModelIden;
 
 // region:    --- ChatResponse
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatResponse {
 	pub content: Option<MessageContent>,
 	pub usage: MetaUsage,
@@ -41,7 +43,7 @@ pub struct ChatStreamResponse {
 // region:    --- MetaUsage
 
 /// IMPORTANT: This is **NOT SUPPORTED** for now. To show the API direction.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct MetaUsage {
 	pub input_tokens: Option<i32>,
 	pub output_tokens: Option<i32>,

--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -2,12 +2,13 @@ use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
 use crate::chat::{MessageContent, MetaUsage};
 use derive_more::From;
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 type InterStreamType = Pin<Box<dyn Stream<Item = crate::Result<InterStreamEvent>> + Send>>;
 
-/// ChatStream is a Rust Future Stream that iterates through the events of a chat stream request.
+/// ChatStream is a Rust Future Stream that iterates through the events of a chat stream request
 pub struct ChatStream {
 	inter_stream: InterStreamType,
 }
@@ -54,19 +55,19 @@ impl Stream for ChatStream {
 
 // region:    --- ChatStreamEvent
 
-#[derive(Debug, From)]
+#[derive(Debug, From, Serialize, Deserialize)]
 pub enum ChatStreamEvent {
 	Start,
 	Chunk(StreamChunk),
 	End(StreamEnd),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StreamChunk {
 	pub content: String,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct StreamEnd {
 	/// The eventual captured UsageMeta
 	pub captured_usage: Option<MetaUsage>,

--- a/src/chat/message_content.rs
+++ b/src/chat/message_content.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 /// For now, supports only Text,
 /// But the goal is to support multi-part message content (see below)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MessageContent {
 	Text(String),
 }

--- a/src/chat/printer.rs
+++ b/src/chat/printer.rs
@@ -1,10 +1,11 @@
 use crate::chat::{ChatStreamEvent, ChatStreamResponse, StreamChunk};
 use futures::StreamExt;
+use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncWriteExt as _, Stdout};
 
 // region:    --- PrintChatOptions
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct PrintChatStreamOptions {
 	print_events: Option<bool>,
 }

--- a/src/chat/tool.rs
+++ b/src/chat/tool.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[allow(unused)] // Not used yet
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tool {
 	fn_name: String,
 	fn_description: String,

--- a/src/common/model_iden.rs
+++ b/src/common/model_iden.rs
@@ -1,9 +1,11 @@
+use serde::{Deserialize, Serialize};
+
 use crate::adapter::AdapterKind;
 use crate::ModelName;
 
 /// Hold the adapter_kind and model_name in a efficient clonable way
 /// Note: For now,
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModelIden {
 	pub adapter_kind: AdapterKind,
 	pub model_name: ModelName,

--- a/src/common/model_name.rs
+++ b/src/common/model_name.rs
@@ -1,7 +1,9 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-#[derive(Clone, Debug)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModelName(Arc<str>);
 
 impl std::fmt::Display for ModelName {

--- a/src/webc/web_client.rs
+++ b/src/webc/web_client.rs
@@ -1,6 +1,7 @@
 use crate::webc::{Error, Result};
 use reqwest::header::HeaderMap;
 use reqwest::{Method, RequestBuilder, StatusCode};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Simple reqwest client wrapper for this library.
@@ -73,7 +74,7 @@ impl WebClient {
 // NOTE: This is not none-stream web response (assume json for this lib)
 //       Streaming is handled with event-source or custom stream (for Cohere for example)
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct WebResponse {
 	#[allow(unused)]
 	pub status: StatusCode,


### PR DESCRIPTION
Making all structs serializable makes them usable in API Requests and IPC communication.