### PR TITLE
Async auth api (#2)

### DIFF
--- a/examples/c08-contrived-async-auth.rs
+++ b/examples/c08-contrived-async-auth.rs
@@ -1,0 +1,53 @@
+//! This example demonstrates how to use a custom async authentication function to override the default AuthData resolution
+//! for any specific adapter (which is based on environment variables).
+
+use genai::chat::printer::print_chat_stream;
+use genai::chat::{ChatMessage, ChatRequest};
+use genai::resolver::{AuthData, AuthResolver};
+use genai::{Client, ModelIden};
+
+const MODEL: &str = "gpt-4o-mini";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let questions = &[
+		// Follow-up questions
+		"Why is the sky blue?",
+		"Why is it red sometimes?",
+	];
+
+	// -- Build an auth_resolver and the AdapterConfig
+	// Auth function is captured with `from_resolver_async_fn` instead of the prior `from_resolver_fn`
+	let auth_resolver = AuthResolver::from_resolver_async_fn(
+		async |_model_iden: ModelIden| -> Result<Option<AuthData>, genai::resolver::Error> {
+			println!("Fetching auth!");
+			// this could be a network call
+			tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+			// This will cause it to fail if any model is not an OPEN_API_KEY
+			let key = std::env::var("OPENAI_API_KEY").map_err(|_| genai::resolver::Error::ApiKeyEnvNotFound {
+				env_name: "OPENAI_API_KEY".to_string(),
+			})?;
+			println!("Auth fetched!");
+			Ok(Some(AuthData::from_single(key)))
+		},
+	);
+
+	// -- Build the new client with this adapter_config
+	let client = Client::builder().with_auth_resolver(auth_resolver).build();
+
+	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
+
+	for &question in questions {
+		chat_req = chat_req.append_message(ChatMessage::user(question));
+
+		println!("\n--- Question:\n{question}");
+		let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), None).await?;
+
+		println!("\n--- Answer: (streaming)");
+		let assistant_answer = print_chat_stream(chat_res, None).await?;
+
+		chat_req = chat_req.append_message(ChatMessage::assistant(assistant_answer));
+	}
+
+	Ok(())
+}

--- a/examples/c09-google-gcp.rs
+++ b/examples/c09-google-gcp.rs
@@ -1,62 +1,59 @@
+//! Exaple showing how to authorize with google gcp
+//! This example uses the AuthData::Override feature which enables request url and headers to be overriden
+
 use gcp_auth::{CustomServiceAccount, TokenProvider};
 use genai::Client;
 use genai::ModelIden;
+use genai::adapter::AdapterKind;
 use genai::chat::printer::print_chat_stream;
 use genai::chat::{ChatMessage, ChatRequest};
+use genai::resolver::Error;
 use genai::resolver::{AuthData, AuthResolver};
