### PR TITLE
Ensure extra headers are applied in exec_chat and exec_chat_stream

### DIFF
--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -218,12 +218,7 @@ impl OpenAIAdapter {
 		let url = AdapterDispatcher::get_service_url(&model, service_type, endpoint)?;
 
 		// -- headers
-		let mut headers = Headers::from(("Authorization".to_string(), format!("Bearer {api_key}")));
-
-		// -- extra headers
-		if let Some(extra_headers) = options_set.extra_headers() {
-			headers.merge_with(extra_headers);
-		}
+		let headers = Headers::from(("Authorization".to_string(), format!("Bearer {api_key}")));
 
 		let stream = matches!(service_type, ServiceType::ChatStream);
 

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -73,12 +73,7 @@ impl Adapter for OpenAIRespAdapter {
 		let url = AdapterDispatcher::get_service_url(&model, service_type, endpoint)?;
 
 		// -- headers
-		let mut headers = Headers::from(("Authorization".to_string(), format!("Bearer {api_key}")));
-
-		// -- extra headers
-		if let Some(extra_headers) = chat_options.extra_headers() {
-			headers.merge_with(extra_headers);
-		}
+		let headers = Headers::from(("Authorization".to_string(), format!("Bearer {api_key}")));
 
 		// -- for new v1/responses/ for now do not support stream
 		let stream = matches!(service_type, ServiceType::ChatStream);

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -70,6 +70,10 @@ impl Client {
 			payload,
 		} = AdapterDispatcher::to_web_request_data(target, ServiceType::Chat, chat_req, options_set.clone())?;
 
+		if let Some(extra_headers) = options.and_then(|o| o.extra_headers.as_ref()) {
+			headers.merge_with(&extra_headers);
+		}
+
 		if let AuthData::RequestOverride {
 			url: override_url,
 			headers: override_headers,
@@ -114,6 +118,10 @@ impl Client {
 			mut headers,
 			payload,
 		} = AdapterDispatcher::to_web_request_data(target, ServiceType::ChatStream, chat_req, options_set.clone())?;
+
+		if let Some(extra_headers) = options.and_then(|o| o.extra_headers.as_ref()) {
+			headers.merge_with(&extra_headers);
+		}
 
 		// TODO: Need to check this.
 		//       This was part of the 429c5cee2241dbef9f33699b9c91202233c22816 commit


### PR DESCRIPTION
While working on a proxy for LLM requests, I found that `ChatOptions::extra_headers` wasn't being applied. Upon investigation, only the OpenAI provider was applying them.

This PR updates the codebase so these are applied unconditionally in `Client::exec_chat` and `Client::exec_chat_stream`.

It was unclear to me if this should go before or after the overrides from `AuthData::RequestOverride`.