### PR TITLE
Implement support for custom HTTP headers in chat completion calls

### DIFF
--- a/examples/c11-extra-headers.rs
+++ b/examples/c11-extra-headers.rs
@@ -1,0 +1,44 @@
+//! Example demonstrating how to add extra headers to chat completion calls
+
+use genai::Client;
+use genai::chat::{ChatMessage, ChatRequest, ChatOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a client
+    let _client = Client::default();
+
+    // Create a simple chat request
+    let _chat_req = ChatRequest::new(vec![
+        ChatMessage::system("You are a helpful assistant."),
+        ChatMessage::user("Hello, how are you?"),
+    ]);
+
+    // Example 1: Add extra headers using individual with_extra_header calls
+    let options_individual = ChatOptions::default()
+        .with_extra_header("X-Custom-App", "my-rust-app")
+        .with_extra_header("X-Request-ID", "req-12345")
+        .with_temperature(0.7);
+
+    // Example 2: Add extra headers using with_extra_headers with a vec
+    let headers = vec![
+        ("X-Custom-App".to_string(), "my-rust-app".to_string()),
+        ("X-Request-ID".to_string(), "req-67890".to_string()),
+        ("X-User-Agent".to_string(), "GenAI-Rust-Client/1.0".to_string()),
+    ];
+    
+    let options_batch = ChatOptions::default()
+        .with_extra_headers(headers)
+        .with_temperature(0.7);
+
+    println!("Extra headers example - these would be included in HTTP requests:");
+    println!("Individual headers: {:?}", options_individual.extra_headers);
+    println!("Batch headers: {:?}", options_batch.extra_headers);
+
+    // Note: To actually test with a real API, you would need valid API keys
+    // For now, we'll just show how the options would be configured
+    println!("\nTo use these options in a real chat call:");
+    println!("let response = client.exec_chat(\"gpt-4o-mini\", chat_req, Some(&options_individual)).await?;");
+
+    Ok(())
+}

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -84,11 +84,14 @@ impl Adapter for AnthropicAdapter {
 		let url = Self::get_service_url(&model, service_type, endpoint);
 
 		// -- headers
-		let headers = vec![
+		let mut headers = vec![
 			// headers
 			("x-api-key".to_string(), api_key),
 			("anthropic-version".to_string(), ANTHROPIC_VERSION.to_string()),
 		];
+
+		// Add extra headers from options
+		headers.extend_from_slice(options_set.extra_headers());
 
 		// -- Parts
 		let AnthropicRequestParts {

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -64,10 +64,13 @@ impl Adapter for CohereAdapter {
 		let url = Self::get_service_url(&model, service_type, endpoint);
 
 		// -- headers
-		let headers = vec![
+		let mut headers = vec![
 			// headers
 			("Authorization".to_string(), format!("Bearer {api_key}")),
 		];
+
+		// Add extra headers from options
+		headers.extend_from_slice(options_set.extra_headers());
 
 		// -- parts
 		let CohereChatRequestParts {

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -81,10 +81,13 @@ impl Adapter for GeminiAdapter {
 		let url = url.to_string();
 
 		// -- headers (empty for gemini)
-		let headers = vec![
+		let mut headers = vec![
 			// headers
 			("x-goog-api-key".to_string(), api_key.to_string()),
 		];
+
+		// Add extra headers from options
+		headers.extend_from_slice(options_set.extra_headers());
 
 		// -- Reasoning Budget
 		let (_, reasoning_effort) = match (model_name, options_set.reasoning_effort()) {

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -194,10 +194,13 @@ impl OpenAIAdapter {
 		let url = AdapterDispatcher::get_service_url(&model, service_type, endpoint);
 
 		// -- headers
-		let headers = vec![
+		let mut headers = vec![
 			// headers
 			("Authorization".to_string(), format!("Bearer {api_key}")),
 		];
+
+		// Add extra headers from options
+		headers.extend_from_slice(options_set.extra_headers());
 
 		let stream = matches!(service_type, ServiceType::ChatStream);
 


### PR DESCRIPTION

> [!CAUTION]  
> ⚠️ Disclaimer: this PR was loosely (given i'm a rust noob) humanly reviewed  but is otherwise mostly AI-generated
> ~ julien-c

This PR implements the ability to add custom HTTP headers to chat completion calls, addressing the need for users to include additional metadata, authentication tokens, or tracking information in their API requests.

## Changes Made

### Core Implementation
- **Added `extra_headers` field** to `ChatOptions` struct as `Vec<(String, String)>`
- **Added chainable setter methods**:
  - `with_extra_header(key, value)` for adding individual headers
  - `with_extra_headers(headers)` for adding multiple headers at once
- **Updated `ChatOptionsSet`** to handle extra headers with proper cascading (chat-level overrides client-level)

### Adapter Updates
- **Updated all adapter implementations** to include extra headers in HTTP requests:
  - OpenAI adapter (via utility function - also applies to Groq, xAI, Ollama, DeepSeek, Zhipu, Nebius)
  - Anthropic adapter
  - Gemini adapter  
  - Cohere adapter

### Usage Examples

```rust
use genai::{Client, ChatOptions, ChatRequest, ChatMessage};

// Add individual headers
let options = ChatOptions::default()
    .with_extra_header("X-Custom-App", "my-rust-app")
    .with_extra_header("X-Request-ID", "req-12345");

// Add multiple headers at once
let headers = vec![
    ("X-Custom-App".to_string(), "my-rust-app".to_string()),
    ("X-Request-ID".to_string(), "req-67890".to_string()),
];
let options = ChatOptions::default().with_extra_headers(headers);

// Use in chat calls
let client = Client::default();
let chat_req = ChatRequest::from_user("Hello!");
let response = client.exec_chat("gpt-4o-mini", chat_req, Some(&options)).await?;
```

## Testing
- **Unit tests** for `ChatOptions` and `ChatOptionsSet` functionality
- **Integration tests** for OpenAI adapter to verify headers are properly included in `WebRequestData`
- **Example application** (`examples/c11-extra-headers.rs`) demonstrating usage

## Compatibility
- Fully backward compatible - existing code continues to work unchanged
- Headers follow the same cascading pattern as other chat options
- Empty headers list by default (no behavior change when not used)
