### PR TITLE
fix: check HTTP status in WebStream before processing byte stream

### DIFF
--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -199,6 +199,7 @@ impl futures::Stream for AnthropicStreamer {
 					return Poll::Ready(Some(Err(Error::WebStream {
 						model_iden: self.options.model_iden.clone(),
 						cause: err.to_string(),
+						error: err,
 					})));
 				}
 				None => return Poll::Ready(None),

--- a/src/adapter/adapters/cohere/streamer.rs
+++ b/src/adapter/adapters/cohere/streamer.rs
@@ -129,6 +129,7 @@ impl futures::Stream for CohereStreamer {
 					return Poll::Ready(Some(Err(Error::WebStream {
 						model_iden: self.options.model_iden.clone(),
 						cause: err.to_string(),
+						error: err,
 					})));
 				}
 				None => {

--- a/src/adapter/adapters/gemini/streamer.rs
+++ b/src/adapter/adapters/gemini/streamer.rs
@@ -172,6 +172,7 @@ impl futures::Stream for GeminiStreamer {
 					return Poll::Ready(Some(Err(Error::WebStream {
 						model_iden: self.options.model_iden.clone(),
 						cause: err.to_string(),
+						error: err,
 					})));
 				}
 				None => {

--- a/src/adapter/adapters/openai/streamer.rs
+++ b/src/adapter/adapters/openai/streamer.rs
@@ -279,6 +279,7 @@ impl futures::Stream for OpenAIStreamer {
 					return Poll::Ready(Some(Err(Error::WebStream {
 						model_iden: self.options.model_iden.clone(),
 						cause: err.to_string(),
+						error: err,
 					})));
 				}
 				None => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use crate::adapter::AdapterKind;
 use crate::chat::ChatRole;
 use crate::{ModelIden, resolver, webc};
 use derive_more::{Display, From};
+use reqwest::StatusCode;
 use value_ext::JsonValueExtError;
 
 /// GenAI main Result type alias (with genai::Error)
@@ -91,6 +92,13 @@ pub enum Error {
 
 	#[display("Web stream error for model '{model_iden}'.\nCause: {cause}")]
 	WebStream { model_iden: ModelIden, cause: String },
+
+	#[display("HTTP error.\nStatus: {status} {canonical_reason}\nBody: {body}")]
+	HttpError {
+		status: StatusCode,
+		canonical_reason: String,
+		body: String,
+	},
 
 	// -- Modules
 	#[display("Resolver error for model '{model_iden}'.\nCause: {resolver_error}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,9 @@ use derive_more::{Display, From};
 use reqwest::StatusCode;
 use value_ext::JsonValueExtError;
 
+/// Type alias for boxed errors that are Send + Sync
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
 /// GenAI main Result type alias (with genai::Error)
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -91,7 +94,11 @@ pub enum Error {
 	},
 
 	#[display("Web stream error for model '{model_iden}'.\nCause: {cause}")]
-	WebStream { model_iden: ModelIden, cause: String },
+	WebStream {
+		model_iden: ModelIden,
+		cause: String,
+		error: BoxError,
+	},
 
 	#[display("HTTP error.\nStatus: {status} {canonical_reason}\nBody: {body}")]
 	HttpError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 // -- Flatten
 pub use client::*;
 pub use common::*;
-pub use error::{Error, Result};
+pub use error::{BoxError, Error, Result};
 
 // -- Public Modules
 pub mod adapter;

--- a/src/webc/event_source_stream.rs
+++ b/src/webc/event_source_stream.rs
@@ -1,3 +1,4 @@
+use crate::error::BoxError;
 use crate::webc::WebStream;
 use futures::Stream;
 use reqwest::RequestBuilder;
@@ -33,7 +34,7 @@ impl EventSourceStream {
 }
 
 impl Stream for EventSourceStream {
-	type Item = Result<Event, Box<dyn std::error::Error + Send + Sync>>;
+	type Item = Result<Event, BoxError>;
 
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
 		let this = self.get_mut();
@@ -77,8 +78,7 @@ impl Stream for EventSourceStream {
 					return Poll::Ready(Some(Ok(Event::Message(Message { event, data }))));
 				}
 				Poll::Ready(Some(Err(e))) => {
-					// Convert Box<dyn Error> to Box<dyn Error + Send + Sync>
-					return Poll::Ready(Some(Err(e.to_string().into())));
+					return Poll::Ready(Some(Err(e)));
 				}
 				Poll::Ready(None) => return Poll::Ready(None),
 				Poll::Pending => return Poll::Pending,


### PR DESCRIPTION
If a streaming request results in a non-streaming error response, `WebStream` silently ignores it. This PR updates `WebStream` to check `response.status()` before creating the byte stream, and reads the body of the request to create the error message.

It also adds an `error` field to `Error::WebStream` so the original data can be pulled out.

Happy to fix this up with any suggestions.