-use std::pin::Pin;
-use std::sync::Arc;
 
 const MODEL: &str = "gemini-2.0-flash";
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
-	// Just an example of a data that will get captured (needs to be locable)
-	let gcp_env_name: Arc<str> = "GCP_SERVICE_ACCOUNT".into();
-
-	// -- Create the Async Auth resolve_fn closure
-	let resolve_fn = move |model: ModelIden| -> Pin<
-		Box<dyn Future<Output = Result<Option<AuthData>, genai::resolver::Error>> + Send + 'static>,
-	> {
-		let gcp_env_name = gcp_env_name.clone();
-		Box::pin(async move {
-			let gcp_json = std::env::var(&*gcp_env_name).map_err(|_err| genai::resolver::Error::ApiKeyEnvNotFound {
-				env_name: gcp_env_name.to_string(),
-			})?;
-			let account = CustomServiceAccount::from_json(&gcp_json)
-				.map_err(|e| genai::resolver::Error::Custom(e.to_string()))?;
-			let scopes: &[&str] = &["https://www.googleapis.com/auth/cloud-platform"];
-			let token = account
-				.token(scopes)
-				.await
-				.map_err(|e| genai::resolver::Error::Custom(e.to_string()))?;
-			let location = std::env::var("GCP_LOCATION").unwrap_or("us-central1".to_string());
-			let project_id = account.project_id().ok_or_else(|| {
-				genai::resolver::Error::Custom("GCP Auth: Service account has no project_id".to_string())
-			})?;
-			let url = format!(
-				"https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}/publishers/google/models/{}:generateContent",
-				location, project_id, location, model.model_name
-			);
-			let auth_header = vec![("Authorization".to_string(), format!("Bearer {}", token.as_str()))];
-			Ok(Some(AuthData::RequestOverride {
-				headers: auth_header,
-				url,
-			}))
-		})
+	// everything happens in the resolver fn
+	let resolve_fn = async |model: ModelIden| {
+		// if we're not requesting gemini use default auth
+		if model.adapter_kind != AdapterKind::Gemini {
+			return Ok(None);
+		}
+		// load auth credentials
+		let gcp_json = std::env::var("GCP_SERVICE_ACCOUNT").map_err(|_err| Error::ApiKeyEnvNotFound {
+			env_name: "GCP_SERVICE_ACCOUNT".to_string(),
+		})?;
+		// initialize gcp account
+		let account = CustomServiceAccount::from_json(&gcp_json).map_err(|e| Error::External(Box::new(e)))?;
+		let scopes: &[&str] = &["https://www.googleapis.com/auth/cloud-platform"];
+		// A fresh bearer token must be requested before each request
+		let token = account.token(scopes).await.map_err(|e| Error::External(Box::new(e)))?;
+		let location = std::env::var("GCP_LOCATION").unwrap_or("us-central1".to_string());
+		let project_id = account.project_id().ok_or_else(|| {
+			genai::resolver::Error::External(Box::new(gcp_auth::Error::Str(
+				"GCP Auth: Service account has no project_id",
+			)))
+		})?;
+		// for url
+		let url = format!(
+			"https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}/publishers/google/models/{}:generateContent",
+			location, project_id, location, model.model_name
+		);
+		// put bearer in headers
+		let auth_header = vec![("Authorization".to_string(), format!("Bearer {}", token.as_str()))];
+		// cowabunga
+		Ok(Some(AuthData::RequestOverride {
+			headers: auth_header,
+			url,
+		}))
 	};
 
-	// -- Create the AuthResolver
+	// set async_auth function
 	let auth_resolver = AuthResolver::from_resolver_async_fn(resolve_fn);
-
-	// -- Create Chat Client
-	let client = Client::builder().with_auth_resolver(auth_resolver).build();
-
-	// -- Create Chat Request
 	let chat_request = ChatRequest::default().with_system("Answer in one sentence");
 	let chat_request = chat_request.append_message(ChatMessage::user("Why is the sky blue?"));
-
-	// -- Executed
+	let client = Client::builder().with_auth_resolver(auth_resolver).build();
 	let stream = client.exec_chat_stream(MODEL, chat_request, None).await.unwrap();
 
 	print_chat_stream(stream, None).await.unwrap();

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,7 +1,7 @@
 use crate::chat::ChatOptions;
 use crate::resolver::{
-	AuthResolver, IntoAuthResolverFn, IntoModelMapperFn, IntoServiceTargetResolverFn, ModelMapper,
-	ServiceTargetResolver,
+	AuthResolver, IntoAuthResolverAsyncFn, IntoAuthResolverFn, IntoModelMapperFn, IntoServiceTargetResolverAsyncFn,
+	IntoServiceTargetResolverFn, ModelMapper, ServiceTargetResolver,
 };
 use crate::webc::WebClient;
 use crate::{Client, ClientConfig};
@@ -59,6 +59,13 @@ impl ClientBuilder {
 		self
 	}
 
+	pub fn with_auth_resolver_asyn_fn(mut self, auth_resolver_fn: impl IntoAuthResolverAsyncFn) -> Self {
+		let client_config = self.config.get_or_insert_with(ClientConfig::default);
+		let auth_resolver = AuthResolver::from_resolver_async_fn(auth_resolver_fn);
+		client_config.auth_resolver = Some(auth_resolver);
+		self
+	}
+
 	pub fn with_service_target_resolver(mut self, target_resolver: ServiceTargetResolver) -> Self {
 		let client_config = self.config.get_or_insert_with(ClientConfig::default);
 		client_config.service_target_resolver = Some(target_resolver);
@@ -68,6 +75,16 @@ impl ClientBuilder {
 	pub fn with_service_target_resolver_fn(mut self, target_resolver_fn: impl IntoServiceTargetResolverFn) -> Self {
 		let client_config = self.config.get_or_insert_with(ClientConfig::default);
 		let target_resolver = ServiceTargetResolver::from_resolver_fn(target_resolver_fn);
+		client_config.service_target_resolver = Some(target_resolver);
+		self
+	}
+
+	pub fn with_service_target_resolver_async_fn(
+		mut self,
+		target_resolver_fn: impl IntoServiceTargetResolverAsyncFn,
+	) -> Self {
+		let client_config = self.config.get_or_insert_with(ClientConfig::default);
+		let target_resolver = ServiceTargetResolver::from_resolver_async_fn(target_resolver_fn);
 		client_config.service_target_resolver = Some(target_resolver);
 		self
 	}

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -69,7 +69,7 @@ impl ClientConfig {
 	}
 }
 
-/// Resolvers
+/// Resolve
 impl ClientConfig {
 	pub async fn resolve_service_target(&self, model: ModelIden) -> Result<ServiceTarget> {
 		// -- Resolve the Model first

--- a/src/resolver/auth_data.rs
+++ b/src/resolver/auth_data.rs
@@ -54,7 +54,7 @@ impl AuthData {
 				Ok(value)
 			}
 			AuthData::Key(value) => Ok(value.to_string()),
-			_ => Err(Error::ResolverAuthDataNotSingleValue),
+			AuthData::MultiKeys(_) => Err(Error::ResolverAuthDataNotSingleValue),
 		}
 	}
 }
@@ -69,9 +69,7 @@ impl std::fmt::Debug for AuthData {
 			AuthData::FromEnv(_env_name) => write!(f, "AuthData::FromEnv(REDACTED)"),
 			AuthData::Key(_) => write!(f, "AuthData::Single(REDACTED)"),
 			AuthData::MultiKeys(_) => write!(f, "AuthData::Multi(REDACTED)"),
-			AuthData::RequestOverride { .. } => {
-				write!(f, "AuthData::RequestOverride {{ url: REDACTED, headers: REDACTED }}")
-			}
+			AuthData::RequestOverride { .. } => write!(f, "AuthData::RequestOverride(REDACTED)"),
 		}
 	}
 }

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
 	/// The `AuthData` is not a single value.
 	ResolverAuthDataNotSingleValue,
 
+	/// Call to an external api failed
+	External(Box<dyn std::error::Error>),
+
 	/// Custom error message.
 	#[from]
 	Custom(String),


### PR DESCRIPTION
- Fix async closure api to allow `async || {...}` instead of `move | |  Box::pin(async {...})`

This should fix the api so any async closure can be moved. The changes here **are breaking** (they change some `Client` and `ClientConfig` to async methods), but from your merge of my previous PR it looks like this is ok. 


