### PR TITLE
feat: remain original response body

### DIFF
--- a/src/adapter/adapter_types.rs
+++ b/src/adapter/adapter_types.rs
@@ -32,6 +32,7 @@ pub trait Adapter {
 
 	/// To be implemented by Adapters.
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		options_set: ChatOptionsSet<'_, '_>,

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -154,12 +154,13 @@ impl Adapter for AnthropicAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		_chat_options: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
 		let WebResponse { mut body, .. } = web_response;
-
+		let capture_raw_body = client.config().capture_raw_body().then(|| body.clone());
 		// -- Capture the provider_model_iden
 		// TODO: Need to be implemented (if available), for now, just clone model_iden
 		let provider_model_name: Option<String> = body.x_remove("model").ok();
@@ -213,6 +214,7 @@ impl Adapter for AnthropicAdapter {
 			model_iden,
 			provider_model_iden,
 			usage,
+			capture_raw_body,
 		})
 	}
 

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -113,12 +113,13 @@ impl Adapter for CohereAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		_chat_options: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
 		let WebResponse { mut body, .. } = web_response;
-
+		let capture_raw_body = client.config().capture_raw_body().then(|| body.clone());
 		// -- Capture the provider_model_iden
 		// TODO: Need to be implemented (if available), for now, just clone model_iden
 		// let provider_model_name: Option<String> = body.x_remove("model").ok();
@@ -144,6 +145,7 @@ impl Adapter for CohereAdapter {
 			model_iden,
 			provider_model_iden,
 			usage,
+			capture_raw_body,
 		})
 	}
 

--- a/src/adapter/adapters/deepseek/adapter_impl.rs
+++ b/src/adapter/adapters/deepseek/adapter_impl.rs
@@ -44,11 +44,12 @@ impl Adapter for DeepSeekAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
-		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+		OpenAIAdapter::to_chat_response(client, model_iden, web_response, options_set)
 	}
 
 	fn to_chat_stream(

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -194,6 +194,7 @@ impl Adapter for GeminiAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		_options_set: ChatOptionsSet<'_, '_>,
@@ -203,7 +204,7 @@ impl Adapter for GeminiAdapter {
 		// TODO: Need to be implemented (if available), for now, just clone model_iden
 		let provider_model_name: Option<String> = body.x_remove("modelVersion").ok();
 		let provider_model_iden = model_iden.from_optional_name(provider_model_name);
-
+		let capture_raw_body = client.config().capture_raw_body().then(|| body.clone());
 		let gemini_response = Self::body_to_gemini_chat_response(&model_iden.clone(), body)?;
 		let GeminiChatResponse {
 			content: gemini_content,
@@ -230,6 +231,7 @@ impl Adapter for GeminiAdapter {
 			model_iden,
 			provider_model_iden,
 			usage,
+			capture_raw_body,
 		})
 	}
 

--- a/src/adapter/adapters/groq/adapter_impl.rs
+++ b/src/adapter/adapters/groq/adapter_impl.rs
@@ -65,11 +65,12 @@ impl Adapter for GroqAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
-		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+		OpenAIAdapter::to_chat_response(client, model_iden, web_response, options_set)
 	}
 
 	fn to_chat_stream(

--- a/src/adapter/adapters/nebius/adapter_impl.rs
+++ b/src/adapter/adapters/nebius/adapter_impl.rs
@@ -76,11 +76,12 @@ impl Adapter for NebiusAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
-		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+		OpenAIAdapter::to_chat_response(client, model_iden, web_response, options_set)
 	}
 
 	fn to_chat_stream(

--- a/src/adapter/adapters/ollama/adapter_impl.rs
+++ b/src/adapter/adapters/ollama/adapter_impl.rs
@@ -73,11 +73,12 @@ impl Adapter for OllamaAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
-		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+		OpenAIAdapter::to_chat_response(client, model_iden, web_response, options_set)
 	}
 
 	fn to_chat_stream(

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -63,11 +63,13 @@ impl Adapter for OpenAIAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
 		let WebResponse { mut body, .. } = web_response;
+		let capture_raw_body = client.config().capture_raw_body().then(|| body.clone());
 
 		// -- Capture the provider_model_iden
 		let provider_model_name: Option<String> = body.x_remove("model").ok();
@@ -120,6 +122,7 @@ impl Adapter for OpenAIAdapter {
 			model_iden,
 			provider_model_iden,
 			usage,
+			capture_raw_body,
 		})
 	}
 

