### PR TITLE
feat: Add `ModelSpec` to allow for additional model details when making API calls

### DIFF
--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -47,7 +47,7 @@ impl Client {
 	/// Accepts any type that implements `Into<ModelSpec>`:
 	/// - `&str` or `String`: Model name with full inference
 	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
-	/// - `ServiceTarget`: Returns directly, bypasses resolution
+	/// - `ServiceTarget`: Uses directly, bypasses model mapping and auth resolution
 	pub async fn resolve_service_target(&self, model: impl Into<ModelSpec>) -> Result<ServiceTarget> {
 		self.config().resolve_model_spec(model.into()).await
 	}
@@ -57,7 +57,7 @@ impl Client {
 	/// Accepts any type that implements `Into<ModelSpec>`:
 	/// - `&str` or `String`: Model name with full inference
 	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
-	/// - `ServiceTarget`: Uses directly, bypasses resolution
+	/// - `ServiceTarget`: Uses directly, bypasses model mapping and auth resolution
 	pub async fn exec_chat(
 		&self,
 		model: impl Into<ModelSpec>,
@@ -110,7 +110,7 @@ impl Client {
 	/// Accepts any type that implements `Into<ModelSpec>`:
 	/// - `&str` or `String`: Model name with full inference
 	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
-	/// - `ServiceTarget`: Uses directly, bypasses resolution
+	/// - `ServiceTarget`: Uses directly, bypasses model mapping and auth resolution
 	pub async fn exec_chat_stream(
 		&self,
 		model: impl Into<ModelSpec>,
@@ -191,7 +191,7 @@ impl Client {
 	/// Accepts any type that implements `Into<ModelSpec>`:
 	/// - `&str` or `String`: Model name with full inference
 	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
-	/// - `ServiceTarget`: Uses directly, bypasses resolution
+	/// - `ServiceTarget`: Uses directly, bypasses model mapping and auth resolution
 	pub async fn exec_embed(
 		&self,
 		model: impl Into<ModelSpec>,

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -1,5 +1,6 @@
 use crate::adapter::{AdapterDispatcher, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptions, ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::client::ModelSpec;
 use crate::embed::{EmbedOptions, EmbedOptionsSet, EmbedRequest, EmbedResponse};
 use crate::resolver::AuthData;
 use crate::{Client, Error, ModelIden, Result, ServiceTarget};
@@ -41,26 +42,33 @@ impl Client {
 		Ok(target.model)
 	}
 
-	/// Resolves the service target (endpoint, auth, and model) for the given model name.
-	pub async fn resolve_service_target(&self, model_name: &str) -> Result<ServiceTarget> {
-		let model = self.default_model(model_name)?;
-		self.config().resolve_service_target(model).await
+	/// Resolves the service target (endpoint, auth, and model) for the given model.
+	///
+	/// Accepts any type that implements `Into<ModelSpec>`:
+	/// - `&str` or `String`: Model name with full inference
+	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
+	/// - `ServiceTarget`: Returns directly, bypasses resolution
+	pub async fn resolve_service_target(&self, model: impl Into<ModelSpec>) -> Result<ServiceTarget> {
+		self.config().resolve_model_spec(model.into()).await
 	}
 
 	/// Sends a chat request and returns the full response.
+	///
+	/// Accepts any type that implements `Into<ModelSpec>`:
+	/// - `&str` or `String`: Model name with full inference
+	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
+	/// - `ServiceTarget`: Uses directly, bypasses resolution
 	pub async fn exec_chat(
 		&self,
-		model: &str,
+		model: impl Into<ModelSpec>,
 		chat_req: ChatRequest,
-		// options not implemented yet
 		options: Option<&ChatOptions>,
 	) -> Result<ChatResponse> {
 		let options_set = ChatOptionsSet::default()
 			.with_chat_options(options)
 			.with_client_options(self.config().chat_options());
 
-		let model = self.default_model(model)?;
-		let target = self.config().resolve_service_target(model).await?;
+		let target = self.config().resolve_model_spec(model.into()).await?;
 		let model = target.model.clone();
 		let auth_data = target.auth.clone();
 
@@ -98,18 +106,22 @@ impl Client {
 	}
 
 	/// Streams a chat response.
+	///
+	/// Accepts any type that implements `Into<ModelSpec>`:
+	/// - `&str` or `String`: Model name with full inference
+	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
+	/// - `ServiceTarget`: Uses directly, bypasses resolution
 	pub async fn exec_chat_stream(
 		&self,
-		model: &str,
-		chat_req: ChatRequest, // options not implemented yet
+		model: impl Into<ModelSpec>,
+		chat_req: ChatRequest,
 		options: Option<&ChatOptions>,
 	) -> Result<ChatStreamResponse> {
 		let options_set = ChatOptionsSet::default()
 			.with_chat_options(options)
 			.with_client_options(self.config().chat_options());
 
-		let model = self.default_model(model)?;
-		let target = self.config().resolve_service_target(model).await?;
+		let target = self.config().resolve_model_spec(model.into()).await?;
 		let model = target.model.clone();
 		let auth_data = target.auth.clone();
 
@@ -149,9 +161,11 @@ impl Client {
 	}
 
 	/// Creates embeddings for a single input string.
+	///
+	/// Accepts any type that implements `Into<ModelSpec>` for the model parameter.
 	pub async fn embed(
 		&self,
-		model: &str,
+		model: impl Into<ModelSpec>,
 		input: impl Into<String>,
 		options: Option<&EmbedOptions>,
 	) -> Result<EmbedResponse> {
@@ -160,9 +174,11 @@ impl Client {
 	}
 
 	/// Creates embeddings for multiple input strings.
+	///
+	/// Accepts any type that implements `Into<ModelSpec>` for the model parameter.
 	pub async fn embed_batch(
 		&self,
-		model: &str,
+		model: impl Into<ModelSpec>,
 		inputs: Vec<String>,
 		options: Option<&EmbedOptions>,
 	) -> Result<EmbedResponse> {
@@ -171,9 +187,14 @@ impl Client {
 	}
 
 	/// Sends an embedding request and returns the response.
+	///
+	/// Accepts any type that implements `Into<ModelSpec>`:
+	/// - `&str` or `String`: Model name with full inference
+	/// - `ModelIden`: Explicit adapter, resolves auth/endpoint
+	/// - `ServiceTarget`: Uses directly, bypasses resolution
 	pub async fn exec_embed(
 		&self,
-		model: &str,
+		model: impl Into<ModelSpec>,
 		embed_req: EmbedRequest,
 		options: Option<&EmbedOptions>,
 	) -> Result<EmbedResponse> {
@@ -181,8 +202,7 @@ impl Client {
 			.with_request_options(options)
 			.with_client_options(self.config().embed_options());
 
-		let model = self.default_model(model)?;
-		let target = self.config().resolve_service_target(model).await?;
+		let target = self.config().resolve_model_spec(model.into()).await?;
 		let model = target.model.clone();
 
 		let WebRequestData { headers, payload, url } =

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -185,7 +185,7 @@ impl ClientConfig {
 	///
 	/// - [`ModelSpec::Iden`]: Skips adapter inference, applies full resolution.
 	///
-	/// - [`ModelSpec::Target`]: Returns the target directly, bypassing all resolution.
+	/// - [`ModelSpec::Target`]: Returns the target directly, running only the service target resolver.
 	pub async fn resolve_model_spec(&self, spec: ModelSpec) -> Result<ServiceTarget> {
 		match spec {
 			ModelSpec::Name(name) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,6 +10,7 @@ mod client_impl;
 mod client_types;
 mod config;
 mod headers;
+mod model_spec;
 mod service_target;
 mod web_config;
 
@@ -17,6 +18,7 @@ pub use builder::*;
 pub use client_types::*;
 pub use config::*;
 pub use headers::*;
+pub use model_spec::*;
 pub use service_target::*;
 pub use web_config::*;
 

--- a/src/client/model_spec.rs
+++ b/src/client/model_spec.rs
@@ -1,0 +1,109 @@
+use crate::adapter::AdapterKind;
+use crate::{ModelIden, ServiceTarget};
+
+/// Specifies how to identify and resolve a model for API calls.
+///
+/// `ModelSpec` provides three levels of control over model resolution:
+///
+/// - [`ModelSpec::Name`]: Just a model name string. The adapter kind is inferred
+///   from the name, and auth/endpoint are resolved via the client's configured resolvers.
+///
+/// - [`ModelSpec::Iden`]: An explicit [`ModelIden`] with adapter kind specified.
+///   Skips adapter inference but still resolves auth/endpoint via config.
+///
+/// - [`ModelSpec::Target`]: A complete [`ServiceTarget`] with endpoint, auth, and model.
+///   Used directly, bypassing all resolution steps.
+///
+/// # Examples
+///
+/// ```rust
+/// use genai::adapter::AdapterKind;
+/// use genai::resolver::{AuthData, Endpoint};
+/// use genai::{ModelIden, ModelSpec, ServiceTarget};
+///
+/// // Using a string name (full inference)
+/// let spec: ModelSpec = "gpt-4".into();
+///
+/// // Using an explicit ModelIden (skip adapter inference)
+/// let spec: ModelSpec = ModelIden::new(AdapterKind::OpenAI, "gpt-4").into();
+///
+/// // Using a complete ServiceTarget (bypass all resolution)
+/// let target = ServiceTarget {
+///     endpoint: Endpoint::from_static("https://custom.api/v1/"),
+///     auth: AuthData::from_env("CUSTOM_API_KEY"),
+///     model: ModelIden::new(AdapterKind::OpenAI, "custom-model"),
+/// };
+/// let spec: ModelSpec = target.into();
+/// ```
+#[derive(Debug, Clone)]
+pub enum ModelSpec {
+	/// Model name string - adapter kind is inferred, auth/endpoint resolved via config.
+	Name(String),
+
+	/// Explicit [`ModelIden`] - skips adapter inference, still resolves auth/endpoint.
+	Iden(ModelIden),
+
+	/// Complete [`ServiceTarget`] - used directly, bypasses all resolution.
+	Target(ServiceTarget),
+}
+
+// region:    --- Constructors
+
+impl ModelSpec {
+	/// Creates a `ModelSpec::Name` from a string.
+	pub fn from_model_name(name: impl Into<String>) -> Self {
+		ModelSpec::Name(name.into())
+	}
+
+	/// Creates a `ModelSpec::Iden` from adapter kind and model name.
+	pub fn from_model(adapter_kind: AdapterKind, model_name: impl Into<String>) -> Self {
+		ModelSpec::Iden(ModelIden::new(adapter_kind, model_name.into()))
+	}
+
+	/// Creates a `ModelSpec::Target` from a complete service target.
+	pub fn from_target(target: ServiceTarget) -> Self {
+		ModelSpec::Target(target)
+	}
+}
+
+// endregion: --- Constructors
+
+// region:    --- From Implementations
+
+impl From<&str> for ModelSpec {
+	fn from(name: &str) -> Self {
+		ModelSpec::Name(name.to_string())
+	}
+}
+
+impl From<&&str> for ModelSpec {
+	fn from(name: &&str) -> Self {
+		ModelSpec::Name((*name).to_string())
+	}
+}
+
+impl From<String> for ModelSpec {
+	fn from(name: String) -> Self {
+		ModelSpec::Name(name)
+	}
+}
+
+impl From<&String> for ModelSpec {
+	fn from(name: &String) -> Self {
+		ModelSpec::Name(name.clone())
+	}
+}
+
+impl From<ModelIden> for ModelSpec {
+	fn from(model: ModelIden) -> Self {
+		ModelSpec::Iden(model)
+	}
+}
+
+impl From<ServiceTarget> for ModelSpec {
+	fn from(target: ServiceTarget) -> Self {
+		ModelSpec::Target(target)
+	}
+}
+
+// endregion: --- From Implementations

--- a/src/client/model_spec.rs
+++ b/src/client/model_spec.rs
@@ -12,7 +12,7 @@ use crate::{ModelIden, ServiceTarget};
 ///   Skips adapter inference but still resolves auth/endpoint via config.
 ///
 /// - [`ModelSpec::Target`]: A complete [`ServiceTarget`] with endpoint, auth, and model.
-///   Used directly, bypassing all resolution steps.
+///   Used directly, only runs the service target resolver.
 ///
 /// # Examples
 ///
@@ -43,7 +43,7 @@ pub enum ModelSpec {
 	/// Explicit [`ModelIden`] - skips adapter inference, still resolves auth/endpoint.
 	Iden(ModelIden),
 
-	/// Complete [`ServiceTarget`] - used directly, bypasses all resolution.
+	/// Complete [`ServiceTarget`] - used directly, bypasses model mapping and auth resolution
 	Target(ServiceTarget),
 }
 

--- a/src/client/service_target.rs
+++ b/src/client/service_target.rs
@@ -9,6 +9,7 @@ use crate::resolver::{AuthData, Endpoint};
 /// - `auth`: Authentication data for the request.
 ///
 /// - `model`: Target model identifier.
+#[derive(Debug, Clone)]
 pub struct ServiceTarget {
 	pub endpoint: Endpoint,
 	pub auth: AuthData,


### PR DESCRIPTION
## Problem

While `ClientConfig` allows for overwriting service target details with the `with_service_target_resolver` family of methods, the resolver function is passed a `ServiceTarget` struct that is inferred based on the string model name. This makes it very difficult to do things like use custom providers or specify a dynamic endpoint for a model. I'm currently formatting my model selection as a "provider::model::endpoint" string, which gets stored as `model_name` in the `ModelIden` and is accessible from the `ServiceTarget` — but this gets quite messy and depends on string manipulation to extract the parts.

## Solution

I explored several options to resolve this, but the most promising one was to use an enum to represent the various model specifications, with a trait implementation to ensure that passing in a string still works for backwards compatibility:

```rust
pub enum ModelSpec {
    Name(String),          // Full inference
    Iden(ModelIden),       // Skip adapter inference
    Target(ServiceTarget), // Full control, skip all resolution
}

impl From<&str> for ModelSpec { ... }
impl From<ModelIden> for ModelSpec { ... }
impl From<ServiceTarget> for ModelSpec { ... }
```

Then change the signatures:

```rust
pub async fn exec_chat_stream(
    &self,
    model: impl Into<ModelSpec>,  // Backward compatible!
    chat_req: ChatRequest,
    options: Option<&ChatOptions>,
) -> Result<ChatStreamResponse>
```

With this, I can pass any struct that implements `Into<ModelSpec>`:

```rust
pub enum ModelSelection {
    Custom { model: String, uri: Option<String> },
    Claude { model: String },
    OpenAI { model: String, uri: Option<String> },
    Ollama { model: String, uri: Option<String> },
}

impl From<&ModelSelection> for ModelSpec {
    fn from(model: &ModelSelection) -> Self {
        match model {
            ModelSelection::Custom { model, uri } => {
                ModelSpec::Target(ServiceTarget {
                    model: ModelIden::new(AdapterKind::Anthropic, model),
                    endpoint: Endpoint::from_owned(
                        uri.clone().unwrap_or("http://localhost:4000/...".to_string()),
                    ),
                    auth: AuthData::Key("".to_string()),
                })
            },
            ModelSelection::Claude { model } => ModelSpec::Name(model.clone()),
            ModelSelection::OpenAI { model, .. } => ModelSpec::Name(model.clone()),
            ModelSelection::Ollama { model, uri } => {
                ModelSpec::Target(ServiceTarget {
                    model: ModelIden::new(AdapterKind::Ollama, model),
                    endpoint: Endpoint::from_owned(
                        uri.clone().unwrap_or("http://localhost:11434".to_string()),
                    ),
                    auth: AuthData::Key("".to_string()),
                }),
            }
        }
    }
}

// elsewhere

let model = ModelSelection::Ollama {
    model: "gpt-oss:2b".to_string(),
    uri: Some("http://localhost:11434".to_string()),
};

let stream = client.exec_chat_stream(&model, chat_request, Some(&chat_options)).await?;
```

---

As always, open to any feedback.