### PR TITLE
Implement Image support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ keywords = ["generative-ai","openai","chatgpt","gemini","ollama"]
 homepage = "https://github.com/jeremychone/rust-genai"
 repository = "https://github.com/jeremychone/rust-genai"
 
+[[example]]
+name = "images"
+path = "examples/c07-image.rs"
+
 [lints.rust]
 unsafe_code = "forbid"
 # unused = { level = "allow", priority = -1 } # For exploratory dev.

--- a/examples/c06-image.rs
+++ b/examples/c06-image.rs
@@ -1,0 +1,33 @@
+//! This example demonstrates how to properly attach image to the conversations
+
+use genai::chat::printer::print_chat_stream;
+use genai::chat::{ChatMessage, ChatRequest, ContentPart, ImageSource};
+use genai::Client;
+
+const MODEL: &str = "gpt-4o-mini";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let client = Client::default();
+
+	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
+	// This is similar to sending initial system chat messages (which will be cumulative with system chat messages)
+	chat_req = chat_req.append_message(ChatMessage::user(
+		vec![
+			ContentPart::Text("What is in this picture?"),
+			ContentPart::Image {
+				content: "IMAGE ENCODE BASE64".to_string(),
+				content_type: "image/png".to_string(),
+				source: ImageSource::Base64,
+			}
+		]
+	));
+
+	println!("\n--- Question:\n{question}");
+	let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), None).await?;
+
+	println!("\n--- Answer: (streaming)");
+	let assistant_answer = print_chat_stream(chat_res, None).await?;
+
+	Ok(())
+}

--- a/examples/c07-image.rs
+++ b/examples/c07-image.rs
@@ -10,15 +10,17 @@ const MODEL: &str = "gpt-4o-mini";
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let client = Client::default();
 
