### PR TITLE
Fix Gemini adapter to use responseJsonSchema

### DIFF
--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -193,7 +193,7 @@ impl Adapter for GeminiAdapter {
 				}
 				true
 			});
-			payload.x_insert("/generationConfig/responseSchema", schema)?;
+			payload.x_insert("/generationConfig/responseJsonSchema", schema)?;
 		}
 
 		// -- Add supported ChatOptions


### PR DESCRIPTION
Use `responseJsonSchema` instead of deprecated `responseSchema` to support full JSON Schema spec including nullable types.

Closes #110