### PR TITLE
Feat: Add budget variant to ReasoningEffort

### DIFF
--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -3,7 +3,7 @@ use crate::adapter::gemini::GeminiStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	ChatOptionsSet, ChatRequest, ChatResponse, ChatResponseFormat, ChatRole, ChatStream, ChatStreamResponse,
-	CompletionTokensDetails, ContentPart, ImageSource, MessageContent, ToolCall, Usage,
+	CompletionTokensDetails, ContentPart, ImageSource, MessageContent, ReasoningEffort, ToolCall, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebResponse, WebStream};
@@ -95,6 +95,11 @@ impl Adapter for GeminiAdapter {
 					"parts": [ { "text": system }]
 				}),
 			)?;
+		}
+
+		// -- Reasoning Budget
+		if let Some(ReasoningEffort::Budget(budget)) = options_set.reasoning_effort() {
+			payload.x_insert("/generationConfig/thinkingConfig/thinkingBudget", budget)?;
 		}
 
 		// -- Tools

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -193,7 +193,9 @@ impl OpenAIAdapter {
 
 		// -- Set reasoning effort
 		if let Some(reasoning_effort) = reasoning_effort {
-			payload.x_insert("reasoning_effort", reasoning_effort.to_lower_str())?;
+			if let Some(keyword) = reasoning_effort.as_keyword() {
+				payload.x_insert("reasoning_effort", keyword)?;
+			}
 		}
 
 		// -- Tools

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -140,18 +140,20 @@ pub enum ReasoningEffort {
 	Low,
 	Medium,
 	High,
+	Budget(u32),
 }
 
 impl ReasoningEffort {
-	pub fn to_lower_str(&self) -> &'static str {
+	pub fn as_keyword(&self) -> Option<&'static str> {
 		match self {
-			ReasoningEffort::Low => "low",
-			ReasoningEffort::Medium => "medium",
-			ReasoningEffort::High => "high",
+			ReasoningEffort::Low => Some("low"),
+			ReasoningEffort::Medium => Some("medium"),
+			ReasoningEffort::High => Some("high"),
+			ReasoningEffort::Budget(_) => None,
 		}
 	}
 
-	pub fn from_lower_str(name: &str) -> Option<Self> {
+	pub fn from_keyword(name: &str) -> Option<Self> {
 		match name {
 			"low" => Some(ReasoningEffort::Low),
 			"medium" => Some(ReasoningEffort::Medium),
@@ -165,7 +167,7 @@ impl ReasoningEffort {
 	/// Returns (reasoning_effort, model_name)
 	pub fn from_model_name(model_name: &str) -> (Option<Self>, &str) {
 		if let Some((prefix, last)) = model_name.rsplit_once('-') {
-			if let Some(effort) = ReasoningEffort::from_lower_str(last) {
+			if let Some(effort) = ReasoningEffort::from_keyword(last) {
 				return (Some(effort), prefix);
 			}
 		}


### PR DESCRIPTION
The `ReasoningEffort` enum now includes a `Budget(u32)` variant to support Gemini reasoning budget.