+	let question = "What is in this picture?";
+
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
 	// This is similar to sending initial system chat messages (which will be cumulative with system chat messages)
 	chat_req = chat_req.append_message(ChatMessage::user(
 		vec![
-			ContentPart::Text("What is in this picture?"),
+			ContentPart::Text(question.to_string()),
 			ContentPart::Image {
-				content: "IMAGE ENCODE BASE64".to_string(),
+				content: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg".to_string(),
 				content_type: "image/png".to_string(),
-				source: ImageSource::Base64,
+				source: ImageSource::Url,
 			}
 		]
 	));

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -3,7 +3,7 @@ use crate::adapter::anthropic::AnthropicStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	ChatOptionsSet, ChatRequest, ChatResponse, ChatRole, ChatStream, ChatStreamResponse, MessageContent, MetaUsage,
-	ToolCall, ContentPart, ImageLocation,
+	ToolCall, ContentPart, ImageSource,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
@@ -241,19 +241,19 @@ impl AnthropicAdapter {
 						MessageContent::Parts(parts) => {
 							json!(parts.iter().map(|part| match part {
 								ContentPart::Text(text) => json!({"type": "text", "text": text.clone()}),
-								ContentPart::Image(location) => match location {
-									ImageLocation::Url(_) => {
-										todo!("Anthropic doesn't support images from URL")
-									},
-									ImageLocation::Base64 {content, mime} => json!({
+								ContentPart::Image{content, content_type, source} => {
+									match source {
+										ImageSource::Url => todo!("Anthropic doesn't support images from URL, need to handle it gracefully"),
+										ImageSource::Base64 => json!({
 					                    "type": "image",
 					                    "source": {
 					                        "type": "base64",
-					                        "media_type": mime,
+					                        "media_type": content_type,
 					                        "data": content,
 					                    },
 					                }),
-								}
+									}
+								},
 							}).collect::<Vec<Value>>())
 						},
 						// Use `match` instead of `if let`. This will allow to future-proof this

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -1,5 +1,5 @@
+use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::gemini::GeminiStreamer;
-use crate::adapter::support::get_api_key;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	ChatOptionsSet, ChatRequest, ChatResponse, ChatResponseFormat, ChatRole, ChatStream, ChatStreamResponse,

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -1,9 +1,9 @@
-use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::gemini::GeminiStreamer;
+use crate::adapter::support::get_api_key;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	ChatOptionsSet, ChatRequest, ChatResponse, ChatResponseFormat, ChatRole, ChatStream, ChatStreamResponse,
-	MessageContent, MetaUsage,
+	MessageContent, MetaUsage, ContentPart, ImageSource
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebResponse, WebStream};
@@ -21,6 +21,7 @@ const MODELS: &[&str] = &[
 	"gemini-1.5-flash-8b",
 	"gemini-1.0-pro",
 	"gemini-1.5-flash-latest",
+	"gemini-2.0-flash-exp"
 ];
 
 // curl \
@@ -214,19 +215,61 @@ impl GeminiAdapter {
 
 		// -- Build
 		for msg in chat_req.messages {
-			// TODO: Needs to implement tool_calls
-			let MessageContent::Text(content) = msg.content else {
-				return Err(Error::MessageContentTypeNotSupported {
-					model_iden,
-					cause: "Only MessageContent::Text supported for this model (for now)",
-				});
-			};
-
 			match msg.role {
 				// For now, system goes as "user" (later, we might have adapter_config.system_to_user_impl)
-				ChatRole::System => systems.push(content),
-				ChatRole::User => contents.push(json! ({"role": "user", "parts": [{"text": content}]})),
-				ChatRole::Assistant => contents.push(json! ({"role": "model", "parts": [{"text": content}]})),
+				ChatRole::System => {
+					let MessageContent::Text(content) = msg.content else {
+						return Err(Error::MessageContentTypeNotSupported {
+							model_iden,
+							cause: "Only MessageContent::Text supported for this model (for now)",
+						});
+					};
+					systems.push(content)
+				},
+				ChatRole::User => {
+					let content = match msg.content {
+						MessageContent::Text(content) => json!([{"text": content}]),
+						MessageContent::Parts(parts) => {
+							json!(parts.iter().map(|part| match part {
+								ContentPart::Text(text) => json!({"text": text.clone()}),
+								ContentPart::Image{content, content_type, source} => {
+									match source {
+										ImageSource::Url => json!({
+											"file_data": {
+												"mime_type": content_type,
+								                "file_uri": content
+											}
+								        }),
+										ImageSource::Base64 => json!({
+							                "inline_data": {
+								                "mime_type": content_type,
+								                "data": content
+							                }
+							            }),
+									}
+								},
+							}).collect::<Vec<Value>>())
+						},
+						// Use `match` instead of `if let`. This will allow to future-proof this
+						// implementation in case some new message content types would appear,
+						// this way library would not compile if not all methods are implemented
+						// continue would allow to gracefully skip pushing unserializable message
+						// TODO: Probably need to warn if it is a ToolCalls type of content
+						MessageContent::ToolCalls(_) => continue,
+						MessageContent::ToolResponses(_) => continue,
+					};
+
+					contents.push(json!({"role": "user", "parts": content}));
+				},
+				ChatRole::Assistant => {
+					let MessageContent::Text(content) = msg.content else {
+						return Err(Error::MessageContentTypeNotSupported {
+							model_iden,
+							cause: "Only MessageContent::Text supported for this model (for now)",
+						});
+					};
+					contents.push(json!({"role": "model", "parts": [{"text": content}]}))
+				},
 				ChatRole::Tool => {
 					return Err(Error::MessageRoleNotSupported {
 						model_iden,

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -256,7 +256,7 @@ impl OpenAIAdapter {
 							json!(parts.iter().map(|part| match part {
 								ContentPart::Text(text) => json!({"type": "text", "text": text.clone()}),
 								ContentPart::Image(location) => match location {
-									ImageLocation::Url(url) => json!({"type": "image_url", "image_url": url.clone()}),
+									ImageLocation::Url(url) => json!({"type": "image_url", "image_url": {"url": url.clone()}}),
 									ImageLocation::Base64 {..} => todo!("Missing B64 implementation!"),
 								}
 							}).collect::<Vec<Value>>())

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -257,7 +257,10 @@ impl OpenAIAdapter {
 								ContentPart::Text(text) => json!({"type": "text", "text": text.clone()}),
 								ContentPart::Image(location) => match location {
 									ImageLocation::Url(url) => json!({"type": "image_url", "image_url": {"url": url.clone()}}),
-									ImageLocation::Base64 {..} => todo!("Missing B64 implementation!"),
+									ImageLocation::Base64 {content, mime} => {
+										let image_url = format!("data:{mime},{content}");
+										json!({"type": "image_url", "image_url": {"url": image_url}})
+									},
 								}
 							}).collect::<Vec<Value>>())
 						},

--- a/src/chat/message_content.rs
+++ b/src/chat/message_content.rs
@@ -2,8 +2,6 @@ use crate::chat::{ToolCall, ToolResponse};
 use derive_more::derive::From;
 use serde::{Deserialize, Serialize};
 
-/// Currently, it only supports Text,
-/// but the goal is to support multi-part message content (see below)
 #[derive(Debug, Clone, Serialize, Deserialize, From)]
 pub enum MessageContent {
 	/// Text content
@@ -122,7 +120,11 @@ impl From<Vec<ContentPart>> for MessageContent {
 #[derive(Debug, Clone, Serialize, Deserialize, From)]
 pub enum ContentPart {
 	Text(String),
-	Image(ImageLocation),
+	Image {
+		content: String,
+		content_type: String,
+		source: ImageSource,
+	},
 }
 
 // region:    --- Froms
@@ -137,14 +139,11 @@ impl<'a> From<&'a str> for ContentPart {
 
 
 #[derive(Debug, Clone, Serialize, Deserialize, From)]
-pub enum ImageLocation {
-	Url(String),
-	Base64{
-		content: String,
-		mime: String,
-	},
+pub enum ImageSource {
+	Url,
+	Base64
 
-	// Not `Local` location, this would require handling errors like "file not found" etc.
+	// No `Local` location, this would require handling errors like "file not found" etc.
 	// Such file can be easily provided by user as Base64, also can implement convenient
 	// TryFrom<File> to Base64 version. All LLMs accepts local Images only as Base64
 }

--- a/src/chat/message_content.rs
+++ b/src/chat/message_content.rs
@@ -9,6 +9,9 @@ pub enum MessageContent {
 	/// Text content
 	Text(String),
 
+	/// Content parts
+	Parts(Vec<ContentPart>),
+
 	/// Tool calls
 	#[from]
 	ToolCalls(Vec<ToolCall>),
@@ -25,6 +28,9 @@ impl MessageContent {
 		MessageContent::Text(content.into())
 	}
 
+	/// Create a new MessageContent from provided content parts
+	pub fn from_parts(parts: impl Into<Vec<ContentPart>>) -> Self { MessageContent::Parts(parts.into()) }
+
 	/// Create a new MessageContent with the ToolCalls variant
 	pub fn from_tool_calls(tool_calls: Vec<ToolCall>) -> Self {
 		MessageContent::ToolCalls(tool_calls)
@@ -40,6 +46,12 @@ impl MessageContent {
 	pub fn text_as_str(&self) -> Option<&str> {
 		match self {
 			MessageContent::Text(content) => Some(content.as_str()),
+			MessageContent::Parts(parts) => {
+				Some(parts.iter().filter_map(|part| match part {
+					ContentPart::Text(content) => Some(content.clone()),
+					_ => None,
+				}).collect::<Vec<String>>().join("\n").leak()) // TODO revisit this, should we leak &str?
+			},
 			MessageContent::ToolCalls(_) => None,
 			MessageContent::ToolResponses(_) => None,
 		}
@@ -53,6 +65,12 @@ impl MessageContent {
 	pub fn text_into_string(self) -> Option<String> {
 		match self {
 			MessageContent::Text(content) => Some(content),
+			MessageContent::Parts(parts) => {
+				Some(parts.into_iter().filter_map(|part| match part {
+					ContentPart::Text(content) => Some(content),
+					_ => None,
+				}).collect::<Vec<String>>().join("\n"))
+			},
 			MessageContent::ToolCalls(_) => None,
 			MessageContent::ToolResponses(_) => None,
 		}
@@ -62,6 +80,7 @@ impl MessageContent {
 	pub fn is_empty(&self) -> bool {
 		match self {
 			MessageContent::Text(content) => content.is_empty(),
+			MessageContent::Parts(parts) => parts.is_empty(),
 			MessageContent::ToolCalls(tool_calls) => tool_calls.is_empty(),
 			MessageContent::ToolResponses(tool_responses) => tool_responses.is_empty(),
 		}
@@ -94,27 +113,38 @@ impl From<ToolResponse> for MessageContent {
 	}
 }
 
+impl From<Vec<ContentPart>> for MessageContent {
+	fn from(parts: Vec<ContentPart>) -> Self { MessageContent::Parts(parts) }
+}
+
 // endregion: --- Froms
 
-// NOTE: The goal is to add a Parts variant with ContentPart for multipart support
-//
-// ````
-// pub enum MessageContent {
-// 	Text(String),
-//  Parts(Vec<ContentPart>)` variant to `MessageContent`
-// }
-// ```
-//
-// With something like this:
-// ```
-// pub enum ContentPart {
-// 	Text(String),
-// 	Image(ImagePart)
-// }
-//
-// pub enum ImagePart {
-// 	Local(PathBuf),
-// 	Remote(Url),
-// 	Base64(String)
-// }
-// ```
+#[derive(Debug, Clone, Serialize, Deserialize, From)]
+pub enum ContentPart {
+	Text(String),
+	Image(ImageLocation),
+}
+
+// region:    --- Froms
+
+impl<'a> From<&'a str> for ContentPart {
+	fn from(s: &'a str) -> Self {
+		ContentPart::Text(s.to_string())
+	}
+}
+
+// endregion: --- Froms
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, From)]
+pub enum ImageLocation {
+	Url(String),
+	Base64{
+		content: String,
+		mime: String,
+	},
+
+	// Not `Local` location, this would require handling errors like "file not found" etc.
+	// Such file can be easily provided by user as Base64, also can implement convenient
+	// TryFrom<File> to Base64 version. All LLMs accepts local Images only as Base64
+}

--- a/tests/support/seeders.rs
+++ b/tests/support/seeders.rs
@@ -1,4 +1,4 @@
-use genai::chat::{ChatMessage, ChatRequest, Tool};
+use genai::chat::{ChatMessage, ChatRequest, ContentPart, ImageLocation, Tool};
 use serde_json::json;
 
 pub fn seed_chat_req_simple() -> ChatRequest {
@@ -6,6 +6,20 @@ pub fn seed_chat_req_simple() -> ChatRequest {
 		// -- Messages (deactivate to see the differences)
 		ChatMessage::system("Answer in one sentence"),
 		ChatMessage::user("Why is the sky blue?"),
+	])
+}
+
+pub fn seed_chat_req_with_image() -> ChatRequest {
+	ChatRequest::new(vec![
+		// -- Messages (deactivate to see the differences)
+		ChatMessage::system("Answer in one sentence"),
+		ChatMessage::user(vec![
+			ContentPart::from("What is in this image?"),
+			ImageLocation::Base64 {
+				content: "BASE64 ENCODED IMAGE".to_string(),
+				mime: "image/png".to_string(),
+			}.into(),
+		]),
 	])
 }
 

--- a/tests/support/seeders.rs
+++ b/tests/support/seeders.rs
@@ -1,4 +1,4 @@
-use genai::chat::{ChatMessage, ChatRequest, ContentPart, ImageLocation, Tool};
+use genai::chat::{ChatMessage, ChatRequest, ContentPart, ImageSource, Tool};
 use serde_json::json;
 
 pub fn seed_chat_req_simple() -> ChatRequest {
@@ -15,10 +15,11 @@ pub fn seed_chat_req_with_image() -> ChatRequest {
 		ChatMessage::system("Answer in one sentence"),
 		ChatMessage::user(vec![
 			ContentPart::from("What is in this image?"),
-			ImageLocation::Base64 {
+			ContentPart::Image {
 				content: "BASE64 ENCODED IMAGE".to_string(),
-				mime: "image/png".to_string(),
-			}.into(),
+				content_type:"image/png".to_string(),
+				source: ImageSource::Base64,
+			}
 		]),
 	])
 }


### PR DESCRIPTION
This pull request addresses a significant gap in the GenAI crate by adding initial image support for chat requests.

**Key updates:**

1. I've updated the `ChatMessage` structure to support `ContentPart`, enabling more flexibility.
2. API calls have been implemented for:
	* OpenAI
	* Anthropic (also known as Ollama)
	* Gemini
3. Additionally, the Gemini 2.0 Flash Experimental has been included.
4. An image example has been added to demonstrate this new feature.

**Testing and results:**

I've successfully tested the API calls with various chat requests:

* OpenAI: both URL and Base64 images were processed correctly.
* Ollama: Base64 images worked as expected.
* Gemini: both URL and Base64 images were handled correctly.

In all cases, the Large Language Model responded accurately to the requests. However, I encountered difficulties adhering strictly to your proposed interface due to differences in how each API handles images. As a result, I extracted a common interface that requires providing MIME/Content-Type for each image.

**Future possibilities:**

This interface could be utilized later to enable PDF support for Anthropic API.

**Remaining work:**

Two aspects require further attention:

1. Providing clear feedback to users when Anthropic API does not support URL images, but only Base64 images.
2. Handling image from file functionality, which I've left commented out for now. This would introduce a point where the file is not accessible in the chat message and could result in unexpected behavior. But it should be possible to implement is as `TryFrom<File/PathBuf>` for `ContentPart` so handling this error would be on user side