### PR TITLE
feat: add embeddings support

### DIFF
--- a/examples/e01-embed-basic.rs
+++ b/examples/e01-embed-basic.rs
@@ -1,0 +1,179 @@
+//! Basic example demonstrating the embedding API
+//!
+//! This example shows how to:
+//! - Create single embeddings
+//! - Create batch embeddings
+//! - Use embedding options
+//! - Handle different providers
+
+use genai::Client;
+use genai::embed::{EmbedOptions, EmbedRequest};
+
+// OpenAI embedding models
+const MODEL_OPENAI_SMALL: &str = "text-embedding-3-small";
+const MODEL_OPENAI_LARGE: &str = "text-embedding-3-large";
+
+// Other providers (will return "not supported" errors for now)
+const MODEL_COHERE: &str = "embed-v4.0";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).init();
+
+	let client = Client::default();
+
+	println!("=== GenAI Embedding Examples ===\n");
+
+	// Example 1: Single embedding
+	println!("1. Single Embedding:");
+	let text = "The quick brown fox jumps over the lazy dog";
+	println!("   Text: \"{}\"", text);
+
+	match client.embed(MODEL_OPENAI_SMALL, text, None).await {
+		Ok(response) => {
+			let embedding = response.first_embedding().unwrap();
+			println!("   Model: {}", response.model_iden.model_name);
+			println!("   Dimensions: {}", embedding.dimensions());
+			println!(
+				"   Vector preview: [{:.4}, {:.4}, {:.4}, ...]",
+				embedding.vector()[0],
+				embedding.vector()[1],
+				embedding.vector()[2]
+			);
+			if let Some(usage) = response.usage.prompt_tokens {
+				println!("   Tokens used: {}", usage);
+			}
+		}
+		Err(e) => println!("   Error: {}", e),
+	}
+	println!();
+
+	// Example 2: Batch embeddings
+	println!("2. Batch Embeddings:");
+	let texts = vec![
+		"Hello world".to_string(),
+		"Goodbye world".to_string(),
+		"The meaning of life".to_string(),
+	];
+	println!("   Texts: {:?}", texts);
+
+	match client.embed_batch(MODEL_OPENAI_SMALL, texts, None).await {
+		Ok(response) => {
+			println!("   Model: {}", response.model_iden.model_name);
+			println!("   Number of embeddings: {}", response.embedding_count());
+			for (i, embedding) in response.embeddings.iter().enumerate() {
+				println!(
+					"   Embedding {}: {} dimensions, vector preview: [{:.4}, {:.4}, ...]",
+					i,
+					embedding.dimensions(),
+					embedding.vector()[0],
+					embedding.vector()[1]
+				);
+			}
+			if let Some(usage) = response.usage.prompt_tokens {
+				println!("   Total tokens used: {}", usage);
+			}
+		}
+		Err(e) => println!("   Error: {}", e),
+	}
+	println!();
+
+	// Example 3: Using EmbedRequest directly
+	println!("3. Using EmbedRequest:");
+	let embed_req = EmbedRequest::from_texts(vec![
+		"Machine learning".to_string(),
+		"Artificial intelligence".to_string(),
+	]);
+
+	match client.exec_embed(MODEL_OPENAI_SMALL, embed_req, None).await {
+		Ok(response) => {
+			println!("   Created {} embeddings", response.embedding_count());
+			for embedding in &response.embeddings {
+				println!("   Index {}: {} dimensions", embedding.index(), embedding.dimensions());
+			}
+		}
+		Err(e) => println!("   Error: {}", e),
+	}
+	println!();
+
+	// Example 4: Using embedding options
+	println!("4. With Embedding Options:");
+	let options = EmbedOptions::new()
+		.with_dimensions(512) // Request smaller dimensions (if supported)
+		.with_capture_usage(true)
+		.with_user("example-user".to_string());
+
+	match client.embed(MODEL_OPENAI_SMALL, "Hello with options", Some(&options)).await {
+		Ok(response) => {
+			let embedding = response.first_embedding().unwrap();
+			println!("   Requested dimensions: 512");
+			println!("   Actual dimensions: {}", embedding.dimensions());
+			println!(
+				"   Vector preview: [{:.4}, {:.4}, {:.4}, ...]",
+				embedding.vector()[0],
+				embedding.vector()[1],
+				embedding.vector()[2]
+			);
+		}
+		Err(e) => println!("   Error: {}", e),
+	}
+	println!();
+
+	// Example 5: Provider-specific options
+	println!("5. Provider-Specific Options:");
+
+	// Cohere-specific options
+	let cohere_options = EmbedOptions::new()
+		.with_dimensions(512)
+		.with_embedding_type("search_query") // Cohere: specify embedding type
+		.with_truncate("START") // Cohere: truncate from start instead of end
+		.with_capture_usage(true);
+
+	println!("   Cohere options: embedding_type='search_query', truncate='START'");
+	match client
+		.embed(MODEL_COHERE, "What is machine learning?", Some(&cohere_options))
+		.await
+	{
+		Ok(response) => {
+			let embedding = response.first_embedding().unwrap();
+			println!("   ✓ Cohere embedding: {} dimensions", embedding.dimensions());
+		}
+		Err(e) => println!("   ✗ Cohere error: {}", e),
+	}
+
+	// Gemini-specific options
+	let gemini_options = EmbedOptions::new()
+		.with_embedding_type("RETRIEVAL_QUERY") // Gemini: specify embedding type
+		.with_capture_usage(true);
+
+	println!("   Gemini options: embedding_type='RETRIEVAL_QUERY'");
+	match client
+		.embed("gemini-embedding-001", "Find documents about AI", Some(&gemini_options))
+		.await
+	{
+		Ok(response) => {
+			let embedding = response.first_embedding().unwrap();
+			println!("   ✓ Gemini embedding: {} dimensions", embedding.dimensions());
+		}
+		Err(e) => println!("   ✗ Gemini error: {}", e),
+	}
+	println!();
+
+	// Example 6: Different models (if available)
+	println!("6. Different Models:");
+	let test_text = "Compare embedding models";
+
+	for model in &[MODEL_OPENAI_SMALL, MODEL_OPENAI_LARGE] {
+		print!("   Testing {}: ", model);
+		match client.embed(model, test_text, None).await {
+			Ok(response) => {
+				let embedding = response.first_embedding().unwrap();
+				println!("{} dimensions", embedding.dimensions());
+			}
+			Err(e) => println!("Error - {}", e),
+		}
+	}
+	println!();
+
+	Ok(())
+}

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -145,11 +145,12 @@ impl AdapterKind {
 			|| model.starts_with("o1")
 			|| model.starts_with("chatgpt")
 			|| model.starts_with("codex")
+			|| model.starts_with("text-embedding")
 		{
 			Ok(Self::OpenAI)
 		} else if model.starts_with("claude") {
 			Ok(Self::Anthropic)
-		} else if model.starts_with("command") {
+		} else if model.starts_with("command") || model.starts_with("embed-") {
 			Ok(Self::Cohere)
 		} else if model.starts_with("gemini") {
 			Ok(Self::Gemini)

--- a/src/adapter/adapter_types.rs
+++ b/src/adapter/adapter_types.rs
@@ -1,5 +1,6 @@
 use crate::adapter::AdapterKind;
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::embed::{EmbedOptionsSet, EmbedRequest, EmbedResponse};
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebResponse;
 use crate::{Headers, ModelIden};
@@ -43,6 +44,20 @@ pub trait Adapter {
 		reqwest_builder: RequestBuilder,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<ChatStreamResponse>;
+
+	/// To be implemented by Adapters.
+	fn to_embed_request_data(
+		service_target: ServiceTarget,
+		embed_req: EmbedRequest,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData>;
+
+	/// To be implemented by Adapters.
+	fn to_embed_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<EmbedResponse>;
 }
 
 // region:    --- ServiceType
@@ -51,6 +66,7 @@ pub trait Adapter {
 pub enum ServiceType {
 	Chat,
 	ChatStream,
+	Embed,
 }
 
 // endregion: --- ServiceType

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -66,6 +66,7 @@ impl Adapter for AnthropicAdapter {
 		let base_url = endpoint.base_url();
 		match service_type {
 			ServiceType::Chat | ServiceType::ChatStream => format!("{base_url}messages"),
+			ServiceType::Embed => format!("{base_url}embeddings"), // Anthropic doesn't support embeddings yet
 		}
 	}
 
@@ -229,6 +230,28 @@ impl Adapter for AnthropicAdapter {
 		Ok(ChatStreamResponse {
 			model_iden,
 			stream: chat_stream,
+		})
+	}
+
+	fn to_embed_request_data(
+		_service_target: crate::ServiceTarget,
+		_embed_req: crate::embed::EmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		Err(crate::Error::AdapterNotSupported {
+			adapter_kind: crate::adapter::AdapterKind::Anthropic,
+			feature: "embeddings".to_string(),
+		})
+	}
+
+	fn to_embed_response(
+		_model_iden: crate::ModelIden,
+		_web_response: crate::webc::WebResponse,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(crate::Error::AdapterNotSupported {
+			adapter_kind: crate::adapter::AdapterKind::Anthropic,
+			feature: "embeddings".to_string(),
 		})
 	}
 }

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -46,6 +46,11 @@ impl Adapter for CohereAdapter {
 		let base_url = endpoint.base_url();
 		match service_type {
 			ServiceType::Chat | ServiceType::ChatStream => format!("{base_url}chat"),
+			ServiceType::Embed => {
+				//HACK: Cohere embeddings use v2 API, but base_url is v1, so we need to replace it
+				let base_without_version = base_url.trim_end_matches("v1/");
+				format!("{base_without_version}v2/embed")
+			}
 		}
 	}
 
@@ -159,6 +164,22 @@ impl Adapter for CohereAdapter {
 			model_iden,
 			stream: chat_stream,
 		})
+	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		super::embed::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		super::embed::to_embed_response(model_iden, web_response, options_set)
 	}
 }
 

