### PR TITLE
Extend OpenAI adapter to preserve request params

### DIFF
--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -157,9 +157,16 @@ impl OpenAIAdapter {
 		default_endpoint: Endpoint,
 	) -> String {
 		let base_url = default_endpoint.base_url();
-		match service_type {
-			ServiceType::Chat | ServiceType::ChatStream => format!("{base_url}chat/completions"),
-		}
+		// Parse into URL and query-params
+		let base_url = reqwest::Url::parse(base_url).unwrap();
+		let original_query_params = base_url.query().to_owned();
+
+		let suffix = match service_type {
+			ServiceType::Chat | ServiceType::ChatStream => "chat/completions",
+		};
+		let mut full_url = base_url.join(suffix).unwrap();
+		full_url.set_query(original_query_params);
+		full_url.to_string()
 	}
 
 	pub(in crate::adapter::adapters) fn util_to_web_request_data(


### PR DESCRIPTION
This change adjusts the way the service_url for the OpenAI adapter is built, so that Azure OpenAI endpoints can be supported.

As Azure OpenAI requires an `api-version` parameter to be set, a simple way to provide them would usually be to set a base URL for the providers, that ends with something like `?api-version=2024-10-08`. However, if we then use the naive current way to build the full service URL, these params end up in the middle of the URL. (Sadly a requwest client doesn't have an alternative extension method like `default_parameters` like it does for headers with `default_headers`).

With this change, the base_url, is first parsed to extract the params, and after building the full url, they are added back in.