### PR TITLE
Implement zhipu (ChatGLM) completions 

### DIFF
--- a/examples/c00-readme.rs
+++ b/examples/c00-readme.rs
@@ -12,6 +12,7 @@ const MODEL_GROQ: &str = "llama-3.1-8b-instant";
 const MODEL_OLLAMA: &str = "gemma:2b"; // sh: `ollama pull gemma:2b`
 const MODEL_XAI: &str = "grok-beta";
 const MODEL_DEEPSEEK: &str = "deepseek-chat";
+const MODEL_ZHIPU: &str = "glm-4-plus";
 
 // NOTE: These are the default environment keys for each AI Adapter Type.
 //       They can be customized; see `examples/c02-auth.rs`
@@ -24,6 +25,7 @@ const MODEL_AND_KEY_ENV_NAME_LIST: &[(&str, &str)] = &[
 	(MODEL_GROQ, "GROQ_API_KEY"),
 	(MODEL_XAI, "XAI_API_KEY"),
 	(MODEL_DEEPSEEK, "DEEPSEEK_API_KEY"),
+	(MODEL_ZHIPU, "ZHIPU_API_KEY"),
 	(MODEL_OLLAMA, ""),
 ];
 
@@ -33,6 +35,7 @@ const MODEL_AND_KEY_ENV_NAME_LIST: &[(&str, &str)] = &[
 //  - starts_with "command"  -> Cohere
 //  - starts_with "gemini"   -> Gemini
 //  - model in Groq models   -> Groq
+//  - starts_with "glm"      -> Zhipu
 //  - For anything else      -> Ollama
 //
 // This can be customized; see `examples/c03-mapper.rs`

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -6,6 +6,7 @@ use crate::adapter::groq::{self, GroqAdapter};
 use crate::adapter::nebius::NebiusAdapter;
 use crate::adapter::openai::OpenAIAdapter;
 use crate::adapter::xai::XaiAdapter;
+use crate::adapter::zhipu::ZhipuAdapter;
 use crate::{ModelName, Result};
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
@@ -32,6 +33,8 @@ pub enum AdapterKind {
 	Xai,
 	/// For DeepSeek
 	DeepSeek,
+	/// For Zhipu
+	Zhipu,
 	// Note: Variants will probably be suffixed
 	// AnthropicBedrock,
 }
@@ -50,6 +53,7 @@ impl AdapterKind {
 			AdapterKind::Nebius => "Nebius",
 			AdapterKind::Xai => "xAi",
 			AdapterKind::DeepSeek => "DeepSeek",
+			AdapterKind::Zhipu => "Zhipu",
 		}
 	}
 
@@ -65,6 +69,7 @@ impl AdapterKind {
 			AdapterKind::Nebius => "nebius",
 			AdapterKind::Xai => "xai",
 			AdapterKind::DeepSeek => "deepseek",
+			AdapterKind::Zhipu => "zhipu",
 		}
 	}
 
@@ -79,6 +84,7 @@ impl AdapterKind {
 			"nebius" => Some(AdapterKind::Nebius),
 			"xai" => Some(AdapterKind::Xai),
 			"deepseek" => Some(AdapterKind::DeepSeek),
+			"zhipu" => Some(AdapterKind::Zhipu),
 			_ => None,
 		}
 	}
@@ -97,6 +103,7 @@ impl AdapterKind {
 			AdapterKind::Nebius => Some(NebiusAdapter::API_KEY_DEFAULT_ENV_NAME),
 			AdapterKind::Xai => Some(XaiAdapter::API_KEY_DEFAULT_ENV_NAME),
 			AdapterKind::DeepSeek => Some(DeepSeekAdapter::API_KEY_DEFAULT_ENV_NAME),
+			AdapterKind::Zhipu => Some(ZhipuAdapter::API_KEY_DEFAULT_ENV_NAME),
 			AdapterKind::Ollama => None,
 		}
 	}
