### PR TITLE
initial embedding implementation

### DIFF
--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -110,7 +110,10 @@ impl AdapterKind {
 			Ok(Self::OpenAI)
 		} else if anthropic::MODELS.contains(&model) || model.starts_with("claude") {
 			Ok(Self::Anthropic)
-		} else if cohere::MODELS.contains(&model) || model.starts_with("command") {
+		} else if cohere::MODELS.contains(&model)
+			|| cohere::EMBEDDING_MODELS.contains(&model)
+			|| model.starts_with("command")
+		{
 			Ok(Self::Cohere)
 		} else if gemini::MODELS.contains(&model)
 			|| gemini::EMBEDDING_MODELS.contains(&model)

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -89,10 +89,10 @@ impl AdapterKind {
 	/// When more control is needed, the `ServiceTypeResolver` can be used
 	/// to map a model name to any adapter and endpoint.
 	///
-	///  - OpenAI     - starts_with "gpt", "o3", "o1", "chatgpt"
-	///  - Anthropic  - starts_with "claude"
-	///  - Cohere     - starts_with "command"
-	///  - Gemini     - starts_with "gemini"
+	///  - OpenAI     - model in OpenAI models or starts_with "gpt", "o3", "o1", "chatgpt"
+	///  - Anthropic  - model in Anthropic models or starts_with "claude"
+	///  - Cohere     - model in Cohere models or starts_with "command"
+	///  - Gemini     - model in Gemini models or starts_with "gemini"
 	///  - Groq       - model in Groq models
 	///  - DeepSeek   - model in DeepSeek models (deepseek.com)
 	///  - Ollama     - For anything else

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -9,6 +9,8 @@ use crate::Result;
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
+use super::{anthropic, cohere, gemini, openai, xai};
+
 /// AdapterKind is an enum that represents the different types of adapters that can be used to interact with the API.
 #[derive(Debug, Clone, Copy, Display, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum AdapterKind {
@@ -98,19 +100,24 @@ impl AdapterKind {
 	/// Note: At this point, this will never fail as the fallback is the Ollama adapter.
 	///       This might change in the future, hence the Result return type.
 	pub fn from_model(model: &str) -> Result<Self> {
-		if model.starts_with("gpt")
+		if openai::MODELS.contains(&model)
+			|| openai::EMBEDDING_MODELS.contains(&model)
+			|| model.starts_with("gpt")
 			|| model.starts_with("o3-")
 			|| model.starts_with("o1-")
 			|| model.starts_with("chatgpt")
 		{
 			Ok(Self::OpenAI)
-		} else if model.starts_with("claude") {
+		} else if anthropic::MODELS.contains(&model) || model.starts_with("claude") {
 			Ok(Self::Anthropic)
-		} else if model.starts_with("command") {
+		} else if cohere::MODELS.contains(&model) || model.starts_with("command") {
 			Ok(Self::Cohere)
-		} else if model.starts_with("gemini") {
+		} else if gemini::MODELS.contains(&model)
+			|| gemini::EMBEDDING_MODELS.contains(&model)
+			|| model.starts_with("gemini")
+		{
 			Ok(Self::Gemini)
-		} else if model.starts_with("grok") {
+		} else if xai::MODELS.contains(&model) || model.starts_with("grok") {
 			Ok(Self::Xai)
 		} else if deepseek::MODELS.contains(&model) {
 			Ok(Self::DeepSeek)

--- a/src/adapter/adapter_types.rs
+++ b/src/adapter/adapter_types.rs
@@ -1,9 +1,9 @@
 use crate::adapter::AdapterKind;
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::embed::{BatchEmbedRequest, EmbedOptionsSet, EmbedResponse, SingleEmbedRequest};
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
-use crate::ModelIden;
-use crate::{Result, ServiceTarget};
+use crate::{ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 use serde_json::Value;
 
@@ -21,6 +21,10 @@ pub trait Adapter {
 	/// The base service URL for this AdapterKind for the given service type.
 	/// NOTE: For some services, the URL will be further updated in the to_web_request_data method.
 	fn get_service_url(model_iden: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> String;
+
+	/// The base embeddings URL for this AdapterKind for the given service type.
+	/// NOTE: Some adapters do not support embedding, so this function will return None incorrectly.
+	fn get_embed_url(model_iden: &ModelIden, endpoint: Endpoint) -> Option<String>;
 
 	/// To be implemented by Adapters.
 	fn to_web_request_data(
@@ -43,6 +47,26 @@ pub trait Adapter {
 		reqwest_builder: RequestBuilder,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatStreamResponse>;
+
+	/// To be implemented by Adapters.
+	fn embed(
+		service_target: ServiceTarget,
+		embed_req: SingleEmbedRequest,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData>;
+
+	/// To be implemented by Adapters.
+	fn embed_batch(
+		service_target: ServiceTarget,
+		embed_req: BatchEmbedRequest,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData>;
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<EmbedResponse>;
 }
 
 // region:    --- ServiceType

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -7,8 +7,7 @@ use crate::chat::{
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
-use crate::ModelIden;
-use crate::{Result, ServiceTarget};
+use crate::{Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 use reqwest_eventsource::EventSource;
 use serde_json::{json, Value};
@@ -54,6 +53,11 @@ impl Adapter for AnthropicAdapter {
 		match service_type {
 			ServiceType::Chat | ServiceType::ChatStream => format!("{base_url}messages"),
 		}
+	}
+
+	/// Anthropic does not support embedding
+	fn get_embed_url(_: &ModelIden, _: Endpoint) -> Option<String> {
+		None
 	}
 
 	fn to_web_request_data(
@@ -196,6 +200,34 @@ impl Adapter for AnthropicAdapter {
 			model_iden,
 			stream: chat_stream,
 		})
+	}
+
+	fn embed(
+		service_target: ServiceTarget,
+		_: crate::embed::SingleEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotSupported {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn embed_batch(
+		service_target: ServiceTarget,
+		_: crate::embed::BatchEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotSupported {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		_: WebResponse,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(Error::EmbeddingNotSupported { model_iden })
 	}
 }
 

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -22,7 +22,7 @@ const MAX_TOKENS_8K: u32 = 8192;
 const MAX_TOKENS_4K: u32 = 4096;
 
 const ANTHROPIC_VERSION: &str = "2023-06-01";
-const MODELS: &[&str] = &[
+pub(in crate::adapter) const MODELS: &[&str] = &[
 	"claude-3-5-sonnet-20241022",
 	"claude-3-5-haiku-20241022",
 	"claude-3-opus-20240229",

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -6,8 +6,7 @@ use crate::chat::{
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebResponse, WebStream};
-use crate::{Error, Result};
-use crate::{ModelIden, ServiceTarget};
+use crate::{Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 use serde_json::{json, Value};
 use value_ext::JsonValueExt;
@@ -47,6 +46,13 @@ impl Adapter for CohereAdapter {
 		match service_type {
 			ServiceType::Chat | ServiceType::ChatStream => format!("{base_url}chat"),
 		}
+	}
+
+	/// We have not implemented embedding for Cohere yet
+	fn get_embed_url(_model_iden: &ModelIden, _endpoint: Endpoint) -> Option<String> {
+		println!("Cohere embedding not implemented yet.");
+
+		None
 	}
 
 	fn to_web_request_data(
@@ -153,6 +159,34 @@ impl Adapter for CohereAdapter {
 			model_iden,
 			stream: chat_stream,
 		})
+	}
+
+	fn embed(
+		service_target: ServiceTarget,
+		_embed_req: crate::embed::SingleEmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotImplemented {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn embed_batch(
+		service_target: ServiceTarget,
+		_embed_req: crate::embed::BatchEmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotImplemented {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		_web_response: WebResponse,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(Error::EmbeddingNotImplemented { model_iden })
 	}
 }
 

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -13,7 +13,7 @@ use value_ext::JsonValueExt;
 
 pub struct CohereAdapter;
 
-const MODELS: &[&str] = &[
+pub(in crate::adapter) const MODELS: &[&str] = &[
 	"command-r-plus",
 	"command-r",
 	"command",

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -4,9 +4,10 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	ChatOptionsSet, ChatRequest, ChatResponse, ChatRole, ChatStream, ChatStreamResponse, MessageContent, MetaUsage,
 };
+use crate::embed::EmbedResponse;
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebResponse, WebStream};
-use crate::{Error, ModelIden, Result, ServiceTarget};
+use crate::{embed, Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 use serde_json::{json, Value};
 use value_ext::JsonValueExt;
@@ -20,6 +21,15 @@ pub(in crate::adapter) const MODELS: &[&str] = &[
 	"command-nightly",
 	"command-light",
 	"command-light-nightly",
+];
+pub(in crate::adapter) const EMBEDDING_MODELS: &[&str] = &[
+	"embed-english-v3.0",
+	"embed-multilingual-v3.0",
+	"embed-english-light-v3.0",
+	"embed-multilingual-light-v3.0",
+	"mbed-english-v2.0",
+	"embed-english-light-v2.0",
+	"embed-multilingual-v2.0",
 ];
 
 impl CohereAdapter {
@@ -49,10 +59,10 @@ impl Adapter for CohereAdapter {
 	}
 
 	/// We have not implemented embedding for Cohere yet
-	fn get_embed_url(_model_iden: &ModelIden, _endpoint: Endpoint) -> Option<String> {
-		println!("Cohere embedding not implemented yet.");
+	fn get_embed_url(_model_iden: &ModelIden, endpoint: Endpoint) -> Option<String> {
+		let base_url = endpoint.base_url();
 
-		None
+		Some(format!("{base_url}embed"))
 	}
 
 	fn to_web_request_data(
@@ -163,30 +173,106 @@ impl Adapter for CohereAdapter {
 
 	fn embed(
 		service_target: ServiceTarget,
-		_embed_req: crate::embed::SingleEmbedRequest,
-		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+		embed_req: crate::embed::SingleEmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<WebRequestData> {
-		Err(Error::EmbeddingNotImplemented {
-			model_iden: service_target.model,
-		})
+		let ServiceTarget { model, auth, endpoint } = service_target;
+		let model_name = &model.model_name;
+
+		// -- api_key
+		let api_key = get_api_key(auth, &model)?;
+
+		// -- url
+		let url = Self::get_embed_url(&model, endpoint).ok_or(Error::EmbeddingNotSupported {
+			model_iden: model.clone(),
+		})?;
+
+		// -- headers
+		let headers = vec![
+			// headers
+			("Authorization".to_string(), format!("Bearer {api_key}")),
+		];
+
+		let payload = json!({
+			"model": model_name,
+			"texts": [embed_req.document],
+			"input_type": options_set.input_type().unwrap_or("search_document"),
+		});
+
+		// Cohere does not support custom embedding dimensions
+		// if let Some(dimensions) = options_set.dimensions() {
+		// 	payload.x_insert("dimensions", dimensions)?;
+		// }
+
+		Ok(WebRequestData { url, headers, payload })
 	}
 
 	fn embed_batch(
 		service_target: ServiceTarget,
-		_embed_req: crate::embed::BatchEmbedRequest,
-		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+		embed_req: crate::embed::BatchEmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<WebRequestData> {
-		Err(Error::EmbeddingNotImplemented {
-			model_iden: service_target.model,
-		})
+		let ServiceTarget { model, auth, endpoint } = service_target;
+		let model_name = &model.model_name;
+
+		// -- api_key
+		let api_key = get_api_key(auth, &model)?;
+
+		// -- url
+		let url = Self::get_embed_url(&model, endpoint).ok_or(Error::EmbeddingNotSupported {
+			model_iden: model.clone(),
+		})?;
+
+		// -- headers
+		let headers = vec![
+			// headers
+			("Authorization".to_string(), format!("Bearer {api_key}")),
+		];
+
+		let payload = json!({
+			"model": model_name,
+			"texts": embed_req.documents,
+			"input_type": options_set.input_type().unwrap_or("search_document"),
+		});
+
+		// Cohere does not support custom embedding dimensions
+		// if let Some(dimensions) = options_set.dimensions() {
+		// 	payload.x_insert("dimensions", dimensions)?;
+		// }
+
+		Ok(WebRequestData { url, headers, payload })
 	}
 
 	fn to_embed_response(
 		model_iden: ModelIden,
-		_web_response: WebResponse,
-		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+		web_response: WebResponse,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<crate::embed::EmbedResponse> {
-		Err(Error::EmbeddingNotImplemented { model_iden })
+		let WebResponse { mut body, .. } = web_response;
+
+		// -- Capture the usage
+		let usage = body.x_take("/meta/billed_units").map(|mut usage: Value| {
+			let prompt_tokens: Option<i32> = usage.x_take("input_tokens").ok();
+
+			embed::MetaUsage {
+				prompt_tokens,
+				total_tokens: None,
+			}
+		})?;
+
+		// -- Capture the content
+		let embeddings = body.x_take("embeddings").map(|embeddings: Vec<Vec<f64>>| {
+			embeddings
+				.into_iter()
+				.filter_map(|embedding: Vec<f64>| Some(embed::EmbeddingObject { index: None, embedding }))
+				.collect::<Vec<embed::EmbeddingObject>>()
+		})?;
+
+		Ok(EmbedResponse {
+			embeddings,
+			usage,
+			model_iden,
+		})
 	}
 }
 

--- a/src/adapter/adapters/deepseek/adapter_impl.rs
+++ b/src/adapter/adapters/deepseek/adapter_impl.rs
@@ -3,8 +3,7 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
-use crate::ModelIden;
-use crate::{Result, ServiceTarget};
+use crate::{Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 
 pub struct DeepSeekAdapter;
@@ -34,6 +33,11 @@ impl Adapter for DeepSeekAdapter {
 		OpenAIAdapter::util_get_service_url(model, service_type, endpoint)
 	}
 
+	/// DeepSeek does not support embedding
+	fn get_embed_url(_: &ModelIden, _: Endpoint) -> Option<String> {
+		None
+	}
+
 	fn to_web_request_data(
 		target: ServiceTarget,
 		service_type: ServiceType,
@@ -57,5 +61,33 @@ impl Adapter for DeepSeekAdapter {
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	fn embed(
+		service_target: ServiceTarget,
+		_: crate::embed::SingleEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotSupported {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn embed_batch(
+		service_target: ServiceTarget,
+		_: crate::embed::BatchEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotSupported {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		_: WebResponse,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(Error::EmbeddingNotSupported { model_iden })
 	}
 }

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -15,13 +15,24 @@ use value_ext::JsonValueExt;
 
 pub struct GeminiAdapter;
 
-const MODELS: &[&str] = &[
+pub(in crate::adapter) const MODELS: &[&str] = &[
 	"gemini-2.0-flash",
+	"gemini-2.0-pro-exp-02-05",
+	"gemini-2.0-flash-thinking-exp-01-21",
+	"learnlm-1.5-pro-experimental",
+	"gemini-2.0-flash-lite-preview-02-05",
 	"gemini-1.5-pro",
 	"gemini-1.5-flash",
 	"gemini-1.5-flash-8b",
 	"gemini-1.0-pro",
 	"gemini-1.5-flash-latest",
+];
+
+// Embedding models
+pub(in crate::adapter) const EMBEDDING_MODELS: &[&str] = &[
+	//
+	"text-embedding-001",
+	"text-embedding-004",
 ];
 
 // curl \

--- a/src/adapter/adapters/groq/adapter_impl.rs
+++ b/src/adapter/adapters/groq/adapter_impl.rs
@@ -3,8 +3,7 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
-use crate::ModelIden;
-use crate::{Result, ServiceTarget};
+use crate::{Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 
 pub struct GroqAdapter;
@@ -55,6 +54,13 @@ impl Adapter for GroqAdapter {
 		OpenAIAdapter::util_get_service_url(model, service_type, endpoint)
 	}
 
+	/// We have not implemented embedding for Groq yet
+	fn get_embed_url(_model_iden: &ModelIden, _endpoint: Endpoint) -> Option<String> {
+		println!("Groq embedding not implemented yet");
+
+		None
+	}
+
 	fn to_web_request_data(
 		target: ServiceTarget,
 		service_type: ServiceType,
@@ -78,5 +84,33 @@ impl Adapter for GroqAdapter {
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	fn embed(
+		service_target: ServiceTarget,
+		_embed_req: crate::embed::SingleEmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotImplemented {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn embed_batch(
+		service_target: ServiceTarget,
+		_embed_req: crate::embed::BatchEmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotImplemented {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		_web_response: WebResponse,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(Error::EmbeddingNotImplemented { model_iden })
 	}
 }

--- a/src/adapter/adapters/groq/adapter_impl.rs
+++ b/src/adapter/adapters/groq/adapter_impl.rs
@@ -91,7 +91,7 @@ impl Adapter for GroqAdapter {
 		_embed_req: crate::embed::SingleEmbedRequest,
 		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<WebRequestData> {
-		Err(Error::EmbeddingNotImplemented {
+		Err(Error::EmbeddingNotSupported {
 			model_iden: service_target.model,
 		})
 	}
@@ -101,7 +101,7 @@ impl Adapter for GroqAdapter {
 		_embed_req: crate::embed::BatchEmbedRequest,
 		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<WebRequestData> {
-		Err(Error::EmbeddingNotImplemented {
+		Err(Error::EmbeddingNotSupported {
 			model_iden: service_target.model,
 		})
 	}
@@ -111,6 +111,6 @@ impl Adapter for GroqAdapter {
 		_web_response: WebResponse,
 		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<crate::embed::EmbedResponse> {
-		Err(Error::EmbeddingNotImplemented { model_iden })
+		Err(Error::EmbeddingNotSupported { model_iden })
 	}
 }

--- a/src/adapter/adapters/ollama/adapter_impl.rs
+++ b/src/adapter/adapters/ollama/adapter_impl.rs
@@ -1,13 +1,15 @@
 //! API DOC: https://github.com/ollama/ollama/blob/main/docs/openai.md
 
+use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::openai::OpenAIAdapter;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::embed::EmbedResponse;
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
-use crate::{Error, ModelIden, Result, ServiceTarget};
+use crate::{embed, Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
-use serde_json::Value;
+use serde_json::{json, Value};
 use value_ext::JsonValueExt;
 
 pub struct OllamaAdapter;
@@ -63,9 +65,11 @@ impl Adapter for OllamaAdapter {
 	}
 
 	/// We have not implemented embedding for Ollama yet
-	fn get_embed_url(_model_iden: &ModelIden, _endpoint: Endpoint) -> Option<String> {
-		println!("Ollama embedding not implemented yet");
-		None
+	fn get_embed_url(_model_iden: &ModelIden, endpoint: Endpoint) -> Option<String> {
+		// Remove the OpenAI compatibility prefix to hop on main Ollama API
+		let base_url = endpoint.base_url().replace("v1/", "");
+
+		Some(format!("{base_url}api/embed"))
 	}
 
 	fn to_web_request_data(
@@ -95,29 +99,96 @@ impl Adapter for OllamaAdapter {
 
 	fn embed(
 		service_target: ServiceTarget,
-		_embed_req: crate::embed::SingleEmbedRequest,
-		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+		embed_req: crate::embed::SingleEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<WebRequestData> {
-		Err(Error::EmbeddingNotImplemented {
-			model_iden: service_target.model,
-		})
+		let ServiceTarget { model, auth, endpoint } = service_target;
+		let model_name = &model.model_name;
+
+		// -- api_key
+		let api_key = get_api_key(auth, &model)?;
+
+		// -- url
+		let url = Self::get_embed_url(&model, endpoint).ok_or(Error::EmbeddingNotSupported {
+			model_iden: model.clone(),
+		})?;
+
+		// -- headers
+		let headers = vec![
+			// headers
+			("Authorization".to_string(), format!("Bearer {api_key}")),
+		];
+
+		let payload = json!({
+			"model": model_name,
+			"input": embed_req.document,
+		});
+
+		// Ollama does not support custom embedding dimensions
+		// if let Some(dimensions) = options_set.dimensions() {
+		// 	payload.x_insert("dimensions", dimensions)?;
+		// }
+
+		Ok(WebRequestData { url, headers, payload })
 	}
 
 	fn embed_batch(
 		service_target: ServiceTarget,
-		_embed_req: crate::embed::BatchEmbedRequest,
-		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+		embed_req: crate::embed::BatchEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<WebRequestData> {
-		Err(Error::EmbeddingNotImplemented {
-			model_iden: service_target.model,
-		})
+		let ServiceTarget { model, auth, endpoint } = service_target;
+		let model_name = &model.model_name;
+
+		// -- api_key
+		let api_key = get_api_key(auth, &model)?;
+
+		// -- url
+		let url = Self::get_embed_url(&model, endpoint).ok_or(Error::EmbeddingNotSupported {
+			model_iden: model.clone(),
+		})?;
+
+		// -- headers
+		let headers = vec![
+			// headers
+			("Authorization".to_string(), format!("Bearer {api_key}")),
+		];
+
+		let payload = json!({
+			"model": model_name,
+			"input": embed_req.documents,
+		});
+
+		// Ollama does not support custom embedding dimensions
+		// if let Some(dimensions) = options_set.dimensions() {
+		// 	payload.x_insert("dimensions", dimensions)?;
+		// }
+
+		Ok(WebRequestData { url, headers, payload })
 	}
 
 	fn to_embed_response(
 		model_iden: ModelIden,
-		_web_response: WebResponse,
-		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+		web_response: WebResponse,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
 	) -> Result<crate::embed::EmbedResponse> {
-		Err(Error::EmbeddingNotImplemented { model_iden })
+		let WebResponse { mut body, .. } = web_response;
+
+		// Ollama does not return the usage
+		let usage = embed::MetaUsage::default();
+
+		// -- Capture the content
+		let embeddings = body.x_take("embeddings").map(|embeddings: Vec<Vec<f64>>| {
+			embeddings
+				.into_iter()
+				.filter_map(|embedding: Vec<f64>| Some(embed::EmbeddingObject { index: None, embedding }))
+				.collect::<Vec<embed::EmbeddingObject>>()
+		})?;
+
+		Ok(EmbedResponse {
+			embeddings,
+			usage,
+			model_iden,
+		})
 	}
 }

--- a/src/adapter/adapters/ollama/adapter_impl.rs
+++ b/src/adapter/adapters/ollama/adapter_impl.rs
@@ -5,8 +5,7 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
-use crate::{Error, Result};
-use crate::{ModelIden, ServiceTarget};
+use crate::{Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 use serde_json::Value;
 use value_ext::JsonValueExt;
@@ -63,6 +62,12 @@ impl Adapter for OllamaAdapter {
 		OpenAIAdapter::util_get_service_url(model_iden, service_type, endpoint)
 	}
 
+	/// We have not implemented embedding for Ollama yet
+	fn get_embed_url(_model_iden: &ModelIden, _endpoint: Endpoint) -> Option<String> {
+		println!("Ollama embedding not implemented yet");
+		None
+	}
+
 	fn to_web_request_data(
 		target: ServiceTarget,
 		service_type: ServiceType,
@@ -86,5 +91,33 @@ impl Adapter for OllamaAdapter {
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	fn embed(
+		service_target: ServiceTarget,
+		_embed_req: crate::embed::SingleEmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotImplemented {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn embed_batch(
+		service_target: ServiceTarget,
+		_embed_req: crate::embed::BatchEmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotImplemented {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		_web_response: WebResponse,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(Error::EmbeddingNotImplemented { model_iden })
 	}
 }

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -18,13 +18,21 @@ use value_ext::JsonValueExt;
 pub struct OpenAIAdapter;
 
 // Latest models
-const MODELS: &[&str] = &[
+pub(in crate::adapter) const MODELS: &[&str] = &[
 	//
 	"gpt-4o",
 	"gpt-4o-mini",
 	"o3-mini",
 	"o1",
 	"o1-mini",
+];
+
+// Embedding models
+pub(in crate::adapter) const EMBEDDING_MODELS: &[&str] = &[
+	//
+	"text-embedding-ada-002",
+	"text-embedding-3-small",
+	"text-embedding-3-large",
 ];
 
 impl OpenAIAdapter {

--- a/src/adapter/adapters/xai/adapter_impl.rs
+++ b/src/adapter/adapters/xai/adapter_impl.rs
@@ -3,8 +3,7 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
-use crate::ModelIden;
-use crate::{Result, ServiceTarget};
+use crate::{Error, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 
 pub struct XaiAdapter;
@@ -57,5 +56,38 @@ impl Adapter for XaiAdapter {
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	/// xAI does not support embedding
+	fn get_embed_url(_: &ModelIden, _: Endpoint) -> Option<String> {
+		None
+	}
+
+	fn embed(
+		service_target: ServiceTarget,
+		_: crate::embed::SingleEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotSupported {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn embed_batch(
+		service_target: ServiceTarget,
+		_: crate::embed::BatchEmbedRequest,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::EmbeddingNotSupported {
+			model_iden: service_target.model,
+		})
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		_: WebResponse,
+		_: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(Error::EmbeddingNotSupported { model_iden })
 	}
 }

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -5,9 +5,9 @@ use crate::adapter::ollama::OllamaAdapter;
 use crate::adapter::openai::OpenAIAdapter;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::embed::{BatchEmbedRequest, EmbedOptionsSet, EmbedResponse, SingleEmbedRequest};
 use crate::webc::WebResponse;
-use crate::ModelIden;
-use crate::{Result, ServiceTarget};
+use crate::{ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 
 use super::groq::GroqAdapter;
@@ -75,6 +75,19 @@ impl AdapterDispatcher {
 		}
 	}
 
+	pub fn get_embed_url(model: &ModelIden, endpoint: Endpoint) -> Option<String> {
+		match model.adapter_kind {
+			AdapterKind::OpenAI => OpenAIAdapter::get_embed_url(model, endpoint),
+			AdapterKind::Anthropic => AnthropicAdapter::get_embed_url(model, endpoint),
+			AdapterKind::Cohere => CohereAdapter::get_embed_url(model, endpoint),
+			AdapterKind::Ollama => OllamaAdapter::get_embed_url(model, endpoint),
+			AdapterKind::Gemini => GeminiAdapter::get_embed_url(model, endpoint),
+			AdapterKind::Groq => GroqAdapter::get_embed_url(model, endpoint),
+			AdapterKind::Xai => XaiAdapter::get_embed_url(model, endpoint),
+			AdapterKind::DeepSeek => DeepSeekAdapter::get_embed_url(model, endpoint),
+		}
+	}
+
 	pub fn to_web_request_data(
 		target: ServiceTarget,
 		service_type: ServiceType,
@@ -127,6 +140,57 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Xai => XaiAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+		}
+	}
+
+	pub fn embed(
+		service_target: ServiceTarget,
+		embed_req: SingleEmbedRequest,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		match service_target.model.adapter_kind {
+			AdapterKind::OpenAI => OpenAIAdapter::embed(service_target, embed_req, options_set),
+			AdapterKind::Anthropic => AnthropicAdapter::embed(service_target, embed_req, options_set),
+			AdapterKind::Cohere => CohereAdapter::embed(service_target, embed_req, options_set),
+			AdapterKind::Ollama => OllamaAdapter::embed(service_target, embed_req, options_set),
+			AdapterKind::Gemini => GeminiAdapter::embed(service_target, embed_req, options_set),
+			AdapterKind::Groq => GroqAdapter::embed(service_target, embed_req, options_set),
+			AdapterKind::Xai => XaiAdapter::embed(service_target, embed_req, options_set),
+			AdapterKind::DeepSeek => DeepSeekAdapter::embed(service_target, embed_req, options_set),
+		}
+	}
+
+	pub fn embed_batch(
+		service_target: ServiceTarget,
+		embed_req: BatchEmbedRequest,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		match service_target.model.adapter_kind {
+			AdapterKind::OpenAI => OpenAIAdapter::embed_batch(service_target, embed_req, options_set),
+			AdapterKind::Anthropic => AnthropicAdapter::embed_batch(service_target, embed_req, options_set),
+			AdapterKind::Cohere => CohereAdapter::embed_batch(service_target, embed_req, options_set),
+			AdapterKind::Ollama => OllamaAdapter::embed_batch(service_target, embed_req, options_set),
+			AdapterKind::Gemini => GeminiAdapter::embed_batch(service_target, embed_req, options_set),
+			AdapterKind::Groq => GroqAdapter::embed_batch(service_target, embed_req, options_set),
+			AdapterKind::Xai => XaiAdapter::embed_batch(service_target, embed_req, options_set),
+			AdapterKind::DeepSeek => DeepSeekAdapter::embed_batch(service_target, embed_req, options_set),
+		}
+	}
+
+	pub fn to_embed_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<EmbedResponse> {
+		match model_iden.adapter_kind {
+			AdapterKind::OpenAI => OpenAIAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Anthropic => AnthropicAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Cohere => CohereAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Ollama => OllamaAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Gemini => GeminiAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Groq => GroqAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Xai => XaiAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::DeepSeek => DeepSeekAdapter::to_embed_response(model_iden, web_response, options_set),
 		}
 	}
 }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,4 +1,5 @@
 use crate::chat::ChatOptions;
+use crate::embed::EmbedOptions;
 use crate::resolver::{
 	AuthResolver, IntoAuthResolverFn, IntoModelMapperFn, IntoServiceTargetResolverFn, ModelMapper,
 	ServiceTargetResolver,
@@ -41,6 +42,15 @@ impl ClientBuilder {
 	pub fn with_chat_options(mut self, options: ChatOptions) -> Self {
 		let client_config = self.config.get_or_insert_with(ClientConfig::default);
 		client_config.chat_options = Some(options);
+		self
+	}
+
+	/// Set the EmbedOptions for the ClientConfig of this ClientBuilder.
+	/// This will create the ClientConfig if it is not present.
+	/// Otherwise, it will just set the `client_config.embed_options`.
+	pub fn with_embed_options(mut self, options: EmbedOptions) -> Self {
+		let client_config = self.config.get_or_insert_with(ClientConfig::default);
+		client_config.embed_options = Some(options);
 		self
 	}
 

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -1,6 +1,7 @@
 use crate::adapter::AdapterDispatcher;
 use crate::chat::ChatOptions;
 use crate::client::ServiceTarget;
+use crate::embed::EmbedOptions;
 use crate::resolver::{AuthResolver, ModelMapper, ServiceTargetResolver};
 use crate::{Error, ModelIden, Result};
 
@@ -11,6 +12,7 @@ pub struct ClientConfig {
 	pub(super) service_target_resolver: Option<ServiceTargetResolver>,
 	pub(super) model_mapper: Option<ModelMapper>,
 	pub(super) chat_options: Option<ChatOptions>,
+	pub(super) embed_options: Option<EmbedOptions>,
 }
 
 /// Chainable setters related to the ClientConfig.
@@ -45,6 +47,12 @@ impl ClientConfig {
 		self.chat_options = Some(options);
 		self
 	}
+
+	/// Set the default embed request options for the ClientConfig.
+	pub fn with_embed_options(mut self, options: EmbedOptions) -> Self {
+		self.embed_options = Some(options);
+		self
+	}
 }
 
 /// Getters for the fields of ClientConfig (as references).
@@ -66,6 +74,11 @@ impl ClientConfig {
 	/// Get a reference to the ChatOptions, if they exist.
 	pub fn chat_options(&self) -> Option<&ChatOptions> {
 		self.chat_options.as_ref()
+	}
+
+	/// Get a reference to the EmbedOptions, if they exist.
+	pub fn embed_options(&self) -> Option<&EmbedOptions> {
+		self.embed_options.as_ref()
 	}
 }
 

--- a/src/embed/embed_options.rs
+++ b/src/embed/embed_options.rs
@@ -1,0 +1,59 @@
+//! ChatOptions allows customization of a chat request.
+//! - It can be provided at the `client::exec_chat(..)` level as an argument,
+//! - or set in the client config `client_config.with_chat_options(..)` to be used as the default for all requests
+//!
+//! Note 1: In the future, we will probably allow setting the client
+//! Note 2: Extracting it from the `ChatRequest` object allows for better reusability of each component.
+
+use serde::{Deserialize, Serialize};
+
+/// Embed Options that are considered for any `Client::exec_embed...` calls.
+///
+/// A fallback `EmbedOptions` can also be set at the `Client` during the client builder phase
+/// ``
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EmbedOptions {
+	/// Will be used for this request if the Adapter/provider supports it.
+	pub dimensions: Option<u32>,
+}
+
+/// Chainable Setters
+impl EmbedOptions {
+	/// Set the `temperature` for this request.
+	pub fn with_dimensions(mut self, value: u32) -> Self {
+		self.dimensions = Some(value);
+		self
+	}
+}
+
+// region:    --- EmbedOptionsSet
+
+/// This is an internal crate struct to resolve the EmbedOptions value in a cascading manner.
+/// First, it attempts to get the value at the embed level (EmbedOptions from the exec_embed...(...) argument).
+/// If a value for the property is not found, it looks at the client default one.
+#[derive(Default, Clone)]
+pub(crate) struct EmbedOptionsSet<'a, 'b> {
+	client: Option<&'a EmbedOptions>,
+	embed: Option<&'b EmbedOptions>,
+}
+
+impl<'a, 'b> EmbedOptionsSet<'a, 'b> {
+	pub fn with_client_options(mut self, options: Option<&'a EmbedOptions>) -> Self {
+		self.client = options;
+		self
+	}
+	pub fn with_embed_options(mut self, options: Option<&'b EmbedOptions>) -> Self {
+		self.embed = options;
+		self
+	}
+}
+
+impl EmbedOptionsSet<'_, '_> {
+	pub fn dimensions(&self) -> Option<u32> {
+		self.embed
+			.and_then(|chat| chat.dimensions)
+			.or_else(|| self.client.and_then(|client| client.dimensions))
+	}
+}
+
+// endregion: --- EmbedOptionsSet

--- a/src/embed/embed_options.rs
+++ b/src/embed/embed_options.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 pub struct EmbedOptions {
 	/// Will be used for this request if the Adapter/provider supports it.
 	pub dimensions: Option<u32>,
+	pub input_type: Option<String>,
 }
 
 /// Chainable Setters
@@ -22,6 +23,10 @@ impl EmbedOptions {
 	/// Set the `temperature` for this request.
 	pub fn with_dimensions(mut self, value: u32) -> Self {
 		self.dimensions = Some(value);
+		self
+	}
+	pub fn with_input_type(mut self, value: String) -> Self {
+		self.input_type = Some(value);
 		self
 	}
 }
@@ -53,6 +58,11 @@ impl EmbedOptionsSet<'_, '_> {
 		self.embed
 			.and_then(|chat| chat.dimensions)
 			.or_else(|| self.client.and_then(|client| client.dimensions))
+	}
+	pub fn input_type(&self) -> Option<&str> {
+		self.embed
+			.and_then(|chat| chat.input_type.as_deref())
+			.or_else(|| self.client.and_then(|client| client.input_type.as_deref()))
 	}
 }
 

--- a/src/embed/embed_request.rs
+++ b/src/embed/embed_request.rs
@@ -1,0 +1,59 @@
+//! This module contains all the types related to a Embed Request (Single or Batch).
+
+use serde::{Deserialize, Serialize};
+
+// region:    --- SingleEmbedRequest
+
+/// The Chat request when performing a direct `Client::`
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SingleEmbedRequest {
+	/// The messages of the request.
+	pub document: String,
+}
+
+/// Constructors
+impl SingleEmbedRequest {
+	/// Create a new SingleEmbedRequest with the given document.
+	pub fn new(document: impl Into<String>) -> Self {
+		Self {
+			document: document.into(),
+		}
+	}
+}
+
+// endregion: --- SingleEmbedRequest
+
+// region:    --- BatchEmbedRequest
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BatchEmbedRequest {
+	/// The messages of the request.
+	pub documents: Vec<String>,
+}
+
+/// Constructors
+impl BatchEmbedRequest {
+	/// Create a new SingleEmbedRequest with the given document.
+	pub fn new(documents: Vec<impl Into<String>>) -> Self {
+		Self {
+			documents: documents.into_iter().map(|s| s.into()).collect(),
+		}
+	}
+}
+
+/// Chainable Setters
+impl BatchEmbedRequest {
+	/// Set the documents of the request.
+	pub fn with_documents(mut self, documents: Vec<impl Into<String>>) -> Self {
+		self.documents = documents.into_iter().map(|s| s.into()).collect();
+		self
+	}
+
+	/// Append a document to the request.
+	pub fn append_document(mut self, document: impl Into<String>) -> Self {
+		self.documents.push(document.into());
+		self
+	}
+}
+
+// endregion: --- BatchEmbedRequest

--- a/src/embed/embed_response.rs
+++ b/src/embed/embed_response.rs
@@ -1,0 +1,70 @@
+//! This module contains all the types related to a Chat Response (except ChatStream, which has its own file).
+
+use serde::{Deserialize, Serialize};
+
+use crate::ModelIden;
+use serde_with::{serde_as, skip_serializing_none};
+
+// region:    --- EmbedResponse
+
+/// The Embed response when performing a direct `Client::`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedResponse {
+	/// The eventual content of the chat response
+	pub embeddings: Vec<EmbeddingObject>,
+
+	/// The Model Identifier (AdapterKind/ModelName) used for this request.
+	/// > NOTE: This might be different from the request model if changed by the ModelMapper
+	pub model_iden: ModelIden,
+
+	/// The eventual usage of the chat response
+	pub usage: MetaUsage,
+}
+
+/// A single embedding object
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingObject {
+	pub index: Option<i32>,
+	pub embedding: Vec<f64>,
+}
+
+// Getters
+impl EmbedResponse {
+	/// Returns the first embedding object of the list as `&EmbeddingObject` if it exists.
+	/// Otherwise, returns None
+	pub fn first_embedding(&self) -> Option<&EmbeddingObject> {
+		self.embeddings.iter().next()
+	}
+
+	/// Consumes the EmbedResponse and returns the first embedding object of the list
+	/// Otherwise, returns None
+	pub fn into_first_embedding(self) -> Option<EmbeddingObject> {
+		self.embeddings.into_iter().next()
+	}
+
+	pub fn embeddings(&self) -> Vec<&EmbeddingObject> {
+		self.embeddings.iter().collect()
+	}
+
+	pub fn into_embeddings(self) -> Vec<EmbeddingObject> {
+		self.embeddings
+	}
+}
+
+// endregion: --- EmbedResponse
+
+// region:    --- MetaUsage
+
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct MetaUsage {
+	/// The input tokens (replaces input_tokens)
+	pub prompt_tokens: Option<i32>,
+
+	/// The total number of tokens if returned by the API call.
+	/// This will either be the total_tokens if returned, or the sum of prompt/completion if not specified in the response.
+	pub total_tokens: Option<i32>,
+}
+
+// endregion: --- MetaUsage

--- a/src/embed/embed_response.rs
+++ b/src/embed/embed_response.rs
@@ -33,7 +33,7 @@ impl EmbedResponse {
 	/// Returns the first embedding object of the list as `&EmbeddingObject` if it exists.
 	/// Otherwise, returns None
 	pub fn first_embedding(&self) -> Option<&EmbeddingObject> {
-		self.embeddings.iter().next()
+		self.embeddings.first()
 	}
 
 	/// Consumes the EmbedResponse and returns the first embedding object of the list

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -1,0 +1,17 @@
+//! The genai chat module contains all of the constructs necessary
+//! to make genai embedding requests with the `genai::Client`.
+
+// region:    --- Modules
+
+mod embed_options;
+mod embed_request;
+mod embed_response;
+
+// -- Flatten
+pub use embed_options::*;
+pub use embed_request::*;
+pub use embed_response::*;
+
+// pub mod printer;
+
+// endregion: --- Modules

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,14 @@ pub enum Error {
 		info: &'static str,
 	},
 
+	// -- Embedding
+	EmbeddingNotSupported {
+		model_iden: ModelIden,
+	},
+	EmbeddingNotImplemented {
+		model_iden: ModelIden,
+	},
+
 	// -- Auth
 	RequiresApiKey {
 		model_iden: ModelIden,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use error::{Error, Result};
 // -- Public Modules
 pub mod adapter;
 pub mod chat;
+pub mod embed;
 pub mod resolver;
 pub mod webc;
 

--- a/tests/support/asserts.rs
+++ b/tests/support/asserts.rs
@@ -79,7 +79,7 @@ impl<'a> From<&'a String> for DataContainer<'a> {
 	}
 }
 
-impl<'a> DataContainer<'a> {
+impl DataContainer<'_> {
 	fn contains(&self, val: &str) -> bool {
 		match self {
 			DataContainer::Owned(vec) => vec.contains(&val),

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -592,20 +592,9 @@ pub async fn common_test_list_models(adapter_kind: AdapterKind, contains: &str) 
 
 // region:    --- Embed
 
-pub async fn test_embed_single(model: &str, target: AdapterKind) -> Result<()> {
+pub async fn test_embed_single(model: &str) -> Result<()> {
 	// -- Setup & Fixtures
-	let model_mapper = ModelMapper::from_mapper_fn(
-		move |model_iden: ModelIden| -> std::result::Result<ModelIden, genai::resolver::Error> {
-			let ModelIden { model_name, .. } = model_iden;
-
-			Ok(ModelIden {
-				adapter_kind: target,
-				model_name,
-			})
-		},
-	);
-
-	let client = Client::builder().with_model_mapper(model_mapper).build();
+	let client = Client::default();
 
 	let embed_req = seed_embed_req_single();
 
@@ -618,20 +607,9 @@ pub async fn test_embed_single(model: &str, target: AdapterKind) -> Result<()> {
 	Ok(())
 }
 
-pub async fn test_embed_multiple(model: &str, target: AdapterKind) -> Result<()> {
+pub async fn test_embed_multiple(model: &str) -> Result<()> {
 	// -- Setup & Fixtures
-	let model_mapper = ModelMapper::from_mapper_fn(
-		move |model_iden: ModelIden| -> std::result::Result<ModelIden, genai::resolver::Error> {
-			let ModelIden { model_name, .. } = model_iden;
-
-			Ok(ModelIden {
-				adapter_kind: target,
-				model_name,
-			})
-		},
-	);
-
-	let client = Client::builder().with_model_mapper(model_mapper).build();
+	let client = Client::default();
 
 	let embed_req = seed_embed_req_batch();
 	let document_count = embed_req.documents.len();

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -8,6 +8,7 @@ use genai::adapter::AdapterKind;
 use genai::chat::{
 	ChatMessage, ChatOptions, ChatRequest, ChatResponseFormat, ContentPart, ImageSource, JsonSpec, Tool, ToolResponse,
 };
+use genai::embed::EmbedOptions;
 use genai::resolver::{
 	AuthData, AuthResolver, AuthResolverFn, Endpoint, IntoAuthResolverFn, ModelMapper, ServiceTargetResolver,
 };
@@ -592,14 +593,14 @@ pub async fn common_test_list_models(adapter_kind: AdapterKind, contains: &str) 
 
 // region:    --- Embed
 
-pub async fn test_embed_single(model: &str) -> Result<()> {
+pub async fn test_embed_single(model: &str, options: Option<&EmbedOptions>) -> Result<()> {
 	// -- Setup & Fixtures
 	let client = Client::default();
 
 	let embed_req = seed_embed_req_single();
 
 	// -- Exec
-	let embed_res = client.exec_embed(model, embed_req, None).await?;
+	let embed_res = client.exec_embed(model, embed_req, options).await?;
 
 	// -- Check
 	assert!(!embed_res.embeddings().is_empty(), "Should have embeddings");
@@ -607,7 +608,7 @@ pub async fn test_embed_single(model: &str) -> Result<()> {
 	Ok(())
 }
 
-pub async fn test_embed_multiple(model: &str) -> Result<()> {
+pub async fn test_embed_multiple(model: &str, options: Option<&EmbedOptions>) -> Result<()> {
 	// -- Setup & Fixtures
 	let client = Client::default();
 
@@ -615,7 +616,7 @@ pub async fn test_embed_multiple(model: &str) -> Result<()> {
 	let document_count = embed_req.documents.len();
 
 	// -- Exec
-	let embed_res = client.exec_embed_batch(model, embed_req, None).await?;
+	let embed_res = client.exec_embed_batch(model, embed_req, options).await?;
 
 	// -- Check
 	assert!(!embed_res.embeddings().is_empty(), "Should have embeddings");

--- a/tests/support/seeders.rs
+++ b/tests/support/seeders.rs
@@ -1,4 +1,5 @@
 use genai::chat::{ChatMessage, ChatRequest, ContentPart, ImageSource, Tool};
+use genai::embed::{BatchEmbedRequest, SingleEmbedRequest};
 use serde_json::json;
 
 pub fn seed_chat_req_simple() -> ChatRequest {
@@ -6,6 +7,18 @@ pub fn seed_chat_req_simple() -> ChatRequest {
 		// -- Messages (deactivate to see the differences)
 		ChatMessage::system("Answer in one sentence"),
 		ChatMessage::user("Why is the sky blue?"),
+	])
+}
+
+pub fn seed_embed_req_single() -> SingleEmbedRequest {
+	SingleEmbedRequest::new("This should be a single embed request")
+}
+
+pub fn seed_embed_req_batch() -> BatchEmbedRequest {
+	BatchEmbedRequest::new(vec![
+		"This should be a batch embed request",
+		"There should be three documents in total",
+		"This is the third one",
 	])
 }
 

--- a/tests/tests_p_cohere.rs
+++ b/tests/tests_p_cohere.rs
@@ -2,11 +2,13 @@ mod support;
 
 use crate::support::common_tests;
 use genai::adapter::AdapterKind;
+use genai::embed::EmbedOptions;
 use genai::resolver::AuthData;
 
 type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
 
 const MODEL: &str = "command-light";
+const EMBEDDING_MODEL: &str = "embed-english-light-v3.0";
 
 // region:    --- Chat
 
@@ -68,3 +70,25 @@ async fn test_list_models() -> Result<()> {
 }
 
 // endregion: --- List
+
+// region:    --- Embed
+
+#[tokio::test]
+async fn test_embed_single() -> Result<()> {
+	common_tests::test_embed_single(
+		EMBEDDING_MODEL,
+		Some(&EmbedOptions::default().with_input_type("search_query".to_string())),
+	)
+	.await
+}
+
+#[tokio::test]
+async fn test_embed_multiple() -> Result<()> {
+	common_tests::test_embed_multiple(
+		EMBEDDING_MODEL,
+		Some(&EmbedOptions::default().with_input_type("search_document".to_string())),
+	)
+	.await
+}
+
+// endregion: --- Embed

--- a/tests/tests_p_gemini.rs
+++ b/tests/tests_p_gemini.rs
@@ -111,12 +111,12 @@ async fn test_list_models() -> Result<()> {
 
 #[tokio::test]
 async fn test_embed_single() -> Result<()> {
-	common_tests::test_embed_single(EMBEDDING_MODEL).await
+	common_tests::test_embed_single(EMBEDDING_MODEL, None).await
 }
 
 #[tokio::test]
 async fn test_embed_multiple() -> Result<()> {
-	common_tests::test_embed_multiple(EMBEDDING_MODEL).await
+	common_tests::test_embed_multiple(EMBEDDING_MODEL, None).await
 }
 
 // endregion: --- Embed

--- a/tests/tests_p_gemini.rs
+++ b/tests/tests_p_gemini.rs
@@ -9,6 +9,7 @@ type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tes
 // NOTE: For now (2025-02-02), use two models as Google models are severely rate limited for tier 1
 //       and increasing the project tier does not seem trivial.
 const MODEL: &str = "gemini-2.0-flash";
+const EMBEDDING_MODEL: &str = "text-embedding-004";
 
 #[allow(dead_code)]
 const MODEL_FOR_IMAGE: &str = "gemini-2.0-flash-exp";
@@ -105,3 +106,17 @@ async fn test_list_models() -> Result<()> {
 }
 
 // endregion: --- List
+
+// region:    --- Embed
+
+#[tokio::test]
+async fn test_embed_single() -> Result<()> {
+	common_tests::test_embed_single(EMBEDDING_MODEL, AdapterKind::Gemini).await
+}
+
+#[tokio::test]
+async fn test_embed_multiple() -> Result<()> {
+	common_tests::test_embed_multiple(EMBEDDING_MODEL, AdapterKind::Gemini).await
+}
+
+// endregion: --- Embed

--- a/tests/tests_p_gemini.rs
+++ b/tests/tests_p_gemini.rs
@@ -111,12 +111,12 @@ async fn test_list_models() -> Result<()> {
 
 #[tokio::test]
 async fn test_embed_single() -> Result<()> {
-	common_tests::test_embed_single(EMBEDDING_MODEL, AdapterKind::Gemini).await
+	common_tests::test_embed_single(EMBEDDING_MODEL).await
 }
 
 #[tokio::test]
 async fn test_embed_multiple() -> Result<()> {
-	common_tests::test_embed_multiple(EMBEDDING_MODEL, AdapterKind::Gemini).await
+	common_tests::test_embed_multiple(EMBEDDING_MODEL).await
 }
 
 // endregion: --- Embed

--- a/tests/tests_p_ollama.rs
+++ b/tests/tests_p_ollama.rs
@@ -7,6 +7,7 @@ use genai::resolver::AuthData;
 type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
 
 const MODEL: &str = "llama3.2:3b"; // phi3:latest
+const EMBEDDING_MODEL: &str = "nomic-embed-text";
 
 // region:    --- Chat
 
@@ -77,3 +78,17 @@ async fn test_list_models() -> Result<()> {
 }
 
 // endregion: --- List
+
+// region:    --- Embed
+
+#[tokio::test]
+async fn test_embed_single() -> Result<()> {
+	common_tests::test_embed_single(EMBEDDING_MODEL).await
+}
+
+#[tokio::test]
+async fn test_embed_multiple() -> Result<()> {
+	common_tests::test_embed_multiple(EMBEDDING_MODEL).await
+}
+
+// endregion: --- Embed

--- a/tests/tests_p_ollama.rs
+++ b/tests/tests_p_ollama.rs
@@ -83,12 +83,12 @@ async fn test_list_models() -> Result<()> {
 
 #[tokio::test]
 async fn test_embed_single() -> Result<()> {
-	common_tests::test_embed_single(EMBEDDING_MODEL).await
+	common_tests::test_embed_single(EMBEDDING_MODEL, None).await
 }
 
 #[tokio::test]
 async fn test_embed_multiple() -> Result<()> {
-	common_tests::test_embed_multiple(EMBEDDING_MODEL).await
+	common_tests::test_embed_multiple(EMBEDDING_MODEL, None).await
 }
 
 // endregion: --- Embed

--- a/tests/tests_p_openai.rs
+++ b/tests/tests_p_openai.rs
@@ -111,12 +111,12 @@ async fn test_list_models() -> Result<()> {
 
 #[tokio::test]
 async fn test_embed_single() -> Result<()> {
-	common_tests::test_embed_single(EMBEDDING_MODEL).await
+	common_tests::test_embed_single(EMBEDDING_MODEL, None).await
 }
 
 #[tokio::test]
 async fn test_embed_multiple() -> Result<()> {
-	common_tests::test_embed_multiple(EMBEDDING_MODEL).await
+	common_tests::test_embed_multiple(EMBEDDING_MODEL, None).await
 }
 
 // endregion: --- Embed

--- a/tests/tests_p_openai.rs
+++ b/tests/tests_p_openai.rs
@@ -7,6 +7,7 @@ use genai::resolver::AuthData;
 type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
 
 const MODEL: &str = "gpt-4o-mini";
+const EMBEDDING_MODEL: &str = "text-embedding-ada-002";
 
 // region:    --- Chat
 
@@ -105,3 +106,17 @@ async fn test_list_models() -> Result<()> {
 }
 
 // endregion: --- List
+
+// region:    --- Embed
+
+#[tokio::test]
+async fn test_embed_single() -> Result<()> {
+	common_tests::test_embed_single(EMBEDDING_MODEL, AdapterKind::OpenAI).await
+}
+
+#[tokio::test]
+async fn test_embed_multiple() -> Result<()> {
+	common_tests::test_embed_multiple(EMBEDDING_MODEL, AdapterKind::OpenAI).await
+}
+
+// endregion: --- Embed

--- a/tests/tests_p_openai.rs
+++ b/tests/tests_p_openai.rs
@@ -111,12 +111,12 @@ async fn test_list_models() -> Result<()> {
 
 #[tokio::test]
 async fn test_embed_single() -> Result<()> {
-	common_tests::test_embed_single(EMBEDDING_MODEL, AdapterKind::OpenAI).await
+	common_tests::test_embed_single(EMBEDDING_MODEL).await
 }
 
 #[tokio::test]
 async fn test_embed_multiple() -> Result<()> {
-	common_tests::test_embed_multiple(EMBEDDING_MODEL, AdapterKind::OpenAI).await
+	common_tests::test_embed_multiple(EMBEDDING_MODEL).await
 }
 
 // endregion: --- Embed


### PR DESCRIPTION
mostly boilerplate and basic embedding code for both openai and gemini providers. there are some things to fix, but this is currently working and the new tests (test_embed_single and test_embed_multiple) are passing for both gemini and openai providers, although the ModelIden function might have to be changed for embedding models, since it works based on prefix and embedding models aren't really standardized in terms of naming like completion models are.