### PR TITLE
add: wasm target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,27 @@ unused = { level = "allow", priority = -1 } # For exploratory dev.
 
 [dependencies]
 # -- Async
-tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 tokio-stream = "0.1"
 # -- Json
 serde = { version = "1", features = ["derive", "rc"] } # Opted to rc for Arc<T> serialization
 serde_json = "1"
 # -- Web
-reqwest = {version = "0.12", features = ["json"]}
+reqwest = { version = "0.12", features = ["json"] }
 reqwest-eventsource = "0.6"
 eventsource-stream = "0.2"
 bytes = "1.6"
 # -- Others
 derive_more = { version = "1.0.0-beta", features = ["from", "display"] }
 value-ext = "0.0.3" # JC Authored. Early release (API might change). Be cautious when using in other projects.
+
+# -- non wasm target
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["full"] }
+
+# -- wasm target
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+log = "0.4"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/tests/tests_p_anthropic.rs
+++ b/tests/tests_p_anthropic.rs
@@ -1,5 +1,3 @@
-
-
 mod support;
 
 use crate::support::common_tests;

--- a/tests/tests_p_anthropic.rs
+++ b/tests/tests_p_anthropic.rs
@@ -1,3 +1,5 @@
+
+
 mod support;
 
 use crate::support::common_tests;
@@ -9,17 +11,20 @@ const MODEL: &str = "claude-3-haiku-20240307";
 
 // region:    --- Chat
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_temperature_ok() -> Result<()> {
 	common_tests::common_test_chat_temperature_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_json_mode_ok() -> Result<()> {
 	common_tests::common_test_chat_json_mode_ok(MODEL, true).await
 }
@@ -28,17 +33,20 @@ async fn test_chat_json_mode_ok() -> Result<()> {
 
 // region:    --- Chat Stream Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_content_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_all_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_all_ok(MODEL).await
 }
@@ -47,12 +55,14 @@ async fn test_chat_stream_capture_all_ok() -> Result<()> {
 
 // region:    --- Tool Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_tool_simple_ok() -> Result<()> {
 	common_tests::common_test_tool_simple_ok(MODEL, false).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_tool_full_flow_ok() -> Result<()> {
 	common_tests::common_test_tool_full_flow_ok(MODEL, false).await
 }
@@ -61,7 +71,8 @@ async fn test_tool_full_flow_ok() -> Result<()> {
 
 // region:    --- Resolver Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_resolver_auth_ok() -> Result<()> {
 	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("ANTHROPIC_API_KEY")).await
 }

--- a/tests/tests_p_cohere.rs
+++ b/tests/tests_p_cohere.rs
@@ -1,5 +1,3 @@
-
-
 mod support;
 
 use crate::support::common_tests;

--- a/tests/tests_p_cohere.rs
+++ b/tests/tests_p_cohere.rs
@@ -1,3 +1,5 @@
+
+
 mod support;
 
 use crate::support::common_tests;
@@ -9,7 +11,8 @@ const MODEL: &str = "command-light";
 
 // region:    --- Chat
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_simple_ok(MODEL).await
 }
@@ -18,22 +21,26 @@ async fn test_chat_simple_ok() -> Result<()> {
 
 // region:    --- Chat Stream Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_content_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_all_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_all_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_temperature_ok() -> Result<()> {
 	common_tests::common_test_chat_temperature_ok(MODEL).await
 }
@@ -42,7 +49,8 @@ async fn test_chat_temperature_ok() -> Result<()> {
 
 // region:    --- Resolver Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_resolver_auth_ok() -> Result<()> {
 	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("COHERE_API_KEY")).await
 }

--- a/tests/tests_p_gemini.rs
+++ b/tests/tests_p_gemini.rs
@@ -1,3 +1,5 @@
+
+
 mod support;
 
 use crate::support::common_tests;
@@ -9,17 +11,20 @@ const MODEL: &str = "gemini-1.5-flash-latest";
 
 // region:    --- Chat
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_json_structured_ok() -> Result<()> {
 	common_tests::common_test_chat_json_structured_ok(MODEL, true).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_temperature_ok() -> Result<()> {
 	common_tests::common_test_chat_temperature_ok(MODEL).await
 }
@@ -28,17 +33,20 @@ async fn test_chat_temperature_ok() -> Result<()> {
 
 // region:    --- Chat Stream Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_content_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_all_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_all_ok(MODEL).await
 }
@@ -47,7 +55,8 @@ async fn test_chat_stream_capture_all_ok() -> Result<()> {
 
 // region:    --- Resolver Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_resolver_auth_ok() -> Result<()> {
 	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("GEMINI_API_KEY")).await
 }

--- a/tests/tests_p_gemini.rs
+++ b/tests/tests_p_gemini.rs
@@ -1,5 +1,3 @@
-
-
 mod support;
 
 use crate::support::common_tests;

--- a/tests/tests_p_groq.rs
+++ b/tests/tests_p_groq.rs
@@ -1,3 +1,5 @@
+
+
 mod support;
 
 use crate::support::common_tests;