@@ -115,6 +122,7 @@ impl AdapterKind {
 	///  - Gemini     - starts_with "gemini"
 	///  - Groq       - model in Groq models
 	///  - DeepSeek   - model in DeepSeek models (deepseek.com)
+	///  - Zhipu      - starts_with "glm"
 	///  - Ollama     - For anything else
 	///
 	/// Note: At this point, this will never fail as the fallback is the Ollama adapter.
@@ -151,6 +159,8 @@ impl AdapterKind {
 			Ok(Self::DeepSeek)
 		} else if groq::MODELS.contains(&model) {
 			return Ok(Self::Groq);
+		} else if model.starts_with("glm") {
+			Ok(Self::Zhipu)
 		}
 		// For now, fallback to Ollama
 		else {

--- a/src/adapter/adapters/mod.rs
+++ b/src/adapter/adapters/mod.rs
@@ -9,3 +9,4 @@ pub(super) mod nebius;
 pub(super) mod ollama;
 pub(super) mod openai;
 pub(super) mod xai;
+pub(super) mod zhipu;

--- a/src/adapter/adapters/openai/streamer.rs
+++ b/src/adapter/adapters/openai/streamer.rs
@@ -104,6 +104,13 @@ impl futures::Stream for OpenAIStreamer {
 											.map(|v| OpenAIAdapter::into_usage(adapter_kind, v))
 											.unwrap_or_default();
 										self.captured_data.usage = Some(usage)
+									},
+									AdapterKind::Zhipu => {
+										let usage = message_data
+											.x_take("usage")
+											.map(|v| OpenAIAdapter::into_usage(adapter_kind, v))
+											.unwrap_or_default();
+										self.captured_data.usage = Some(usage)
 									}
 									_ => (), // do nothing, will be captured the OpenAI way
 								}

--- a/src/adapter/adapters/zhipu/adapter_impl.rs
+++ b/src/adapter/adapters/zhipu/adapter_impl.rs
@@ -1,0 +1,77 @@
+use crate::ModelIden;
+use crate::adapter::openai::OpenAIAdapter;
+use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
+use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::resolver::{AuthData, Endpoint};
+use crate::webc::WebResponse;
+use crate::{Result, ServiceTarget};
+use reqwest::RequestBuilder;
+
+pub struct ZhipuAdapter;
+
+pub(in crate::adapter) const MODELS: &[&str] = &[
+	"glm-4-plus",
+	"glm-4-air-250414",
+	"glm-4-flashx-250414",
+	"glm-4-flash-250414",
+	"glm-4-air",
+	"glm-4-air-250414",
+	"glm-4-airx",
+	"glm-4-long",
+	"glm-4-flash",
+	"glm-4v-plus-0111",
+	"glm-4v-flash",
+	"glm-z1-air",
+	"glm-z1-airx",
+	"glm-z1-flash",
+	"glm-z1-flashx",
+];
+
+impl ZhipuAdapter {
+	pub const API_KEY_DEFAULT_ENV_NAME: &str = "ZHIPU_API_KEY";
+}
+
+// The Zhipu API is mostly compatible with the OpenAI API.
+impl Adapter for ZhipuAdapter {
+	fn default_endpoint() -> Endpoint {
+		const BASE_URL: &str = "https://open.bigmodel.cn/api/paas/v4/";
+		Endpoint::from_static(BASE_URL)
+	}
+
+	fn default_auth() -> AuthData {
+		AuthData::from_env(Self::API_KEY_DEFAULT_ENV_NAME)
+	}
+
+	async fn all_model_names(_kind: AdapterKind) -> Result<Vec<String>> {
+		Ok(MODELS.iter().map(|s| s.to_string()).collect())
+	}
+
+	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> String {
+		OpenAIAdapter::util_get_service_url(model, service_type, endpoint)
+	}
+
+	fn to_web_request_data(
+		target: ServiceTarget,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		chat_options: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		OpenAIAdapter::util_to_web_request_data(target, service_type, chat_req, chat_options)
+	}
+
+	fn to_chat_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatResponse> {
+		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+	}
+
+	fn to_chat_stream(
+		model_iden: ModelIden,
+		reqwest_builder: RequestBuilder,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatStreamResponse> {
+		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+}

--- a/src/adapter/adapters/zhipu/adapter_impl.rs
+++ b/src/adapter/adapters/zhipu/adapter_impl.rs
@@ -25,6 +25,8 @@ pub(in crate::adapter) const MODELS: &[&str] = &[
 	"glm-z1-airx",
 	"glm-z1-flash",
 	"glm-z1-flashx",
+	"glm-4.1v-thinking-flash",
+	"glm-4.1v-thinking-flashx"
 ];
 
 impl ZhipuAdapter {

--- a/src/adapter/adapters/zhipu/mod.rs
+++ b/src/adapter/adapters/zhipu/mod.rs
@@ -1,0 +1,12 @@
+//! Click the globe icon on the top-right corner of the page to switch language.
+//! API Documentation:     https://bigmodel.cn/dev/api
+//! Model Names:           https://bigmodel.cn/dev/howuse/model
+//! Pricing:               https://bigmodel.cn/pricing
+
+// region:    --- Modules
+
+mod adapter_impl;
+
+pub use adapter_impl::*;
+
+// endregion: --- Modules

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -14,6 +14,7 @@ use super::groq::GroqAdapter;
 use crate::adapter::deepseek::DeepSeekAdapter;
 use crate::adapter::nebius::NebiusAdapter;
 use crate::adapter::xai::XaiAdapter;
+use crate::adapter::zhipu::ZhipuAdapter;
 use crate::resolver::{AuthData, Endpoint};
 
 /// A construct that allows dispatching calls to the Adapters.
@@ -35,6 +36,7 @@ impl AdapterDispatcher {
 			AdapterKind::Nebius => NebiusAdapter::default_endpoint(),
 			AdapterKind::Xai => XaiAdapter::default_endpoint(),
 			AdapterKind::DeepSeek => DeepSeekAdapter::default_endpoint(),
+			AdapterKind::Zhipu => ZhipuAdapter::default_endpoint(),
 		}
 	}
 
@@ -49,6 +51,7 @@ impl AdapterDispatcher {
 			AdapterKind::Nebius => NebiusAdapter::default_auth(),
 			AdapterKind::Xai => XaiAdapter::default_auth(),
 			AdapterKind::DeepSeek => DeepSeekAdapter::default_auth(),
+			AdapterKind::Zhipu => ZhipuAdapter::default_auth(),
 		}
 	}
 
@@ -63,6 +66,7 @@ impl AdapterDispatcher {
 			AdapterKind::Nebius => NebiusAdapter::all_model_names(kind).await,
 			AdapterKind::Xai => XaiAdapter::all_model_names(kind).await,
 			AdapterKind::DeepSeek => DeepSeekAdapter::all_model_names(kind).await,
+			AdapterKind::Zhipu => ZhipuAdapter::all_model_names(kind).await,
 		}
 	}
 
@@ -77,6 +81,7 @@ impl AdapterDispatcher {
 			AdapterKind::Nebius => NebiusAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Xai => XaiAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::DeepSeek => DeepSeekAdapter::get_service_url(model, service_type, endpoint),
+			AdapterKind::Zhipu => ZhipuAdapter::get_service_url(model, service_type, endpoint),
 		}
 	}
 