--- a/src/adapter/adapters/cohere/embed.rs
+++ b/src/adapter/adapters/cohere/embed.rs
@@ -1,0 +1,248 @@
+//! Cohere Embeddings API implementation
+//! API Documentation: https://docs.cohere.com/reference/embed
+
+use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::{Adapter, ServiceType, WebRequestData};
+use crate::chat::Usage;
+use crate::embed::{EmbedOptionsSet, EmbedRequest, EmbedResponse, Embedding};
+use crate::webc::WebResponse;
+use crate::{Error, Headers, ModelIden, Result, ServiceTarget};
+use serde::{Deserialize, Serialize};
+
+// region:    --- Cohere Embed Request
+
+#[derive(Debug, Serialize)]
+struct CohereEmbedRequest {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	texts: Option<Vec<String>>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	inputs: Option<Vec<CohereInput>>,
+	model: String,
+	input_type: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	embedding_types: Option<Vec<String>>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	truncate: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	output_dimension: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct CohereInput {
+	content: Vec<CohereContent>,
+}
+
+#[derive(Debug, Serialize)]
+struct CohereContent {
+	#[serde(rename = "type")]
+	content_type: String,
+	text: String,
+}
+
+// endregion: --- Cohere Embed Request
+
+// region:    --- Cohere Embed Response
+
+#[derive(Debug, Deserialize)]
+struct CohereEmbedResponse {
+	embeddings: CohereEmbeddings,
+	meta: Option<CohereMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CohereEmbeddings {
+	#[serde(rename = "float")]
+	float_embeddings: Option<Vec<Vec<f32>>>,
+	int8: Option<Vec<Vec<i8>>>,
+	uint8: Option<Vec<Vec<u8>>>,
+	binary: Option<Vec<Vec<i8>>>,
+	ubinary: Option<Vec<Vec<u8>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CohereMeta {
+	billed_units: Option<CohereBilledUnits>,
+	warnings: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CohereBilledUnits {
+	input_tokens: Option<u32>,
+}
+
+// endregion: --- Cohere Embed Response
+
+// region:    --- Public Functions
+
+pub fn to_embed_request_data(
+	service_target: ServiceTarget,
+	embed_req: EmbedRequest,
+	options_set: EmbedOptionsSet<'_, '_>,
+) -> Result<WebRequestData> {
+	let ServiceTarget { model, auth, .. } = service_target;
+	let api_key = get_api_key(auth, &model)?;
+
+	// Extract the actual model name (without namespace)
+	let (model_name, _) = model.model_name.as_model_name_and_namespace();
+
+	// Build headers
+	let mut headers = Headers::from(vec![
+		("Authorization".to_string(), format!("Bearer {api_key}")),
+		("Content-Type".to_string(), "application/json".to_string()),
+	]);
+
+	// Add custom headers from options
+	if let Some(custom_headers) = options_set.headers() {
+		headers.merge_with(custom_headers);
+	}
+
+	// Convert EmbedRequest to Cohere format
+	let (texts, inputs) = match embed_req.input {
+		crate::embed::EmbedInput::Single(text) => {
+			// For single text, use the simpler texts array format
+			(Some(vec![text]), None)
+		}
+		crate::embed::EmbedInput::Batch(texts) => {
+			// For batch, use the texts array format
+			(Some(texts), None)
+		}
+	};
+
+	// Determine embedding types - default to float
+	let embedding_types = {
+		let format = options_set.encoding_format().unwrap_or("float");
+		let embedding_type = match format {
+			"float" | "int8" | "uint8" | "binary" | "ubinary" => format,
+			_ => "float",
+		};
+		Some(vec![embedding_type.to_string()])
+	};
+
+	let cohere_req = CohereEmbedRequest {
+		texts,
+		inputs,
+		model: model_name.to_string(),
+		input_type: options_set.embedding_type().unwrap_or("search_document").to_string(),
+		embedding_types,
+		truncate: options_set
+			.truncate()
+			.map(|s| s.to_string())
+			.or_else(|| Some("END".to_string())),
+		output_dimension: options_set.dimensions(),
+	};
+
+	let payload = serde_json::to_value(cohere_req).map_err(|serde_error| Error::StreamParse {
+		model_iden: model.clone(),
+		serde_error,
+	})?;
+
+	// Get the service URL
+	let url = <crate::adapter::cohere::CohereAdapter as Adapter>::get_service_url(
+		&model,
+		ServiceType::Embed,
+		service_target.endpoint,
+	);
+
+	Ok(WebRequestData { url, headers, payload })
+}
+
+pub fn to_embed_response(
+	model_iden: ModelIden,
+	web_response: WebResponse,
+	options_set: EmbedOptionsSet<'_, '_>,
+) -> Result<EmbedResponse> {
+	let WebResponse { body, .. } = web_response;
+
+	// Parse the Cohere response
+	let cohere_res: CohereEmbedResponse =
+		serde_json::from_value(body.clone()).map_err(|serde_error| Error::StreamParse {
+			model_iden: model_iden.clone(),
+			serde_error,
+		})?;
+
+	// Extract embedding vectors, converting all types to f32
+	let embedding_vectors = {
+		let embeddings = &cohere_res.embeddings;
+
+		if let Some(float_embeddings) = &embeddings.float_embeddings {
+			float_embeddings.clone()
+		} else if let Some(int8_embeddings) = &embeddings.int8 {
+			int8_embeddings
+				.iter()
+				.map(|vec| vec.iter().map(|&v| v as f32).collect())
+				.collect()
+		} else if let Some(uint8_embeddings) = &embeddings.uint8 {
+			uint8_embeddings
+				.iter()
+				.map(|vec| vec.iter().map(|&v| v as f32).collect())
+				.collect()
+		} else if let Some(binary_embeddings) = &embeddings.binary {
+			binary_embeddings
+				.iter()
+				.map(|vec| vec.iter().map(|&v| v as f32).collect())
+				.collect()
+		} else if let Some(ubinary_embeddings) = &embeddings.ubinary {
+			ubinary_embeddings
+				.iter()
+				.map(|vec| vec.iter().map(|&v| v as f32).collect())
+				.collect()
+		} else {
+			return Err(Error::StreamParse {
+				model_iden: model_iden.clone(),
+				serde_error: serde_json::from_str::<()>("No embedding data found in response").unwrap_err(),
+			});
+		}
+	};
+
+	// Convert to our format
+	let embeddings: Vec<Embedding> = embedding_vectors
+		.into_iter()
+		.enumerate()
+		.map(|(index, vector)| Embedding::new(vector, index))
+		.collect();
+
+	// Log any API warnings and debug info
+	if let Some(meta) = &cohere_res.meta {
+		if let Some(warnings) = &meta.warnings {
+			for warning in warnings {
+				eprintln!("Cohere API Warning: {}", warning);
+			}
+		}
+	}
+
+	// Create usage information
+	let usage = Usage {
+		prompt_tokens: cohere_res
+			.meta
+			.as_ref()
+			.and_then(|m| m.billed_units.as_ref())
+			.and_then(|b| b.input_tokens)
+			.map(|t| t as i32),
+		completion_tokens: None, // Embeddings don't have output tokens
+		total_tokens: cohere_res
+			.meta
+			.as_ref()
+			.and_then(|m| m.billed_units.as_ref())
+			.and_then(|b| b.input_tokens)
+			.map(|t| t as i32),
+		prompt_tokens_details: None,
+		completion_tokens_details: None,
+	};
+
+	// Create provider model identifier
+	let provider_model_iden = ModelIden {
+		adapter_kind: model_iden.adapter_kind,
+		model_name: model_iden.model_name.clone(),
+	};
+
+	let mut response = EmbedResponse::new(embeddings, model_iden, provider_model_iden, usage);
+
+	// Capture raw body if requested
+	if options_set.capture_raw_body() {
+		response = response.with_captured_raw_body(body);
+	}
+
+	Ok(response)
+}
+
+// endregion: --- Public Functions

--- a/src/adapter/adapters/cohere/mod.rs
+++ b/src/adapter/adapters/cohere/mod.rs
@@ -5,6 +5,7 @@
 // region:    --- Modules
 
 mod adapter_impl;
+mod embed;
 mod streamer;
 
 pub use adapter_impl::*;

--- a/src/adapter/adapters/deepseek/adapter_impl.rs
+++ b/src/adapter/adapters/deepseek/adapter_impl.rs
@@ -58,4 +58,20 @@ impl Adapter for DeepSeekAdapter {
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
 	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
 }

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -61,6 +61,7 @@ impl Adapter for GeminiAdapter {
 		match service_type {
 			ServiceType::Chat => format!("{base_url}models/{model_name}:generateContent"),
 			ServiceType::ChatStream => format!("{base_url}models/{model_name}:streamGenerateContent"),
+			ServiceType::Embed => format!("{base_url}models/{model_name}:embedContent"), // Gemini embeddings API
 		}
 	}
 
@@ -243,6 +244,22 @@ impl Adapter for GeminiAdapter {
 			model_iden,
 			stream: chat_stream,
 		})
+	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		super::embed::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		super::embed::to_embed_response(model_iden, web_response, options_set)
 	}
 }
 

--- a/src/adapter/adapters/gemini/embed.rs
+++ b/src/adapter/adapters/gemini/embed.rs
@@ -1,0 +1,239 @@
+//! Gemini Embeddings API implementation
+//! API Documentation: https://ai.google.dev/gemini-api/docs/embeddings
+
+use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::{Adapter, ServiceType, WebRequestData};
+use crate::chat::Usage;
+use crate::embed::{EmbedOptionsSet, EmbedRequest, EmbedResponse, Embedding};
+use crate::webc::WebResponse;
+use crate::{Error, Headers, ModelIden, Result, ServiceTarget};
+use serde::{Deserialize, Serialize};
+
+// region:    --- Gemini Embed Request
+
+#[derive(Debug, Serialize)]
+struct GeminiEmbedRequest {
+	model: String,
+	content: GeminiContent,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(rename = "taskType")]
+	task_type: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(rename = "outputDimensionality")]
+	output_dimensionality: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiBatchEmbedRequest {
+	requests: Vec<GeminiEmbedContentRequest>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiEmbedContentRequest {
+	model: String,
+	content: GeminiContent,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(rename = "taskType")]
+	task_type: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(rename = "outputDimensionality")]
+	output_dimensionality: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiContent {
+	parts: Vec<GeminiPart>,
+}
+
+#[derive(Debug, Serialize)]
+struct GeminiPart {
+	text: String,
+}
+
+// endregion: --- Gemini Embed Request
+
+// region:    --- Gemini Embed Response
+
+#[derive(Debug, Deserialize)]
+struct GeminiEmbedResponse {
+	#[serde(rename = "embedding")]
+	embedding: GeminiEmbedding,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiBatchEmbedResponse {
+	#[serde(rename = "embeddings")]
+	embeddings: Vec<GeminiEmbedding>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiEmbedding {
+	values: Vec<f32>,
+}
+
+// endregion: --- Gemini Embed Response
+
+// region:    --- Public Functions
+
+pub fn to_embed_request_data(
+	service_target: ServiceTarget,
+	embed_req: EmbedRequest,
+	options_set: EmbedOptionsSet<'_, '_>,
+) -> Result<WebRequestData> {
+	let ServiceTarget { model, auth, .. } = service_target;
+	let api_key = get_api_key(auth, &model)?;
+
+	// Extract the actual model name (without namespace) - not needed for Gemini request body
+	let (_model_name, _) = model.model_name.as_model_name_and_namespace();
+
+	// Build headers - Gemini uses x-goog-api-key header
+	let mut headers = Headers::from(vec![
+		("x-goog-api-key".to_string(), api_key),
+		("Content-Type".to_string(), "application/json".to_string()),
+	]);
+
+	// Add custom headers from options
+	if let Some(custom_headers) = options_set.headers() {
+		headers.merge_with(custom_headers);
+	}
+
+	// Get the model name for the request
+	let (model_name, _) = model.model_name.as_model_name_and_namespace();
+	let full_model_name = format!("models/{}", model_name);
+
+	// Convert EmbedRequest to Gemini format and determine URL
+	let (payload, is_batch) = match embed_req.input {
+		crate::embed::EmbedInput::Single(text) => {
+			// Handle empty text edge case - Gemini API returns 429 for empty strings
+			let processed_text = if text.trim().is_empty() {
+				" ".to_string() // Use a single space instead of empty string
+			} else {
+				text
+			};
+
+			// Single embedding request
+			let gemini_req = GeminiEmbedRequest {
+				model: full_model_name,
+				content: GeminiContent {
+					parts: vec![GeminiPart { text: processed_text }],
+				},
+				task_type: options_set
+					.embedding_type()
+					.map(|s| s.to_string())
+					.or_else(|| Some("SEMANTIC_SIMILARITY".to_string())),
+				output_dimensionality: options_set.dimensions(),
+			};
+
+			let payload = serde_json::to_value(gemini_req).map_err(|serde_error| Error::StreamParse {
+				model_iden: model.clone(),
+				serde_error,
+			})?;
+
+			(payload, false)
+		}
+		crate::embed::EmbedInput::Batch(texts) => {
+			// Batch embedding request
+			let requests: Vec<GeminiEmbedContentRequest> = texts
+				.into_iter()
+				.map(|text| {
+					// Handle empty text edge case - Gemini API returns 429 for empty strings
+					let processed_text = if text.trim().is_empty() {
+						" ".to_string() // Use a single space instead of empty string
+					} else {
+						text
+					};
+
+					GeminiEmbedContentRequest {
+						model: full_model_name.clone(),
+						content: GeminiContent {
+							parts: vec![GeminiPart { text: processed_text }],
+						},
+						task_type: options_set
+							.embedding_type()
+							.map(|s| s.to_string())
+							.or_else(|| Some("SEMANTIC_SIMILARITY".to_string())),
+						output_dimensionality: options_set.dimensions(),
+					}
+				})
+				.collect();
+
+			let gemini_req = GeminiBatchEmbedRequest { requests };
+
+			let payload = serde_json::to_value(gemini_req).map_err(|serde_error| Error::StreamParse {
+				model_iden: model.clone(),
+				serde_error,
+			})?;
+
+			(payload, true)
+		}
+	};
+
+	// Get the service URL and modify it for batch requests
+	let mut url = <crate::adapter::gemini::GeminiAdapter as Adapter>::get_service_url(
+		&model,
+		ServiceType::Embed,
+		service_target.endpoint,
+	);
+
+	// For batch requests, change :embedContent to :batchEmbedContents
+	if is_batch {
+		url = url.replace(":embedContent", ":batchEmbedContents");
+	}
+
+	Ok(WebRequestData { url, headers, payload })
+}
+
+pub fn to_embed_response(
+	model_iden: ModelIden,
+	web_response: WebResponse,
+	options_set: EmbedOptionsSet<'_, '_>,
+) -> Result<EmbedResponse> {
+	let WebResponse { body, .. } = web_response;
+
+	// Parse the Gemini response - try single first, then batch
+	let embedding_vectors = if let Ok(single_res) = serde_json::from_value::<GeminiEmbedResponse>(body.clone()) {
+		// Single embedding response
+		vec![single_res.embedding.values]
+	} else if let Ok(batch_res) = serde_json::from_value::<GeminiBatchEmbedResponse>(body.clone()) {
+		// Batch embedding response
+		batch_res.embeddings.into_iter().map(|e| e.values).collect()
+	} else {
+		return Err(Error::StreamParse {
+			model_iden: model_iden.clone(),
+			serde_error: serde_json::from_str::<()>("").unwrap_err(), // Create a dummy serde error
+		});
+	};
+
+	// Convert to our format
+	let embeddings: Vec<Embedding> = embedding_vectors
+		.into_iter()
+		.enumerate()
+		.map(|(index, vector)| Embedding::new(vector, index))
+		.collect();
+
+	// Create usage information - Gemini doesn't provide token counts in embedding responses
+	let usage = Usage {
+		prompt_tokens: None, // Gemini doesn't provide token counts for embeddings
+		completion_tokens: None,
+		total_tokens: None,
+		prompt_tokens_details: None,
+		completion_tokens_details: None,
+	};
+
+	// Create provider model identifier
+	let provider_model_iden = ModelIden {
+		adapter_kind: model_iden.adapter_kind,
+		model_name: model_iden.model_name.clone(),
+	};
+
+	let mut response = EmbedResponse::new(embeddings, model_iden, provider_model_iden, usage);
+
+	// Capture raw body if requested
+	if options_set.capture_raw_body() {
+		response = response.with_captured_raw_body(body);
+	}
+
+	Ok(response)
+}
+
+// endregion: --- Public Functions

--- a/src/adapter/adapters/gemini/mod.rs
+++ b/src/adapter/adapters/gemini/mod.rs
@@ -5,6 +5,7 @@
 // region:    --- Modules
 
 mod adapter_impl;
+mod embed;
 mod streamer;
 
 pub use adapter_impl::*;

--- a/src/adapter/adapters/groq/adapter_impl.rs
+++ b/src/adapter/adapters/groq/adapter_impl.rs
@@ -85,4 +85,26 @@ impl Adapter for GroqAdapter {
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
 	}
+
+	fn to_embed_request_data(
+		_service_target: crate::ServiceTarget,
+		_embed_req: crate::embed::EmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		Err(crate::Error::AdapterNotSupported {
+			adapter_kind: crate::adapter::AdapterKind::Groq,
+			feature: "embeddings".to_string(),
+		})
+	}
+
+	fn to_embed_response(
+		_model_iden: crate::ModelIden,
+		_web_response: crate::webc::WebResponse,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(crate::Error::AdapterNotSupported {
+			adapter_kind: crate::adapter::AdapterKind::Groq,
+			feature: "embeddings".to_string(),
+		})
+	}
 }

--- a/src/adapter/adapters/nebius/adapter_impl.rs
+++ b/src/adapter/adapters/nebius/adapter_impl.rs
@@ -90,4 +90,20 @@ impl Adapter for NebiusAdapter {
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
 	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
 }

--- a/src/adapter/adapters/ollama/adapter_impl.rs
+++ b/src/adapter/adapters/ollama/adapter_impl.rs
@@ -87,4 +87,20 @@ impl Adapter for OllamaAdapter {
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
 	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
 }

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -154,6 +154,22 @@ impl Adapter for OpenAIAdapter {
 			stream: chat_stream,
 		})
 	}