@@ -11,17 +13,20 @@ const MODEL: &str = "llama3-groq-8b-8192-tool-use-preview";
 
 // region:    --- Chat
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_json_mode_ok() -> Result<()> {
 	common_tests::common_test_chat_json_mode_ok(MODEL, true).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_temperature_ok() -> Result<()> {
 	common_tests::common_test_chat_temperature_ok(MODEL).await
 }
@@ -30,17 +35,20 @@ async fn test_chat_temperature_ok() -> Result<()> {
 
 // region:    --- Chat Stream Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_content_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_all_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_all_ok(MODEL).await
 }
@@ -49,7 +57,8 @@ async fn test_chat_stream_capture_all_ok() -> Result<()> {
 
 // region:    --- Resolver Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_resolver_auth_ok() -> Result<()> {
 	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("GROQ_API_KEY")).await
 }

--- a/tests/tests_p_groq.rs
+++ b/tests/tests_p_groq.rs
@@ -1,5 +1,3 @@
-
-
 mod support;
 
 use crate::support::common_tests;

--- a/tests/tests_p_ollama.rs
+++ b/tests/tests_p_ollama.rs
@@ -1,5 +1,3 @@
-
-
 mod support;
 
 use crate::support::common_tests;

--- a/tests/tests_p_ollama.rs
+++ b/tests/tests_p_ollama.rs
@@ -1,3 +1,5 @@
+
+
 mod support;
 
 use crate::support::common_tests;
@@ -9,17 +11,20 @@ const MODEL: &str = "phi3:latest";
 
 // region:    --- Chat
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_json_mode_ok() -> Result<()> {
 	common_tests::common_test_chat_json_mode_ok(MODEL, false).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_temperature_ok() -> Result<()> {
 	common_tests::common_test_chat_temperature_ok(MODEL).await
 }
@@ -28,19 +33,22 @@ async fn test_chat_temperature_ok() -> Result<()> {
 
 // region:    --- Chat Stream Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_content_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
 }
 
 // /// COMMENTED FOR NOW AS OLLAMA OpenAI Compatibility Layer does not support
 // /// usage tokens when streaming. See https://github.com/ollama/ollama/issues/4448
-// #[tokio::test]
+// #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 // async fn test_chat_stream_capture_all_ok() -> Result<()> {
 // 	common_tests::common_test_chat_stream_capture_all_ok(MODEL).await
 // }
@@ -49,7 +57,8 @@ async fn test_chat_stream_capture_content_ok() -> Result<()> {
 
 // region:    --- Resolver Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_resolver_auth_ok() -> Result<()> {
 	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_single("ollama")).await
 }

--- a/tests/tests_p_openai.rs
+++ b/tests/tests_p_openai.rs
@@ -1,5 +1,3 @@
-
-
 mod support;
 
 use crate::support::common_tests;

--- a/tests/tests_p_openai.rs
+++ b/tests/tests_p_openai.rs
@@ -1,3 +1,5 @@
+
+
 mod support;
 
 use crate::support::common_tests;
@@ -9,22 +11,26 @@ const MODEL: &str = "gpt-4o-mini";
 
 // region:    --- Chat
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_json_mode_ok() -> Result<()> {
 	common_tests::common_test_chat_json_mode_ok(MODEL, true).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_json_structured_ok() -> Result<()> {
 	common_tests::common_test_chat_json_structured_ok(MODEL, true).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_temperature_ok() -> Result<()> {
 	common_tests::common_test_chat_temperature_ok(MODEL).await
 }
@@ -33,17 +39,20 @@ async fn test_chat_temperature_ok() -> Result<()> {
 
 // region:    --- Chat Stream Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_simple_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_simple_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_content_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_chat_stream_capture_all_ok() -> Result<()> {
 	common_tests::common_test_chat_stream_capture_all_ok(MODEL).await
 }
@@ -52,12 +61,14 @@ async fn test_chat_stream_capture_all_ok() -> Result<()> {
 
 // region:    --- Tool Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_tool_simple_ok() -> Result<()> {
 	common_tests::common_test_tool_simple_ok(MODEL, true).await
 }
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_tool_full_flow_ok() -> Result<()> {
 	common_tests::common_test_tool_full_flow_ok(MODEL, true).await
 }
@@ -65,7 +76,8 @@ async fn test_tool_full_flow_ok() -> Result<()> {
 
 // region:    --- Resolver Tests
 
-#[tokio::test]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_resolver_auth_ok() -> Result<()> {
 	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("OPENAI_API_KEY")).await
 }


### PR DESCRIPTION
Hi Monsieur Chone,

I don't know if these changes work because I'm poor xD. I'm starting a new project and I want to use this crate on the client side *(hydrate and csr)*.

### Changes

I used `target` instead of `feature` config to target *wasm* or *non-wasm* because some crates already implement *wasm* in their crate.

Thanks for this great library and happy to contribute to your project. Let me know what you think about my impl.

EDIT: related to #11 