--- a/src/adapter/adapters/xai/adapter_impl.rs
+++ b/src/adapter/adapters/xai/adapter_impl.rs
@@ -45,11 +45,12 @@ impl Adapter for XaiAdapter {
 	}
 
 	fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		chat_options: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
-		OpenAIAdapter::to_chat_response(model_iden, web_response, chat_options)
+		OpenAIAdapter::to_chat_response(client, model_iden, web_response, chat_options)
 	}
 
 	fn to_chat_stream(

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -103,20 +103,21 @@ impl AdapterDispatcher {
 	}
 
 	pub fn to_chat_response(
+		client: &crate::Client,
 		model_iden: ModelIden,
 		web_response: WebResponse,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatResponse> {
 		match model_iden.adapter_kind {
-			AdapterKind::OpenAI => OpenAIAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::Anthropic => AnthropicAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::Cohere => CohereAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::Ollama => OllamaAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::Gemini => GeminiAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::Groq => GroqAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::Nebius => NebiusAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::Xai => XaiAdapter::to_chat_response(model_iden, web_response, options_set),
-			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_response(model_iden, web_response, options_set),
+			AdapterKind::OpenAI => OpenAIAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::Anthropic => AnthropicAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::Cohere => CohereAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::Ollama => OllamaAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::Gemini => GeminiAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::Groq => GroqAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::Nebius => NebiusAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::Xai => XaiAdapter::to_chat_response(client, model_iden, web_response, options_set),
+			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_response(client, model_iden, web_response, options_set),
 		}
 	}
 

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -293,7 +293,7 @@ impl ChatOptionsSet<'_, '_> {
 			.and_then(|chat| chat.capture_reasoning_content)
 			.or_else(|| self.client.and_then(|client| client.capture_reasoning_content))
 	}
-	
+
 	pub fn capture_tool_calls(&self) -> Option<bool> {
 		self.chat
 			.and_then(|chat| chat.capture_tool_calls)

--- a/src/chat/chat_response.rs
+++ b/src/chat/chat_response.rs
@@ -28,6 +28,9 @@ pub struct ChatResponse {
 	// pub model
 	/// The eventual usage of the chat response
 	pub usage: Usage,
+
+	/// The raw value of the response body, which can be used for provider specific features.
+	pub capture_raw_body: Option<serde_json::Value>,
 }
 
 // Getters
@@ -132,4 +135,3 @@ pub struct ChatStreamResponse {
 }
 
 // endregion: --- ChatStreamResponse
-

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -70,7 +70,7 @@ impl Client {
 					webc_error,
 				})?;
 
-		let chat_res = AdapterDispatcher::to_chat_response(model, web_res, options_set)?;
+		let chat_res = AdapterDispatcher::to_chat_response(self, model, web_res, options_set)?;
 
 		Ok(chat_res)
 	}

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -12,6 +12,7 @@ pub struct ClientConfig {
 	pub(super) model_mapper: Option<ModelMapper>,
 	pub(super) chat_options: Option<ChatOptions>,
 	pub(super) web_config: Option<WebConfig>,
+	pub(super) capture_raw_body: bool,
 }
 
 /// Chainable setters related to the ClientConfig.
@@ -57,6 +58,14 @@ impl ClientConfig {
 	pub fn web_config(&self) -> Option<&WebConfig> {
 		self.web_config.as_ref()
 	}
+
+	/// Set the capture_raw_body flag for the ClientConfig.
+	///
+	/// If set to true, the raw body of the response will be captured and included in the [`ChatResponse`](crate::chat::ChatResponse).
+	pub fn with_capture_raw_body(mut self, capture_raw_body: bool) -> Self {
+		self.capture_raw_body = capture_raw_body;
+		self
+	}
 }
 
 /// Getters for the fields of ClientConfig (as references).
@@ -78,6 +87,11 @@ impl ClientConfig {
 	/// Get a reference to the ChatOptions, if they exist.
 	pub fn chat_options(&self) -> Option<&ChatOptions> {
 		self.chat_options.as_ref()
+	}
+
+	/// Check if the raw body of the response should be captured.
+	pub fn capture_raw_body(&self) -> bool {
+		self.capture_raw_body
 	}
 }
 


### PR DESCRIPTION
Remain original response body, so users can do provider specific operations.