### PR TITLE
Add separate reasoning content and thought signature for anthropic messages api

### DIFF
--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -115,17 +115,27 @@ impl futures::Stream for AnthropicStreamer {
 									continue;
 								}
 								InProgressBlock::Thinking => {
-									let thinking: String = data.x_take("/delta/thinking")?;
-
-									// Add to the captured_thinking if chat options say so
-									if self.options.capture_reasoning_content {
-										match self.captured_data.reasoning_content {
-											Some(ref mut r) => r.push_str(&thinking),
-											None => self.captured_data.reasoning_content = Some(thinking.clone()),
+									if let Ok(thinking) = data.x_take::<String>("/delta/thinking") {
+										// Add to the captured_thinking if chat options say so
+										if self.options.capture_reasoning_content {
+											match self.captured_data.reasoning_content {
+												Some(ref mut r) => r.push_str(&thinking),
+												None => self.captured_data.reasoning_content = Some(thinking.clone()),
+											}
 										}
-									}
 
-									return Poll::Ready(Some(Ok(InterStreamEvent::ReasoningChunk(thinking))));
+										return Poll::Ready(Some(Ok(InterStreamEvent::ReasoningChunk(thinking))));
+									} else if let Ok(signature) = data.x_take::<String>("/delta/signature") {
+										return Poll::Ready(Some(Ok(InterStreamEvent::ThoughtSignatureChunk(
+											signature,
+										))));
+									} else {
+										// If it is thinking but no thinking or signature field, we log and skip.
+										tracing::warn!(
+											"content_block_delta for thinking block but no thinking or signature found: {data:?}"
+										);
+										continue;
+									}
 								}
 							}
 						}


### PR DESCRIPTION
Anthropic also has thought signatures as a part of its messages API. When we are streaming it is still under the thought block. We first get the thought summary tokens as `delta/thinking` and the thought signature as `delta/signature`. The current implementation fails when we enable thoughts while in the streaming mode.