### PR TITLE
Added Github Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -59,22 +59,22 @@ body:
         // ...
         ```
       render: md
-    - type: textarea
-      attributes:
-        label: Verbose output
-        description: 'Output of the command run (with ther verbose flag). The output will include the contents of your target file, so take care not to include any sensitive data.'
-        value: |
-          $ devai run proof-comments
-          Running agent command: proof-comments
-                           from: .devai/defaults/proof-comments.md
-                     with model: mistral:latest
-          # ...
-        render: fundamental
-    - type: textarea
-      attributes:
-        label: Target file
-        description: 'The relevant contents of the file targeted by the `-f` flag. Take care not to include any sensitive data. '
-        render: fundamental
-    - type: textarea
-      attributes:
-        label: Additional information
+  - type: textarea
+    attributes:
+      label: Verbose output
+      description: 'Output of the command run (with ther verbose flag). The output will include the contents of your target file, so take care not to include any sensitive data.'
+      value: |
+        $ devai run proof-comments
+        Running agent command: proof-comments
+                          from: .devai/defaults/proof-comments.md
+                    with model: mistral:latest
+        # ...
+      render: fundamental
+  - type: textarea
+    attributes:
+      label: Target file
+      description: 'The relevant contents of the file targeted by the `-f` flag. Take care not to include any sensitive data. '
+      render: fundamental
+  - type: textarea
+    attributes:
+      label: Additional information

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -18,18 +18,18 @@ body:
     attributes:
       label: Command
       description: "`devai` command that triggered the bug"
-      placeholder: devai run {agent-name} -f {file-name} --verbose
+      placeholder: 'devai run {agent-name} -f {file-name} --verbose'
       render: bash
   - type: input
     attributes:
       label: Error
       description: Error message, if any
-      placeholder: Error: Rhai(ErrorArrayBounds(0, 0, 2:36))
+      placeholder: 'Error: Rhai(ErrorArrayBounds(0, 0, 2:36))'
       render: bash
   - type: textarea
     attributes:
       label: Config
-      description: Contents of ".devai/config.toml"
+      description: 'Contents of ".devai/config.toml"'
       value: |
         [genai]
         model = "gpt-4o"
@@ -40,7 +40,7 @@ body:
   - type: textarea
     attributes:
       label: Agent
-      description: Contents of "{{my-agent}}.md". Markdown will be escaped automatically.
+      description: 'Contents of "{{my-agent}}.md". Markdown will be escaped automatically.'
       value: |
         # Data
         ```rhai
@@ -62,7 +62,7 @@ body:
     - type: textarea
       attributes:
         label: Verbose output
-        description: Output of the command run (with ther verbose flag). The output will include the contents of your target file, so take care not to include any sensitive data.
+        description: 'Output of the command run (with ther verbose flag). The output will include the contents of your target file, so take care not to include any sensitive data.'
         value: |
           $ devai run proof-comments
           Running agent command: proof-comments
@@ -73,7 +73,7 @@ body:
     - type: textarea
       attributes:
         label: Target file
-        description: The relevant contents of the file targeted by the `-f` flag. Take care not to include any sensitive data. 
+        description: 'The relevant contents of the file targeted by the `-f` flag. Take care not to include any sensitive data. '
         render: fundamental
     - type: textarea
       attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,7 +17,7 @@ body:
   - type: input
     attributes:
       label: Command
-      description: `devai` command that triggered the bug
+      description: "`devai` command that triggered the bug"
       placeholder: devai run {agent-name} -f {file-name} --verbose
       render: bash
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,80 @@
+name: Bug Report
+about: File a bug report.
+title: "🐛 "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    attributes:
+      label: Bug description
+      description: Describe the bug in one line
+      placeholder: Ran {this}, did {that}, expected {the other}
+    validations: 
+      required: true
+  - type: input
+    attributes:
+      label: Command
+      description: `devai` command that triggered the bug
+      placeholder: devai run {agent-name} -f {file-name} --verbose
+      render: bash
+  - type: input
+    attributes:
+      label: Error
+      description: Error message, if any
+      placeholder: Error: Rhai(ErrorArrayBounds(0, 0, 2:36))
+      render: bash
+  - type: textarea
+    attributes:
+      label: Config
+      description: Contents of ".devai/config.toml"
+      value: |
+        [genai]
+        model = "gpt-4o"
+        
+        [runtime]
+        # Default to 1 if absent
+        items_concurrency = 1 
+  - type: textarea
+    attributes:
+      label: Agent
+      description: Contents of "{{my-agent}}.md". Markdown will be escaped automatically.
+      value: |
+        # Data
+        ```rhai
+        let path = item.path;
+        // ...
+        ```
+
+        # Instruction
+
+        - The user will provide good error messages
+        - The information provided by the user will be helpful for debugging issues
+        - ...
+
+        # Output
+        ```rhai
+        // ...
+        ```
+      render: md
+    - type: textarea
+      attributes:
+        label: Verbose output
+        description: Output of the command run (with ther verbose flag). The output will include the contents of your target file, so take care not to include any sensitive data.
+        value: |
+          $ devai run proof-comments
+          Running agent command: proof-comments
+                           from: .devai/defaults/proof-comments.md
+                     with model: mistral:latest
+          # ...
+        render: fundamental
+    - type: textarea
+      attributes:
+        label: Target file
+        description: The relevant contents of the file targeted by the `-f` flag. Take care not to include any sensitive data. 
+        render: fundamental
+    - type: textarea
+      attributes:
+        label: Additional information

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-about: File a bug report.
+description: File a bug report.
 title: "🐛 "
 labels: ["bug"]
 body:
@@ -19,13 +19,11 @@ body:
       label: Command
       description: "`devai` command that triggered the bug"
       placeholder: 'devai run {agent-name} -f {file-name} --verbose'
-      render: bash
   - type: input
     attributes:
       label: Error
       description: Error message, if any
       placeholder: 'Error: Rhai(ErrorArrayBounds(0, 0, 2:36))'
-      render: bash
   - type: textarea
     attributes:
       label: Config

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,10 +7,10 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
-  - type: input
+  - type: textarea
     attributes:
       label: Bug description
-      description: Describe the bug in one line
+      description: Describe the bug
       placeholder: Ran {this}, did {that}, expected {the other}
     validations: 
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -69,6 +69,3 @@ body:
                     with model: mistral:latest
         # ...
       render: fundamental
-  - type: textarea
-    attributes:
-      label: Additional information

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -35,6 +35,7 @@ body:
         [runtime]
         # Default to 1 if absent
         items_concurrency = 1 
+      render: toml
   - type: textarea
     attributes:
       label: Agent
@@ -67,11 +68,6 @@ body:
                           from: .devai/defaults/proof-comments.md
                     with model: mistral:latest
         # ...
-      render: fundamental
-  - type: textarea
-    attributes:
-      label: Target file
-      description: 'The relevant contents of the file targeted by the `-f` flag. Take care not to include any sensitive data. '
       render: fundamental
   - type: textarea
     attributes:


### PR DESCRIPTION
The contents of ".github/ISSUE_TEMPLATE/bug_report.yaml" configure a custom GitHub bug report web form. This web form guides the users through creating a helpful bug report. See the screenshot of this form below.

![image](https://github.com/user-attachments/assets/c4699926-72fa-4830-8d78-ee57f834d7f3)