@@ -99,6 +104,7 @@ impl AdapterDispatcher {
 			AdapterKind::Nebius => NebiusAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Xai => XaiAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_web_request_data(target, service_type, chat_req, options_set),
+			AdapterKind::Zhipu => ZhipuAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 		}
 	}
 
@@ -117,6 +123,7 @@ impl AdapterDispatcher {
 			AdapterKind::Nebius => NebiusAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Xai => XaiAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_response(model_iden, web_response, options_set),
+			AdapterKind::Zhipu => ZhipuAdapter::to_chat_response(model_iden, web_response, options_set),
 		}
 	}
 
@@ -135,6 +142,7 @@ impl AdapterDispatcher {
 			AdapterKind::Nebius => NebiusAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Xai => XaiAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+			AdapterKind::Zhipu => ZhipuAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 		}
 	}
 }

--- a/tests/tests_p_zhipu.rs
+++ b/tests/tests_p_zhipu.rs
@@ -1,0 +1,126 @@
+mod support;
+
+use crate::support::{Check, common_tests};
+use genai::adapter::AdapterKind;
+use genai::resolver::AuthData;
+
+type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
+
+const MODEL: &str = "glm-4-plus";
+const MODEL_NS: &str = "zhipu::glm-4-plus";
+const MODEL_V: &str = "glm-4v-flash"; // Visual language model does not support function calling
+
+// region:    --- Chat
+
+#[tokio::test]
+async fn test_chat_simple_ok() -> Result<()> {
+	common_tests::common_test_chat_simple_ok(MODEL, None).await
+}
+
+#[tokio::test]
+async fn test_chat_namespaced_ok() -> Result<()> {
+	common_tests::common_test_chat_simple_ok(MODEL_NS, None).await
+}
+
+#[tokio::test]
+async fn test_chat_multi_system_ok() -> Result<()> {
+	common_tests::common_test_chat_multi_system_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_chat_json_mode_ok() -> Result<()> {
+	common_tests::common_test_chat_json_mode_ok(MODEL, Some(Check::USAGE)).await
+}
+
+/// NOTE - Disable for now, not supported by Zhipu as of 2025-07-08
+// #[tokio::test]
+// async fn test_chat_json_structured_ok() -> Result<()> {
+// 	common_tests::common_test_chat_json_structured_ok(MODEL, Some(Check::USAGE)).await
+// }
+
+#[tokio::test]
+async fn test_chat_temperature_ok() -> Result<()> {
+	common_tests::common_test_chat_temperature_ok(MODEL).await
+}
+
+/// NOTE - Disabled for now, as the model currently includes the stop sequences as the last sequences in the generation as of 2025-07-08.
+// #[tokio::test]
+// async fn test_chat_stop_sequences_ok() -> Result<()> {
+// 	common_tests::common_test_chat_stop_sequences_ok(MODEL).await
+// }
+
+// endregion: --- Chat
+
+// region:    --- Chat Implicit Cache
+
+/// NOTE - Disable for now, not supported by Zhipu as of 2025-07-08
+// #[tokio::test]
+// async fn test_chat_cache_implicit_simple_ok() -> Result<()> {
+// 	common_tests::common_test_chat_cache_implicit_simple_ok(MODEL).await
+// }
+
+// endregion: --- Chat Implicit Cache
+
+// region:    --- Chat Stream Tests
+
+#[tokio::test]
+async fn test_chat_stream_simple_ok() -> Result<()> {
+	common_tests::common_test_chat_stream_simple_ok(MODEL, None).await
+}
+
+#[tokio::test]
+async fn test_chat_stream_capture_content_ok() -> Result<()> {
+	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_chat_stream_capture_all_ok() -> Result<()> {
+	common_tests::common_test_chat_stream_capture_all_ok(MODEL, None).await
+}
+
+// endregion: --- Chat Stream Tests
+
+// region:    --- Image Tests
+
+#[tokio::test]
+async fn test_chat_image_url_ok() -> Result<()> {
+	common_tests::common_test_chat_image_url_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_chat_image_b64_ok() -> Result<()> {
+	common_tests::common_test_chat_image_b64_ok(MODEL_V).await
+}
+
+// endregion: --- Image Test
+
+// region:    --- Tool Tests
+
+#[tokio::test]
+async fn test_tool_simple_ok() -> Result<()> {
+	common_tests::common_test_tool_simple_ok(MODEL, true).await
+}
+
+#[tokio::test]
+async fn test_tool_full_flow_ok() -> Result<()> {
+	common_tests::common_test_tool_full_flow_ok(MODEL, true).await
+}
+// endregion: --- Tool Tests
+
+// region:    --- Resolver Tests
+
+#[tokio::test]
+async fn test_resolver_auth_ok() -> Result<()> {
+	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("ZHIPU_API_KEY")).await
+}
+
+// endregion: --- Resolver Tests
+
+// region:    --- List
+
+#[tokio::test]
+async fn test_list_models() -> Result<()> {
+	common_tests::common_test_list_models(AdapterKind::Zhipu, "glm-4-plus").await
+}
+
+// endregion: --- List

--- a/tests/tests_p_zhipu_reasoning.rs
+++ b/tests/tests_p_zhipu_reasoning.rs
@@ -1,0 +1,83 @@
+mod support;
+
+use crate::support::{Check, common_tests};
+use genai::adapter::AdapterKind;
+use genai::resolver::AuthData;
+
+type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
+
+const MODEL: &str = "glm-z1-flash";
+
+// region:    --- Chat
+
+// NOTE - Disabled for now, as the model does not add .reasoning_content. Instead, it uses a <think> tag, which is tested in test_chat_reasoning_normalize_ok as of 2025-07-08.
+// #[tokio::test]
+// async fn test_chat_simple_ok() -> Result<()> {
+// 	common_tests::common_test_chat_simple_ok(MODEL, Some(Check::REASONING)).await
+// }
+
+#[tokio::test]
+async fn test_chat_multi_system_ok() -> Result<()> {
+	common_tests::common_test_chat_multi_system_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_chat_json_mode_ok() -> Result<()> {
+	common_tests::common_test_chat_json_mode_ok(MODEL, Some(Check::USAGE)).await
+}
+
+#[tokio::test]
+async fn test_chat_temperature_ok() -> Result<()> {
+	common_tests::common_test_chat_temperature_ok(MODEL).await
+}
+
+/// NOTE - Disabled for now, as the model currently includes the stop sequences as the last sequences in the generation as of 2025-07-08.
+// #[tokio::test]
+// async fn test_chat_stop_sequences_ok() -> Result<()> {
+// 	common_tests::common_test_chat_stop_sequences_ok(MODEL).await
+// }
+
+#[tokio::test]
+async fn test_chat_reasoning_normalize_ok() -> Result<()> {
+	common_tests::common_test_chat_reasoning_normalize_ok(MODEL).await
+}
+// endregion: --- Chat
+
+// region:    --- Chat Stream Tests
+
+// NOTE - Disabled for now, as the model does not add .reasoning_content. Instead, it uses a <think> tag, which is tested in test_chat_reasoning_normalize_ok as of 2025-07-08.
+// #[tokio::test]
+// async fn test_chat_stream_simple_ok() -> Result<()> {
+// 	common_tests::common_test_chat_stream_simple_ok(MODEL, Some(Check::REASONING)).await
+// }
+
+#[tokio::test]
+async fn test_chat_stream_capture_content_ok() -> Result<()> {
+	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
+}
+
+// NOTE - Disabled for now, as the model does not add .reasoning_content. Instead, it uses a <think> tag, which is tested in test_chat_reasoning_normalize_ok as of 2025-07-08.
+// #[tokio::test]
+// async fn test_chat_stream_capture_all_ok() -> Result<()> {
+// 	common_tests::common_test_chat_stream_capture_all_ok(MODEL, Some(Check::REASONING)).await
+// }
+
+// endregion: --- Chat Stream Tests
+
+// region:    --- Resolver Tests
+
+#[tokio::test]
+async fn test_resolver_auth_ok() -> Result<()> {
+	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("ZHIPU_API_KEY")).await
+}
+
+// endregion: --- Resolver Tests
+
+// region:    --- List
+
+#[tokio::test]
+async fn test_list_models() -> Result<()> {
+	common_tests::common_test_list_models(AdapterKind::Zhipu, "glm-z1-flash").await
+}
+
+// endregion: --- List


### PR DESCRIPTION
This PR adds support for Zhipu (Z.ai) models, which closely follow the OpenAI API schema.
All models are prefixed with `glm` and have been verified locally to work correctly.

Notable Differences from OpenAI:
- **No implicit caching**: Each request is evaluated fully without automatic reuse of prior responses.
- **No native structured output**: The model does not support returning strict JSON.
- **Stop tokens are included**: The stop word is returned as part of the generated text (as the final token).
