### PR TITLE
Async auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ value-ext = "0.1.2"
 serial_test = "3.2.0"
 base64 = "0.22.0"  # Check for the latest version
 bitflags = "2.8.0"
+gcp_auth = "0.12.3"

--- a/examples/c08-contrived-async-auth.rs
+++ b/examples/c08-contrived-async-auth.rs
@@ -1,4 +1,4 @@
-//! This example demonstrates how to use a custom authentication function to override the default AuthData resolution
+//! This example demonstrates how to use a custom async authentication function to override the default AuthData resolution
 //! for any specific adapter (which is based on environment variables).
 
 use genai::chat::printer::print_chat_stream;
@@ -17,17 +17,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	];
 
 	// -- Build an auth_resolver and the AdapterConfig
+	// Auth function is captured with `from_resolver_async_fn` instead of the prior `from_resolver_fn`
 	let auth_resolver = AuthResolver::from_resolver_async_fn(
-		async |model_iden: ModelIden| -> Result<Option<AuthData>, genai::resolver::Error> {
+		async |_model_iden: ModelIden| -> Result<Option<AuthData>, genai::resolver::Error> {
 			println!("Fetching auth!");
-			let ModelIden {
-				adapter_kind,
-				model_name,
-			} = model_iden;
-
+			// this could be a network call
 			tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
-			println!("\n>> Custom auth provider for {adapter_kind} (model: {model_name}) <<");
 			// This will cause it to fail if any model is not an OPEN_API_KEY
 			let key = std::env::var("OPENAI_API_KEY").map_err(|_| genai::resolver::Error::ApiKeyEnvNotFound {
 				env_name: "OPENAI_API_KEY".to_string(),

--- a/examples/c08-contrived-async-auth.rs
+++ b/examples/c08-contrived-async-auth.rs
@@ -1,0 +1,58 @@
+//! This example demonstrates how to use a custom authentication function to override the default AuthData resolution
+//! for any specific adapter (which is based on environment variables).
+
+use genai::chat::printer::print_chat_stream;
+use genai::chat::{ChatMessage, ChatRequest};
+use genai::resolver::{AuthData, AuthResolver};
+use genai::{Client, ModelIden};
+
+const MODEL: &str = "gpt-4o-mini";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let questions = &[
+		// Follow-up questions
+		"Why is the sky blue?",
+		"Why is it red sometimes?",
+	];
+
+	// -- Build an auth_resolver and the AdapterConfig
+	let auth_resolver = AuthResolver::from_resolver_async_fn(
+		async |model_iden: ModelIden| -> Result<Option<AuthData>, genai::resolver::Error> {
+			println!("Fetching auth!");
+			let ModelIden {
+				adapter_kind,
+				model_name,
+			} = model_iden;
+
+			tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+			println!("\n>> Custom auth provider for {adapter_kind} (model: {model_name}) <<");
+			// This will cause it to fail if any model is not an OPEN_API_KEY
+			let key = std::env::var("OPENAI_API_KEY").map_err(|_| genai::resolver::Error::ApiKeyEnvNotFound {
+				env_name: "OPENAI_API_KEY".to_string(),
+			})?;
+			println!("Auth fetched!");
+			Ok(Some(AuthData::from_single(key)))
+		},
+	);
+
+	// -- Build the new client with this adapter_config
+	let client = Client::builder().with_auth_resolver(auth_resolver).build();
+
+	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
+
+	for &question in questions {
+		chat_req = chat_req.append_message(ChatMessage::user(question));
+
+		println!("\n--- Question:\n{question}");
+		let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), None).await?;
+
+		println!("\n--- Answer: (streaming)");
+		let assistant_answer = print_chat_stream(chat_res, None).await?;
+
+		chat_req = chat_req.append_message(ChatMessage::assistant(assistant_answer));
+	}
+
+	Ok(())
+}

--- a/examples/c09-google-gcp.rs
+++ b/examples/c09-google-gcp.rs
@@ -1,0 +1,48 @@
+use gcp_auth::{CustomServiceAccount, TokenProvider};
+use genai::adapter::AdapterKind;
+use genai::chat::printer::print_chat_stream;
+use genai::chat::{ChatMessage, ChatRequest};
+use genai::resolver::Error;
+use genai::resolver::{AuthData, AuthResolver};
+use genai::Client;
+use genai::ModelIden;
+
+const MODEL: &str = "gemini-2.0-flash";
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+	let resolve_fn = async |model: ModelIden| {
+		if model.adapter_kind != AdapterKind::Gemini {
+			return Ok(None);
+		}
+		let gcp_json = std::env::var("GCP_SERVICE_ACCOUNT").map_err(|_err| Error::ApiKeyEnvNotFound {
+			env_name: "GCP_SERVICE_ACCOUNT".to_string(),
+		})?;
+		let account = CustomServiceAccount::from_json(&gcp_json).map_err(|e| Error::External(Box::new(e)))?;
+		let scopes: &[&str] = &["https://www.googleapis.com/auth/cloud-platform"];
+		let token = account.token(scopes).await.map_err(|e| Error::External(Box::new(e)))?;
+		let location = std::env::var("GCP_LOCATION").unwrap_or("us-central1".to_string());
+		let project_id = account.project_id().ok_or_else(|| {
+			genai::resolver::Error::External(Box::new(gcp_auth::Error::Str(
+				"GCP Auth: Service account has no project_id",
+			)))
+		})?;
+		let url = format!(
+      	"https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}/publishers/google/models/{}:generateContent",
+      	location, project_id, location, model.model_name
+      );
+		let auth_header = vec![("Authorization".to_string(), format!("Bearer {}", token.as_str()))];
+		Ok(Some(AuthData::RequestOverride {
+			headers: auth_header,
+			url,
+		}))
+	};
+	let auth_resolver = AuthResolver::from_resolver_async_fn(resolve_fn);
+	let chat_request = ChatRequest::default().with_system("Answer in one sentence");
+	let chat_request = chat_request.append_message(ChatMessage::user("Why is the sky blue?"));
+	let client = Client::builder().with_auth_resolver(auth_resolver).build();
+	let stream = client.exec_chat_stream(MODEL, chat_request, None).await.unwrap();
+
+	print_chat_stream(stream, None).await.unwrap();
+	Ok(())
+}

--- a/examples/c09-google-gcp.rs
+++ b/examples/c09-google-gcp.rs
@@ -1,3 +1,6 @@
+//! Exaple showing how to authorize with google gcp
+//! This example uses the AuthData::Override feature which enables request url and headers to be overriden
+
 use gcp_auth::{CustomServiceAccount, TokenProvider};
 use genai::adapter::AdapterKind;
 use genai::chat::printer::print_chat_stream;
@@ -11,15 +14,20 @@ const MODEL: &str = "gemini-2.0-flash";
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+	// everything happens in the resolver fn
 	let resolve_fn = async |model: ModelIden| {
+		// if we're not requesting gemini use default auth
 		if model.adapter_kind != AdapterKind::Gemini {
 			return Ok(None);
 		}
+		// load auth credentials
 		let gcp_json = std::env::var("GCP_SERVICE_ACCOUNT").map_err(|_err| Error::ApiKeyEnvNotFound {
 			env_name: "GCP_SERVICE_ACCOUNT".to_string(),
 		})?;
+		// initialize gcp account
 		let account = CustomServiceAccount::from_json(&gcp_json).map_err(|e| Error::External(Box::new(e)))?;
 		let scopes: &[&str] = &["https://www.googleapis.com/auth/cloud-platform"];
+		// A fresh bearer token must be requested before each request
 		let token = account.token(scopes).await.map_err(|e| Error::External(Box::new(e)))?;
 		let location = std::env::var("GCP_LOCATION").unwrap_or("us-central1".to_string());
 		let project_id = account.project_id().ok_or_else(|| {
@@ -27,16 +35,21 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 				"GCP Auth: Service account has no project_id",
 			)))
 		})?;
