### PR TITLE
feat: support built-in provider tools such as Google Search for Gemini

### DIFF
--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -150,12 +150,7 @@ impl Adapter for GeminiAdapter {
 
 		// -- Tools
 		if let Some(tools) = tools {
-			payload.x_insert(
-				"tools",
-				json!({
-					"function_declarations": tools
-				}),
-			)?;
+			payload.x_insert("tools", tools)?;
 		}
 
 		// -- Response Format
@@ -545,14 +540,30 @@ impl GeminiAdapter {
 			tools
 				.into_iter()
 				.map(|tool| {
-					// TODO: Need to handle the error correctly
-					// TODO: Needs to have a custom serializer (tool should not have to match to a provider)
-					// NOTE: Right now, low probability, so, we just return null if cannot convert to value.
-					json!({
-						"name": tool.name,
-						"description": tool.description,
-						"parameters": tool.schema,
-					})
+					if matches!(
+						tool.name.as_str(),
+						"googleSearch" | "googleSearchRetrieval" | "codeExecution" | "urlContext"
+					) {
+						json!(
+							{
+								tool.name: tool.config
+							}
+						)
+					} else {
+						// TODO: Need to handle the error correctly
+						// TODO: Needs to have a custom serializer (tool should not have to match to a provider)
+						// NOTE: Right now, low probability, so, we just return null if cannot convert to value.
+						json!({
+							"functionDeclarations": [
+								{
+									"name": tool.name,
+									"description": tool.description,
+									"parameters": tool.schema,
+								}
+							]
+
+						})
+					}
 				})
 				.collect::<Vec<Value>>()
 		});

--- a/src/chat/tool/tool_base.rs
+++ b/src/chat/tool/tool_base.rs
@@ -34,6 +34,11 @@ pub struct Tool {
 	/// })
 	/// ```
 	pub schema: Option<Value>,
+
+	/// Optional configuration for the tool.
+	///
+	/// This could be usefull when you are using embeded tools like googleSearch of gimini
+	pub config: Option<Value>,
 }
 
 /// Constructor
@@ -43,6 +48,7 @@ impl Tool {
 			name: name.into(),
 			description: None,
 			schema: None,
+			config: None,
 		}
 	}
 }
@@ -57,6 +63,11 @@ impl Tool {
 
 	pub fn with_schema(mut self, parameters: Value) -> Self {
 		self.schema = Some(parameters);
+		self
+	}
+
+	pub fn with_config(mut self, config: Value) -> Self {
+		self.config = Some(config);
 		self
 	}
 }


### PR DESCRIPTION
This pr would allow us to use "embeded" tools like google search, witch will be called on server side instead of client side.
# Example

```rust
        llm
            .exec_chat(
                &config.query_generator_model,
                ChatRequest::new(vec![ChatMessage::user(
                    WebSearch {
                        research_topic: &query.query,
                        current_date: &chrono::Utc::now().to_rfc3339(),
                    }
                    .format_prompt(),
                )])
                .with_tools(vec![
                    Tool::new("googleSearch").with_config(serde_json::json!({})),
                ]),
                Some(&ChatOptions::default().with_temperature(0.0)),
            )
            .await?;
```