### PR TITLE
fix: push empty content for sglang impl

### DIFF
--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -397,7 +397,7 @@ impl OpenAIAdapter {
 								})
 							})
 							.collect::<Vec<Value>>();
-						messages.push(json! ({"role": "assistant", "tool_calls": tool_calls}))
+						messages.push(json! ({"role": "assistant", "tool_calls": tool_calls, "content": ""}))
 					}
 					// TODO: Probably need to trace/warn that this will be ignored
 					MessageContent::Parts(_) => (),
@@ -483,6 +483,11 @@ struct OpenAIRequestParts {
 }
 
 fn parse_tool_calls(raw_tool_calls: Value) -> Result<Vec<ToolCall>> {
+	// Some backends (like sglang) return null if no tool calls are present.
+	if raw_tool_calls.is_null() {
+		return Ok(vec![]);
+	}
+
 	let Value::Array(raw_tool_calls) = raw_tool_calls else {
 		return Err(Error::InvalidJsonResponseElement {
 			info: "tool calls is not an array",


### PR DESCRIPTION
sglang have another implementation for parsing that raise this error:

```
{
  "object": "error",
  "message": "[{'type': 'missing', 'loc': ('body', 'messages', 2, 'ChatCompletionMessageGenericParam', 'content'), 'msg': 'Field required', 'input': {'role': 'assistant', 'tool_calls': [{'function': {'arguments': '{\"url\":\"dada\"}', 'name': 'tool-0_browser_navigate'}, 'id': 'call_7c29ed1e05ad4ea78b58ce23', 'type': 'function'}]}}, {'type': 'literal_error', 'loc': ('body', 'messages', 2, 'ChatCompletionMessageUserParam', 'role'), 'msg': \"Input should be 'user'\", 'input': 'assistant', 'ctx': {'expected': \"'user'\"}}, {'type': 'missing', 'loc': ('body', 'messages', 2, 'ChatCompletionMessageUserParam', 'content'), 'msg': 'Field required', 'input': {'role': 'assistant', 'tool_calls': [{'function': {'arguments': '{\"url\":\"dada\"}', 'name': 'tool-0_browser_navigate'}, 'id': 'call_7c29ed1e05ad4ea78b58ce23', 'type': 'function'}]}}]",
  "type": "Bad Request",
  "param": null,
  "code": 400
}
```

+ It can result null value in the tool result