+		// for url
 		let url = format!(
       	"https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}/publishers/google/models/{}:generateContent",
       	location, project_id, location, model.model_name
       );
+		// put bearer in headers
 		let auth_header = vec![("Authorization".to_string(), format!("Bearer {}", token.as_str()))];
+		// cowabunga
 		Ok(Some(AuthData::RequestOverride {
 			headers: auth_header,
 			url,
 		}))
 	};
+
+	// set async_auth function
 	let auth_resolver = AuthResolver::from_resolver_async_fn(resolve_fn);
 	let chat_request = ChatRequest::default().with_system("Answer in one sentence");
 	let chat_request = chat_request.append_message(ChatMessage::user("Why is the sky blue?"));

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -41,6 +41,11 @@ impl Client {
 		self.config().resolve_service_target(model)
 	}
 
+	pub async fn resolve_service_target_async(&self, model_name: &str) -> Result<ServiceTarget> {
+		let model = self.default_model(model_name)?;
+		self.config().resolve_service_target_async(model).await
+	}
+
 	/// Executes a chat.
 	pub async fn exec_chat(
 		&self,
@@ -54,7 +59,7 @@ impl Client {
 			.with_client_options(self.config().chat_options());
 
 		let model = self.default_model(model)?;
-		let target = self.config().resolve_service_target(model)?;
+		let target = self.config().resolve_service_target_async(model).await?;
 		let model = target.model.clone();
 
 		let WebRequestData { headers, payload, url } =
@@ -86,7 +91,7 @@ impl Client {
 			.with_client_options(self.config().chat_options());
 
 		let model = self.default_model(model)?;
-		let target = self.config().resolve_service_target(model)?;
+		let target = self.config().resolve_service_target_async(model).await?;
 		let model = target.model.clone();
 
 		let WebRequestData { url, headers, payload } =

--- a/src/resolver/auth_data.rs
+++ b/src/resolver/auth_data.rs
@@ -9,6 +9,11 @@ pub enum AuthData {
 	/// The key value itself.
 	Key(String),
 
+	RequestOverride {
+		url: String,
+		headers: Vec<(String, String)>,
+	},
+
 	/// The key names/values when a credential has multiple pieces of credential information.
 	/// This will be adapter-specific.
 	/// NOTE: Not used yet.
@@ -47,6 +52,8 @@ impl AuthData {
 			}
 			AuthData::Key(value) => Ok(value.to_string()),
 			AuthData::MultiKeys(_) => Err(Error::ResolverAuthDataNotSingleValue),
+			// use an empty key for request override
+			AuthData::RequestOverride { .. } => Ok(String::new()),
 		}
 	}
 }
@@ -61,6 +68,7 @@ impl std::fmt::Debug for AuthData {
 			AuthData::FromEnv(_env_name) => write!(f, "AuthData::FromEnv(REDACTED)"),
 			AuthData::Key(_) => write!(f, "AuthData::Single(REDACTED)"),
 			AuthData::MultiKeys(_) => write!(f, "AuthData::Multi(REDACTED)"),
+			AuthData::RequestOverride { .. } => write!(f, "AuthData::RequestOverride(REDACTED)"),
 		}
 	}
 }

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
 	/// The `AuthData` is not a single value.
 	ResolverAuthDataNotSingleValue,
 
+	/// Async auth resolvers can only be used from methods returning futures
+	UnsupportedUsageOfAsyncResolver(String),
+
 	/// Custom error message.
 	#[from]
 	Custom(String),

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
 	/// Async auth resolvers can only be used from methods returning futures
 	UnsupportedUsageOfAsyncResolver(String),
 
+	/// Call to an external api failed
+	External(Box<dyn std::error::Error>),
+
 	/// Custom error message.
 	#[from]
 	Custom(String),


### PR DESCRIPTION
- Add support for async auth closures
- Add support for auth override url + headers
- Add examples

I'm using gemini through vertex and need to request a token before each request. These features are targeted at addressing this use-case (see `c09-google-gcp` for a concrete example of my use-case.

--- 
## Async auth
To avoid breaking changes to the API I've added async methods where appropriate. These methods could replace the existing methods as it's easy to wrap `FnOnce` in a future. 

I've marked several functions deprecated, as the config can be initialized with an async closure which cannot be used with the non-async functions. 

## AuthData::RequestOverride
This is pretty janky and was created to address more weirdness surrounding google auth. I think this functionality may better be split between the `service_target_resolver` and the `auth_resolver`, but I thought I'd ask before making larger changes.

--- 
These changes are based on the stable release.