### PR TITLE
Capture response body in ResponseFailedNotJson error

### DIFF
--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -3,26 +3,26 @@
 
 // region:    --- Modules
 
+mod binary;
 mod chat_message;
 mod chat_options;
 mod chat_req_response_format;
 mod chat_request;
 mod chat_response;
 mod chat_stream;
-mod binary;
 mod content_part;
 mod message_content;
 mod tool;
 mod usage;
 
 // -- Flatten
+pub use binary::*;
 pub use chat_message::*;
 pub use chat_options::*;
 pub use chat_req_response_format::*;
 pub use chat_request::*;
 pub use chat_response::*;
 pub use chat_stream::*;
-pub use binary::*;
 pub use content_part::*;
 pub use message_content::*;
 pub use tool::*;

--- a/src/webc/error.rs
+++ b/src/webc/error.rs
@@ -8,8 +8,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[allow(missing_docs)]
 #[derive(Debug, From, Display)]
 pub enum Error {
-	#[display("Response content type '{content_type}' is not JSON as expected.")]
-	ResponseFailedNotJson { content_type: String },
+	#[display("Response content type '{content_type}' is not JSON as expected. Response body:\n{body}")]
+	ResponseFailedNotJson { content_type: String, body: String },
 
 	#[display("Request failed with status code '{status}'. Response body:\n{body}")]
 	ResponseFailedStatus {

--- a/src/webc/web_client.rs
+++ b/src/webc/web_client.rs
@@ -108,8 +108,10 @@ impl WebResponse {
 		let body = if ct.starts_with("application/json") {
 			res.json::<Value>().await?
 		} else {
+			let body = res.text().await?;
 			return Err(Error::ResponseFailedNotJson {
 				content_type: ct.to_string(),
+				body,
 			});
 		};
 


### PR DESCRIPTION
Fixes #102

Captures the response body in ResponseFailedNotJson, matching the pattern used by ResponseFailedStatus.