+
+	fn to_embed_request_data(
+		service_target: ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		super::embed::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		super::embed::to_embed_response(model_iden, web_response, options_set)
+	}
 }
 
 /// Support functions for other adapters that share OpenAI APIs
@@ -171,6 +187,7 @@ impl OpenAIAdapter {
 
 		let suffix = match service_type {
 			ServiceType::Chat | ServiceType::ChatStream => "chat/completions",
+			ServiceType::Embed => "embeddings",
 		};
 		let mut full_url = base_url.join(suffix).unwrap();
 		full_url.set_query(original_query_params);

--- a/src/adapter/adapters/openai/embed.rs
+++ b/src/adapter/adapters/openai/embed.rs
@@ -1,0 +1,157 @@
+//! OpenAI Embeddings API implementation
+//! API Documentation: https://platform.openai.com/docs/api-reference/embeddings
+
+use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::{Adapter, ServiceType, WebRequestData};
+use crate::chat::Usage;
+use crate::embed::{EmbedOptionsSet, EmbedRequest, EmbedResponse, Embedding};
+use crate::webc::WebResponse;
+use crate::{Error, Headers, ModelIden, Result, ServiceTarget};
+use serde::{Deserialize, Serialize};
+
+// region:    --- OpenAI Embed Request
+
+#[derive(Debug, Serialize)]
+struct OpenAIEmbedRequest {
+	input: OpenAIEmbedInput,
+	model: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	encoding_format: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	dimensions: Option<usize>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	user: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum OpenAIEmbedInput {
+	Single(String),
+	Batch(Vec<String>),
+}
+
+// endregion: --- OpenAI Embed Request
+
+// region:    --- OpenAI Embed Response
+
+#[derive(Debug, Deserialize)]
+struct OpenAIEmbedResponse {
+	data: Vec<OpenAIEmbedData>,
+	model: String,
+	usage: OpenAIEmbedUsage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIEmbedData {
+	embedding: Vec<f32>,
+	index: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIEmbedUsage {
+	prompt_tokens: u32,
+	total_tokens: u32,
+}
+
+// endregion: --- OpenAI Embed Response
+
+// region:    --- Public Functions
+
+pub fn to_embed_request_data(
+	service_target: ServiceTarget,
+	embed_req: EmbedRequest,
+	options_set: EmbedOptionsSet<'_, '_>,
+) -> Result<WebRequestData> {
+	let ServiceTarget { model, auth, .. } = service_target;
+	let api_key = get_api_key(auth, &model)?;
+
+	// Build headers
+	let mut headers = Headers::from(vec![
+		("Authorization".to_string(), format!("Bearer {api_key}")),
+		("Content-Type".to_string(), "application/json".to_string()),
+	]);
+
+	// Add custom headers from options
+	if let Some(custom_headers) = options_set.headers() {
+		headers.merge_with(custom_headers);
+	}
+
+	// Convert EmbedRequest to OpenAI format
+	let input = match embed_req.input {
+		crate::embed::EmbedInput::Single(text) => OpenAIEmbedInput::Single(text),
+		crate::embed::EmbedInput::Batch(texts) => OpenAIEmbedInput::Batch(texts),
+	};
+
+	// Extract the actual model name (without namespace)
+	let (model_name, _) = model.model_name.as_model_name_and_namespace();
+
+	let openai_req = OpenAIEmbedRequest {
+		input,
+		model: model_name.to_string(),
+		encoding_format: options_set.encoding_format().map(|s| s.to_string()),
+		dimensions: options_set.dimensions(),
+		user: options_set.user().map(|s| s.to_string()),
+	};
+
+	let payload = serde_json::to_value(openai_req).map_err(|serde_error| Error::StreamParse {
+		model_iden: model.clone(),
+		serde_error,
+	})?;
+
+	// Get the service URL
+	let url = <crate::adapter::openai::OpenAIAdapter as Adapter>::get_service_url(
+		&model,
+		ServiceType::Embed,
+		service_target.endpoint,
+	);
+
+	Ok(WebRequestData { url, headers, payload })
+}
+
+pub fn to_embed_response(
+	model_iden: ModelIden,
+	web_response: WebResponse,
+	options_set: EmbedOptionsSet<'_, '_>,
+) -> Result<EmbedResponse> {
+	let WebResponse { body, .. } = web_response;
+
+	// Parse the OpenAI response
+	let openai_res: OpenAIEmbedResponse =
+		serde_json::from_value(body.clone()).map_err(|serde_error| Error::StreamParse {
+			model_iden: model_iden.clone(),
+			serde_error,
+		})?;
+
+	// Convert to our format
+	let embeddings: Vec<Embedding> = openai_res
+		.data
+		.into_iter()
+		.map(|data| Embedding::new(data.embedding, data.index))
+		.collect();
+
+	// Create usage information
+	let usage = Usage {
+		prompt_tokens: Some(openai_res.usage.prompt_tokens as i32),
+		completion_tokens: None, // Embeddings don't have output tokens
+		total_tokens: Some(openai_res.usage.total_tokens as i32),
+		prompt_tokens_details: None,
+		completion_tokens_details: None,
+	};
+
+	// Create provider model identifier
+	let provider_model_iden = ModelIden {
+		adapter_kind: model_iden.adapter_kind,
+		model_name: openai_res.model.into(),
+	};
+
+	let mut response = EmbedResponse::new(embeddings, model_iden, provider_model_iden, usage);
+
+	// Capture raw body if requested
+	if options_set.capture_raw_body() {
+		response = response.with_captured_raw_body(body);
+	}
+
+	Ok(response)
+}
+
+// endregion: --- Public Functions

--- a/src/adapter/adapters/openai/mod.rs
+++ b/src/adapter/adapters/openai/mod.rs
@@ -5,6 +5,7 @@
 // region:    --- Modules
 
 mod adapter_impl;
+mod embed;
 mod streamer;
 
 pub use adapter_impl::*;

--- a/src/adapter/adapters/xai/adapter_impl.rs
+++ b/src/adapter/adapters/xai/adapter_impl.rs
@@ -58,4 +58,20 @@ impl Adapter for XaiAdapter {
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
 	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
 }

--- a/src/adapter/adapters/zhipu/adapter_impl.rs
+++ b/src/adapter/adapters/zhipu/adapter_impl.rs
@@ -76,4 +76,20 @@ impl Adapter for ZhipuAdapter {
 	) -> Result<ChatStreamResponse> {
 		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
 	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
 }

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -6,6 +6,7 @@ use crate::adapter::ollama::OllamaAdapter;
 use crate::adapter::openai::OpenAIAdapter;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::embed::{EmbedOptionsSet, EmbedRequest, EmbedResponse};
 use crate::webc::WebResponse;
 use crate::{Result, ServiceTarget};
 use reqwest::RequestBuilder;
@@ -143,6 +144,45 @@ impl AdapterDispatcher {
 			AdapterKind::Xai => XaiAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Zhipu => ZhipuAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+		}
+	}
+
+	pub fn to_embed_request_data(
+		target: ServiceTarget,
+		embed_req: EmbedRequest,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		let adapter_kind = &target.model.adapter_kind;
+		match adapter_kind {
+			AdapterKind::OpenAI => OpenAIAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Anthropic => AnthropicAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Cohere => CohereAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Ollama => OllamaAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Gemini => GeminiAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Groq => GroqAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Nebius => NebiusAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Xai => XaiAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::DeepSeek => DeepSeekAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Zhipu => ZhipuAdapter::to_embed_request_data(target, embed_req, options_set),
+		}
+	}
+
+	pub fn to_embed_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<EmbedResponse> {
+		match model_iden.adapter_kind {
+			AdapterKind::OpenAI => OpenAIAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Anthropic => AnthropicAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Cohere => CohereAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Ollama => OllamaAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Gemini => GeminiAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Groq => GroqAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Nebius => NebiusAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Xai => XaiAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::DeepSeek => DeepSeekAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Zhipu => ZhipuAdapter::to_embed_response(model_iden, web_response, options_set),
 		}
 	}
 }

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -1,6 +1,7 @@
 use crate::adapter::AdapterDispatcher;
 use crate::chat::ChatOptions;
 use crate::client::ServiceTarget;
+use crate::embed::EmbedOptions;
 use crate::resolver::{AuthResolver, ModelMapper, ServiceTargetResolver};
 use crate::{Error, ModelIden, Result, WebConfig};
 
@@ -12,6 +13,7 @@ pub struct ClientConfig {
 	pub(super) model_mapper: Option<ModelMapper>,
 	pub(super) web_config: Option<WebConfig>,
 	pub(super) chat_options: Option<ChatOptions>,
+	pub(super) embed_options: Option<EmbedOptions>,
 }
 
 /// Chainable setters related to the ClientConfig.
@@ -47,6 +49,12 @@ impl ClientConfig {
 		self
 	}
 
+	/// Set the default embed request options for the ClientConfig.
+	pub fn with_embed_options(mut self, options: EmbedOptions) -> Self {
+		self.embed_options = Some(options);
+		self
+	}
+
 	/// Set the reqwest client configuration options for the ClientConfig.
 	pub fn with_web_config(mut self, web_config: WebConfig) -> Self {
 		self.web_config = Some(web_config);
@@ -78,6 +86,11 @@ impl ClientConfig {
 	/// Get a reference to the ChatOptions, if they exist.
 	pub fn chat_options(&self) -> Option<&ChatOptions> {
 		self.chat_options.as_ref()
+	}
+
+	/// Get a reference to the EmbedOptions, if they exist.
+	pub fn embed_options(&self) -> Option<&EmbedOptions> {
+		self.embed_options.as_ref()
 	}
 }
 

--- a/src/embed/embed_options.rs
+++ b/src/embed/embed_options.rs
@@ -1,0 +1,236 @@
+//! EmbedOptions allows customization of an embed request.
+//! - It can be provided at the `client::embed(..)` level as an argument,
+//! - or set in the client config `client_config.with_embed_options(..)` to be used as the default for all requests
+
+use crate::Headers;
+use serde::{Deserialize, Serialize};
+
+// region:    --- EmbedOptions
+
+/// Options for customizing embedding requests.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EmbedOptions {
+	/// Custom headers to include in the request.
+	pub headers: Option<Headers>,
+
+	/// Whether to capture the raw response body for provider-specific features.
+	pub capture_raw_body: Option<bool>,
+
+	/// Whether to capture usage information (token counts, etc.).
+	pub capture_usage: Option<bool>,
+
+	/// The desired dimensionality of the embedding vectors (if supported by the provider).
+	/// Note: Not all providers support custom dimensions.
+	pub dimensions: Option<usize>,
+
+	/// The encoding format for the embeddings (if supported by the provider).
+	/// Common values: "float", "base64", "binary", etc.
+	pub encoding_format: Option<String>,
+
+	/// A unique identifier representing your end-user (for OpenAI and similar providers).
+	pub user: Option<String>,
+
+	/// The type/purpose of the embedding request.
+	/// - Cohere: "search_document", "search_query", "classification", "clustering"
+	/// - Gemini: "SEMANTIC_SIMILARITY", "RETRIEVAL_QUERY", "RETRIEVAL_DOCUMENT", "CLASSIFICATION"
+	///
+	/// Default: "search_document" (Cohere), "SEMANTIC_SIMILARITY" (Gemini)
+	pub embedding_type: Option<String>,
+
+	/// How to handle inputs longer than the maximum token length (supported by Cohere).
+	/// Common values: "NONE", "START", "END"
+	/// Default: "END"
+	pub truncate: Option<String>,
+}
+
+/// Constructors
+impl EmbedOptions {
+	/// Create a new EmbedOptions with default values.
+	pub fn new() -> Self {
+		Self::default()
+	}
+}
+
+/// Chainable Setters
+impl EmbedOptions {
+	/// Set custom headers for the request.
+	pub fn with_headers(mut self, headers: Headers) -> Self {
+		self.headers = Some(headers);
+		self
+	}
+
+	/// Enable or disable capturing the raw response body.
+	pub fn with_capture_raw_body(mut self, capture: bool) -> Self {
+		self.capture_raw_body = Some(capture);
+		self
+	}
+
+	/// Enable or disable capturing usage information.
+	pub fn with_capture_usage(mut self, capture: bool) -> Self {
+		self.capture_usage = Some(capture);
+		self
+	}
+
+	/// Set the desired dimensionality of the embedding vectors.
+	pub fn with_dimensions(mut self, dimensions: usize) -> Self {
+		self.dimensions = Some(dimensions);
+		self
+	}
+
+	/// Set the encoding format for the embeddings.
+	pub fn with_encoding_format(mut self, format: impl Into<String>) -> Self {
+		self.encoding_format = Some(format.into());
+		self
+	}
+
+	/// Set the user identifier.
+	pub fn with_user(mut self, user: impl Into<String>) -> Self {
+		self.user = Some(user.into());
+		self
+	}
+
+	/// Set the type/purpose of the embedding request.
+	pub fn with_embedding_type(mut self, embedding_type: impl Into<String>) -> Self {
+		self.embedding_type = Some(embedding_type.into());
+		self
+	}
+
+	/// Set the truncation method for inputs longer than the maximum token length.
+	pub fn with_truncate(mut self, truncate: impl Into<String>) -> Self {
+		self.truncate = Some(truncate.into());
+		self
+	}
+}
+
+/// Getters
+impl EmbedOptions {
+	/// Get the headers.
+	pub fn headers(&self) -> Option<&Headers> {
+		self.headers.as_ref()
+	}
+
+	/// Get whether to capture raw body.
+	pub fn capture_raw_body(&self) -> bool {
+		self.capture_raw_body.unwrap_or(false)
+	}
+
+	/// Get whether to capture usage.
+	pub fn capture_usage(&self) -> bool {
+		self.capture_usage.unwrap_or(true)
+	}
+
+	/// Get the desired dimensions.
+	pub fn dimensions(&self) -> Option<usize> {
+		self.dimensions
+	}
+
+	/// Get the encoding format.
+	pub fn encoding_format(&self) -> Option<&str> {
+		self.encoding_format.as_deref()
+	}
+
+	/// Get the user identifier.
+	pub fn user(&self) -> Option<&str> {
+		self.user.as_deref()
+	}
+
+	/// Get the type/purpose of the embedding request.
+	pub fn embedding_type(&self) -> Option<&str> {
+		self.embedding_type.as_deref()
+	}
+
+	/// Get the truncation method.
+	pub fn truncate(&self) -> Option<&str> {
+		self.truncate.as_deref()
+	}
+}
+
+// endregion: --- EmbedOptions
+
+// region:    --- EmbedOptionsSet
+
+/// A set of EmbedOptions that can be layered (client-level defaults + request-level overrides).
+#[derive(Debug, Clone, Default)]
+pub struct EmbedOptionsSet<'client, 'request> {
+	client_options: Option<&'client EmbedOptions>,
+	request_options: Option<&'request EmbedOptions>,
+}
+
+impl<'client, 'request> EmbedOptionsSet<'client, 'request> {
+	/// Create a new EmbedOptionsSet.
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	/// Set the client-level options.
+	pub fn with_client_options(mut self, options: Option<&'client EmbedOptions>) -> Self {
+		self.client_options = options;
+		self
+	}
+
+	/// Set the request-level options.
+	pub fn with_request_options(mut self, options: Option<&'request EmbedOptions>) -> Self {
+		self.request_options = options;
+		self
+	}
+
+	/// Get the effective headers (request overrides client).
+	pub fn headers(&self) -> Option<&Headers> {
+		self.request_options
+			.and_then(|o| o.headers())
+			.or_else(|| self.client_options.and_then(|o| o.headers()))
+	}
+
+	/// Get the effective capture_raw_body setting.
+	pub fn capture_raw_body(&self) -> bool {
+		self.request_options
+			.map(|o| o.capture_raw_body())
+			.or_else(|| self.client_options.map(|o| o.capture_raw_body()))
+			.unwrap_or(false)
+	}
+
+	/// Get the effective capture_usage setting.
+	pub fn capture_usage(&self) -> bool {
+		self.request_options
+			.map(|o| o.capture_usage())
+			.or_else(|| self.client_options.map(|o| o.capture_usage()))
+			.unwrap_or(true)
+	}
+
+	/// Get the effective dimensions setting.
+	pub fn dimensions(&self) -> Option<usize> {
+		self.request_options
+			.and_then(|o| o.dimensions())
+			.or_else(|| self.client_options.and_then(|o| o.dimensions()))
+	}
+
+	/// Get the effective encoding_format setting.
+	pub fn encoding_format(&self) -> Option<&str> {
+		self.request_options
+			.and_then(|o| o.encoding_format())
+			.or_else(|| self.client_options.and_then(|o| o.encoding_format()))
+	}
+
+	/// Get the effective user setting.
+	pub fn user(&self) -> Option<&str> {
+		self.request_options
+			.and_then(|o| o.user())
+			.or_else(|| self.client_options.and_then(|o| o.user()))
+	}
+
+	/// Get the effective embedding type setting.
+	pub fn embedding_type(&self) -> Option<&str> {
+		self.request_options
+			.and_then(|o| o.embedding_type())
+			.or_else(|| self.client_options.and_then(|o| o.embedding_type()))
+	}
+
+	/// Get the effective truncate setting.
+	pub fn truncate(&self) -> Option<&str> {
+		self.request_options
+			.and_then(|o| o.truncate())
+			.or_else(|| self.client_options.and_then(|o| o.truncate()))
+	}
+}
+
+// endregion: --- EmbedOptionsSet

--- a/src/embed/embed_request.rs
+++ b/src/embed/embed_request.rs
@@ -1,0 +1,111 @@
+//! This module contains all the types related to an Embed Request.
+
+use serde::{Deserialize, Serialize};
+
+// region:    --- EmbedRequest
+
+/// The Embed request for performing embedding operations with `Client::embed` or `Client::embed_batch`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedRequest {
+    /// The input text(s) to embed.
+    pub input: EmbedInput,
+}
+
+/// Constructors
+impl EmbedRequest {
+    /// Create a new EmbedRequest with a single text input.
+    pub fn new(input: impl Into<String>) -> Self {
+        Self {
+            input: EmbedInput::Single(input.into()),
+        }
+    }
+
+    /// Create a new EmbedRequest with multiple text inputs for batch processing.
+    pub fn new_batch(inputs: Vec<String>) -> Self {
+        Self {
+            input: EmbedInput::Batch(inputs),
+        }
+    }
+
+    /// Create an EmbedRequest from a single string.
+    pub fn from_text(text: impl Into<String>) -> Self {
+        Self::new(text)
+    }
+
+    /// Create an EmbedRequest from multiple strings.
+    pub fn from_texts(texts: Vec<String>) -> Self {
+        Self::new_batch(texts)
+    }
+}
+
+/// Getters
+impl EmbedRequest {
+    /// Get the input as a single string if it's a single input, None otherwise.
+    pub fn single_input(&self) -> Option<&str> {
+        match &self.input {
+            EmbedInput::Single(text) => Some(text),
+            EmbedInput::Batch(_) => None,
+        }
+    }
+
+    /// Get the input as a vector of strings.
+    /// For single input, returns a vector with one element.
+    pub fn inputs(&self) -> Vec<&str> {
+        match &self.input {
+            EmbedInput::Single(text) => vec![text],
+            EmbedInput::Batch(texts) => texts.iter().map(|s| s.as_str()).collect(),
+        }
+    }
+
+    /// Check if this is a batch request.
+    pub fn is_batch(&self) -> bool {
+        matches!(self.input, EmbedInput::Batch(_))
+    }
+
+    /// Get the number of inputs.
+    pub fn input_count(&self) -> usize {
+        match &self.input {
+            EmbedInput::Single(_) => 1,
+            EmbedInput::Batch(texts) => texts.len(),
+        }
+    }
+}
+
+// endregion: --- EmbedRequest
+
+// region:    --- EmbedInput
+
+/// The input for an embedding request, supporting both single and batch operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EmbedInput {
+    /// A single text input.
+    Single(String),
+    /// Multiple text inputs for batch processing.
+    Batch(Vec<String>),
+}
+
+impl From<String> for EmbedInput {
+    fn from(text: String) -> Self {
+        EmbedInput::Single(text)
+    }
+}
+
+impl From<&str> for EmbedInput {
+    fn from(text: &str) -> Self {
+        EmbedInput::Single(text.to_string())
+    }
+}
+
+impl From<Vec<String>> for EmbedInput {
+    fn from(texts: Vec<String>) -> Self {
+        EmbedInput::Batch(texts)
+    }
+}
+
+impl From<Vec<&str>> for EmbedInput {
+    fn from(texts: Vec<&str>) -> Self {
+        EmbedInput::Batch(texts.into_iter().map(|s| s.to_string()).collect())
+    }
+}
+
+// endregion: --- EmbedInput

