### PR TITLE
added ModelName partial eq implementations for string types

### DIFF
--- a/src/common/model_name.rs
+++ b/src/common/model_name.rs
@@ -69,6 +69,48 @@ impl Deref for ModelName {
 
 // endregion: --- Froms
 
+// region:    --- EQ
+
+// PartialEq implementations for various string types
+impl PartialEq<str> for ModelName {
+	fn eq(&self, other: &str) -> bool {
+		&*self.0 == other
+	}
+}
+
+impl PartialEq<&str> for ModelName {
+	fn eq(&self, other: &&str) -> bool {
+		&*self.0 == *other
+	}
+}
+
+impl PartialEq<String> for ModelName {
+	fn eq(&self, other: &String) -> bool {
+		&*self.0 == other
+	}
+}
+
+// Symmetric implementations (allow "string" == model_name)
+impl PartialEq<ModelName> for str {
+	fn eq(&self, other: &ModelName) -> bool {
+		self == &*other.0
+	}
+}
+
+impl PartialEq<ModelName> for &str {
+	fn eq(&self, other: &ModelName) -> bool {
+		*self == &*other.0
+	}
+}
+
+impl PartialEq<ModelName> for String {
+	fn eq(&self, other: &ModelName) -> bool {
+		self == &*other.0
+	}
+}
+
+// endregion: --- EQ
+
 // TODO: replace with derive_more Display
 impl std::fmt::Display for ModelName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Added simple `PartialEq` implementations for the `ModelName` type, which improved the ergonomics of my test code.

After this change, the following code works:

```rust
const MODEL_LOCAL_VLLM: &str = "google/gemma-3-4b-it";
const MODEL_ANTHROPIC: &str = "claude-3-haiku-20240307";
const MODEL_OPENAI: &str = "gpt-4o-mini";

const MODEL: &str = MODEL_LOCAL_VLLM;

...

fn service_target_resolver_fn(service_target: ServiceTarget) -> Result<ServiceTarget, genai::resolver::Error> {
    if service_target.model.model_name == MODEL_LOCAL_VLLM {
        let endpoint = Endpoint::from_static("http://localhost:8000/v1/");
        let auth = AuthData::from_single("");
        let model = ModelIden::new(AdapterKind::OpenAI, service_target.model.model_name);
        Ok(ServiceTarget { endpoint, auth, model })
    } else {
        Ok(service_target)
    }
}
```