--- a/src/embed/embed_response.rs
+++ b/src/embed/embed_response.rs
@@ -1,0 +1,154 @@
+//! This module contains all the types related to an Embed Response.
+
+use crate::ModelIden;
+use crate::chat::Usage;
+use serde::{Deserialize, Serialize};
+
+// region:    --- EmbedResponse
+
+/// The Embed response when performing a direct `Client::embed` or `Client::embed_batch`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedResponse {
+	/// The embedding vectors.
+	pub embeddings: Vec<Embedding>,
+
+	/// The resolved Model Identifier (AdapterKind/ModelName) used for this request.
+	pub model_iden: ModelIden,
+
+	/// The provider model iden. Will be `model_iden` if not returned or mapped, but can be different.
+	/// For example, `text-embedding-3-small` model_iden might have a provider_model_iden as `text-embedding-3-small-2024-01-01`
+	pub provider_model_iden: ModelIden,
+
+	/// The eventual usage of the embed response (token counts, etc.)
+	pub usage: Usage,
+
+	/// The raw value of the response body, which can be used for provider specific features.
+	pub captured_raw_body: Option<serde_json::Value>,
+}
+
+/// Constructors
+impl EmbedResponse {
+	/// Create a new EmbedResponse.
+	pub fn new(
+		embeddings: Vec<Embedding>,
+		model_iden: ModelIden,
+		provider_model_iden: ModelIden,
+		usage: Usage,
+	) -> Self {
+		Self {
+			embeddings,
+			model_iden,
+			provider_model_iden,
+			usage,
+			captured_raw_body: None,
+		}
+	}
+
+	/// Create a new EmbedResponse with captured raw body.
+	pub fn with_captured_raw_body(mut self, raw_body: serde_json::Value) -> Self {
+		self.captured_raw_body = Some(raw_body);
+		self
+	}
+}
+
+/// Getters
+impl EmbedResponse {
+	/// Get the first embedding if available.
+	pub fn first_embedding(&self) -> Option<&Embedding> {
+		self.embeddings.first()
+	}
+
+	/// Get the first embedding vector if available.
+	pub fn first_vector(&self) -> Option<&Vec<f32>> {
+		self.first_embedding().map(|e| &e.vector)
+	}
+
+	/// Get all embedding vectors.
+	pub fn vectors(&self) -> Vec<&Vec<f32>> {
+		self.embeddings.iter().map(|e| &e.vector).collect()
+	}
+
+	/// Get all embedding vectors as owned data.
+	pub fn into_vectors(self) -> Vec<Vec<f32>> {
+		self.embeddings.into_iter().map(|e| e.vector).collect()
+	}
+
+	/// Check if this is a single embedding response.
+	pub fn is_single(&self) -> bool {
+		self.embeddings.len() == 1
+	}
+
+	/// Check if this is a batch embedding response.
+	pub fn is_batch(&self) -> bool {
+		self.embeddings.len() > 1
+	}
+
+	/// Get the number of embeddings.
+	pub fn embedding_count(&self) -> usize {
+		self.embeddings.len()
+	}
+}
+
+// endregion: --- EmbedResponse
+
+// region:    --- Embedding
+
+/// A single embedding vector with metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Embedding {
+	/// The embedding vector.
+	pub vector: Vec<f32>,
+
+	/// The index of this embedding in the original request (for batch operations).
+	pub index: usize,
+
+	/// The dimensionality of the embedding vector.
+	pub dimensions: usize,
+}
+
+/// Constructors
+impl Embedding {
+	/// Create a new Embedding.
+	pub fn new(vector: Vec<f32>, index: usize) -> Self {
+		let dimensions = vector.len();
+		Self {
+			vector,
+			index,
+			dimensions,
+		}
+	}
+
+	/// Create a new Embedding with explicit dimensions.
+	pub fn with_dimensions(vector: Vec<f32>, index: usize, dimensions: usize) -> Self {
+		Self {
+			vector,
+			index,
+			dimensions,
+		}
+	}
+}
+
+/// Getters
+impl Embedding {
+	/// Get the embedding vector.
+	pub fn vector(&self) -> &Vec<f32> {
+		&self.vector
+	}
+
+	/// Get the embedding vector as owned data.
+	pub fn into_vector(self) -> Vec<f32> {
+		self.vector
+	}
+
+	/// Get the index of this embedding.
+	pub fn index(&self) -> usize {
+		self.index
+	}
+
+	/// Get the dimensionality of the embedding.
+	pub fn dimensions(&self) -> usize {
+		self.dimensions
+	}
+}
+
+// endregion: --- Embedding

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -1,0 +1,15 @@
+//! The genai embed module contains all of the constructs necessary
+//! to make embedding requests with the `genai::Client`.
+
+// region:    --- Modules
+
+mod embed_request;
+mod embed_response;
+mod embed_options;
+
+// -- Flatten
+pub use embed_request::*;
+pub use embed_response::*;
+pub use embed_options::*;
+
+// endregion: --- Modules

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,6 +93,10 @@ pub enum Error {
 		resolver_error: resolver::Error,
 	},
 
+	// -- Adapter Support
+	#[display("Adapter '{adapter_kind}' does not support feature '{feature}'")]
+	AdapterNotSupported { adapter_kind: AdapterKind, feature: String },
+
 	// -- Externals
 	#[display("Failed to clone EventSource request: {_0}")]
 	#[from]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use error::{Error, Result};
 // -- Public Modules
 pub mod adapter;
 pub mod chat;
+pub mod embed;
 pub mod resolver;
 pub mod webc;
 

--- a/tests/tests_p_cohere_embeddings.rs
+++ b/tests/tests_p_cohere_embeddings.rs
@@ -1,0 +1,49 @@
+mod support;
+
+use crate::support::{Result, common_tests};
+
+const MODEL: &str = "embed-english-v3.0";
+const MODEL_V4: &str = "embed-v4.0";
+const MODEL_NS: &str = "cohere::embed-english-v3.0";
+
+// region:    --- Single Embedding Tests
+
+#[tokio::test]
+async fn test_cohere_embed_single_simple_ok() -> Result<()> {
+	common_tests::common_test_embed_single_simple_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_cohere_embed_single_namespaced_ok() -> Result<()> {
+	common_tests::common_test_embed_single_simple_ok(MODEL_NS).await
+}
+
+#[tokio::test]
+async fn test_cohere_embed_single_with_options_ok() -> Result<()> {
+	common_tests::common_test_embed_single_with_options_ok(MODEL_V4).await
+}
+
+// endregion: --- Single Embedding Tests
+
+// region:    --- Batch Embedding Tests
+
+#[tokio::test]
+async fn test_cohere_embed_batch_simple_ok() -> Result<()> {
+	common_tests::common_test_embed_batch_simple_ok(MODEL_V4).await
+}
+
+#[tokio::test]
+async fn test_cohere_embed_batch_empty_should_fail() -> Result<()> {
+	common_tests::common_test_embed_empty_batch_should_fail(MODEL).await
+}
+
+// endregion: --- Batch Embedding Tests
+
+// region:    --- Provider-Specific Tests
+
+#[tokio::test]
+async fn test_cohere_embed_with_provider_specific_options_ok() -> Result<()> {
+	common_tests::common_test_embed_provider_specific_options_ok(MODEL_V4, "search_query", Some("START")).await
+}
+
+// endregion: --- Provider-Specific Tests

--- a/tests/tests_p_gemini_embeddings.rs
+++ b/tests/tests_p_gemini_embeddings.rs
@@ -1,0 +1,49 @@
+mod support;
+
+use crate::support::{Result, common_tests};
+
+const MODEL: &str = "gemini-embedding-001";
+const MODEL_NS: &str = "gemini::gemini-embedding-001";
+
+// region:    --- Single Embedding Tests
+
+#[tokio::test]
+async fn test_gemini_embed_single_simple_ok() -> Result<()> {
+	common_tests::common_test_embed_single_simple_ok_with_usage_check(MODEL, false).await
+}
+
+#[tokio::test]
+async fn test_gemini_embed_single_namespaced_ok() -> Result<()> {
+	common_tests::common_test_embed_single_simple_ok_with_usage_check(MODEL_NS, false).await
+}
+
+#[tokio::test]
+async fn test_gemini_embed_single_with_options_ok() -> Result<()> {
+	common_tests::common_test_embed_single_with_options_ok_with_usage_check(MODEL, false).await
+}
+
+// endregion: --- Single Embedding Tests
+
+// region:    --- Batch Embedding Tests
+
+#[tokio::test]
+async fn test_gemini_embed_batch_simple_ok() -> Result<()> {
+	common_tests::common_test_embed_batch_simple_ok_with_usage_check(MODEL, false).await
+}
+
+#[tokio::test]
+async fn test_gemini_embed_batch_empty_should_fail() -> Result<()> {
+	common_tests::common_test_embed_empty_batch_should_fail(MODEL).await
+}
+
+// endregion: --- Batch Embedding Tests
+
+// region:    --- Provider-Specific Tests
+
+#[tokio::test]
+async fn test_gemini_embed_with_provider_specific_options_ok() -> Result<()> {
+	common_tests::common_test_embed_provider_specific_options_ok_with_usage_check(MODEL, "RETRIEVAL_QUERY", None, false)
+		.await
+}
+
+// endregion: --- Provider-Specific Tests

--- a/tests/tests_p_openai_embeddings.rs
+++ b/tests/tests_p_openai_embeddings.rs
@@ -1,0 +1,206 @@
+mod support;
+
+use crate::support::{Result, common_tests};
+use genai::Client;
+use genai::embed::{EmbedOptions, EmbedRequest};
+
+const MODEL: &str = "text-embedding-3-small";
+const MODEL_LARGE: &str = "text-embedding-3-large";
+const MODEL_NS: &str = "openai::text-embedding-3-small";
+
+// region:    --- Single Embedding Tests
+
+#[tokio::test]
+async fn test_embed_single_simple_ok() -> Result<()> {
+	common_tests::common_test_embed_single_simple_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_embed_single_namespaced_ok() -> Result<()> {
+	common_tests::common_test_embed_single_simple_ok(MODEL_NS).await
+}
+
+#[tokio::test]
+async fn test_embed_single_with_options_ok() -> Result<()> {
+	common_tests::common_test_embed_single_with_options_ok(MODEL).await
+}
+
+// endregion: --- Single Embedding Tests
+
+// region:    --- Batch Embedding Tests
+
+#[tokio::test]
+async fn test_embed_batch_simple_ok() -> Result<()> {
+	common_tests::common_test_embed_batch_simple_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_embed_batch_empty_should_fail() -> Result<()> {
+	common_tests::common_test_embed_empty_batch_should_fail(MODEL).await
+}
+
+// endregion: --- Batch Embedding Tests
+
+// region:    --- EmbedRequest Tests
+
+#[tokio::test]
+async fn test_embed_request_single_ok() -> Result<()> {
+	let client = Client::default();
+	let embed_req = EmbedRequest::from_text("Direct EmbedRequest test");
+
+	let response = client.exec_embed(MODEL, embed_req, None).await?;
+
+	assert_eq!(response.embedding_count(), 1);
+	let embedding = response.first_embedding().unwrap();
+	assert!(embedding.dimensions() > 0);
+
+	println!("✓ EmbedRequest single: {} dimensions", embedding.dimensions());
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_embed_request_batch_ok() -> Result<()> {
+	let client = Client::default();
+	let embed_req = EmbedRequest::from_texts(vec![
+		"Batch request text 1".to_string(),
+		"Batch request text 2".to_string(),
+	]);
+
+	let response = client.exec_embed(MODEL, embed_req, None).await?;
+
+	assert_eq!(response.embedding_count(), 2);
+	for embedding in &response.embeddings {
+		assert!(embedding.dimensions() > 0);
+	}
+
+	println!("✓ EmbedRequest batch: {} embeddings", response.embedding_count());
+
+	Ok(())
+}
+
+// endregion: --- EmbedRequest Tests
+
+// region:    --- Model Comparison Tests
+
+#[tokio::test]
+async fn test_embed_different_models_ok() -> Result<()> {
+	let client = Client::default();
+	let text = "Compare embedding models";
+
+	// Test small model
+	let response_small = client.embed(MODEL, text, None).await?;
+	let dims_small = response_small.first_embedding().unwrap().dimensions();
+
+	// Test large model
+	let response_large = client.embed(MODEL_LARGE, text, None).await?;
+	let dims_large = response_large.first_embedding().unwrap().dimensions();
+
+	// Large model should have more dimensions
+	assert!(dims_large >= dims_small);
+
+	println!(
+		"✓ Model comparison: small={} dims, large={} dims",
+		dims_small, dims_large
+	);
+
+	Ok(())
+}
+
+// endregion: --- Model Comparison Tests
+
+// region:    --- Error Tests
+
+#[tokio::test]
+async fn test_embed_invalid_model_should_fail() -> Result<()> {
+	let client = Client::default();
+	let text = "Test with invalid model";
+
+	let result = client.embed("invalid-embedding-model", text, None).await;
+
+	// This should fail
+	assert!(result.is_err());
+
+	println!("✓ Invalid model correctly failed");
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_embed_empty_text_should_work() -> Result<()> {
+	let client = Client::default();
+	let text = "";
+
+	// Empty text should still work (though may have minimal dimensions)
+	let response = client.embed(MODEL, text, None).await?;
+
+	assert_eq!(response.embedding_count(), 1);
+	let embedding = response.first_embedding().unwrap();
+	assert!(embedding.dimensions() > 0);
+
+	println!("✓ Empty text embedding: {} dimensions", embedding.dimensions());
+
+	Ok(())
+}
+
+// endregion: --- Error Tests
+
+// region:    --- Utility Tests
+
+#[tokio::test]
+async fn test_embed_response_methods_ok() -> Result<()> {
+	let client = Client::default();
+	let texts = vec!["First".to_string(), "Second".to_string()];
+
+	let response = client.embed_batch(MODEL, texts, None).await?;
+
+	// Test response methods
+	assert_eq!(response.embedding_count(), 2);
+	assert!(response.is_batch());
+	assert!(!response.is_single());
+
+	// Test vector access methods
+	let vectors = response.vectors();
+	assert_eq!(vectors.len(), 2);
+
+	let owned_vectors = response.clone().into_vectors();
+	assert_eq!(owned_vectors.len(), 2);
+
+	// Test first embedding access
+	let first = response.first_embedding().unwrap();
+	let first_vector = response.first_vector().unwrap();
+	assert_eq!(first.vector(), first_vector);
+
+	println!("✓ Response utility methods work correctly");
+
+	Ok(())
+}
+
+// endregion: --- Utility Tests
+
+// region:    --- Provider-Specific Tests
+
+#[tokio::test]
+async fn test_embed_with_openai_specific_options_ok() -> Result<()> {
+	// OpenAI supports encoding_format and user parameters
+	let client = Client::default();
+	let text = "Test with OpenAI-specific options";
+
+	let options = EmbedOptions::new()
+		.with_dimensions(512)
+		.with_capture_usage(true)
+		.with_encoding_format("float")
+		.with_user("test-user");
+
+	let response = client.embed(MODEL, text, Some(&options)).await?;
+
+	let embedding = response.first_embedding().unwrap();
+	assert!(embedding.dimensions() > 0);
+	assert!(response.usage.prompt_tokens.is_some());
+
+	println!("✓ OpenAI-specific options: {} dimensions", embedding.dimensions());
+
+	Ok(())
+}
+
+// endregion: --- Provider-Specific Tests


### PR DESCRIPTION
This pull request introduces comprehensive support for embedding APIs across multiple providers, including OpenAI, Cohere, and Gemini, while also ensuring compatibility with existing adapter implementations. The changes include adding embedding-specific methods to the `Adapter` trait, implementing provider-specific logic for embedding requests and responses, and adding examples to demonstrate the embedding API usage.