### PR TITLE
fix(anthropic): prevent custom tool hijacking and stale streamer state

### DIFF
--- a/examples/c16-web-search.rs
+++ b/examples/c16-web-search.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let location = UserLocation::default()
 		.with_city("Tokyo")
-		.with_country("Japan")
+		.with_country("JP") // ISO 2-letter country code
 		.with_timezone("Asia/Tokyo");
 
 	let config = WebSearchConfig::default()

--- a/examples/c16-web-search.rs
+++ b/examples/c16-web-search.rs
@@ -1,0 +1,152 @@
+//! Example demonstrating Anthropic's web search tool.
+//!
+//! This example shows how to:
+//! 1. Enable web search with default settings
+//! 2. Configure web search with domain filtering and usage limits
+//! 3. Access citations from the response
+//! 4. Track web search billing
+//!
+//! Requires: ANTHROPIC_API_KEY environment variable
+//!
+//! Run with: `cargo run --example c16-web-search`
+
+use genai::chat::{ChatRequest, ContentPart, Tool, UserLocation, WebSearchConfig};
+use genai::Client;
+
+// Web search supported models: Claude Sonnet 4/4.5, Claude Haiku 3.5/4.5, Claude Opus 4/4.1/4.5
+const MODEL: &str = "claude-sonnet-4-20250514";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let client = Client::default();
+
+	// -- Example 1: Simple web search
+	println!("=== Example 1: Simple Web Search ===\n");
+
+	let req = ChatRequest::from_user("What are the main new features in Rust 2024? Be brief.")
+		.with_tools(vec![Tool::web_search()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	// Print the text response
+	if let Some(text) = res.content.first_text() {
+		println!("Response:\n{}\n", text);
+	}
+
+	// Check for text with citations
+	for part in res.content.parts() {
+		if let ContentPart::TextWithCitations(twc) = part {
+			println!("Text with {} citations:\n{}\n", twc.citations.len(), twc.text);
+			for citation in &twc.citations {
+				println!("  - {} ({})", citation.title, citation.url);
+			}
+		}
+	}
+
+	// -- Example 2: Configured web search with domain filtering
+	println!("\n=== Example 2: Configured Web Search ===\n");
+
+	let config = WebSearchConfig::default()
+		.with_max_uses(5)
+		.with_allowed_domains(vec!["rust-lang.org".into(), "docs.rs".into(), "crates.io".into()]);
+
+	let req = ChatRequest::from_user("Find information about the async-std crate. Brief answer.")
+		.with_tools(vec![Tool::web_search().with_web_search_config(config)]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	if let Some(text) = res.content.first_text() {
+		println!("Response:\n{}\n", text);
+	}
+
+	// Use the helper method to get all citations
+	let citations = res.content.citations();
+	if !citations.is_empty() {
+		println!("Sources cited:");
+		for citation in citations {
+			println!("  - {} ({})", citation.title, citation.url);
+		}
+	}
+
+	// -- Example 3: Web search with user location
+	println!("\n=== Example 3: Localized Web Search ===\n");
+
+	let location = UserLocation::default()
+		.with_city("Tokyo")
+		.with_country("Japan")
+		.with_timezone("Asia/Tokyo");
+
+	let config = WebSearchConfig::default()
+		.with_max_uses(3)
+		.with_user_location(location);
+
+	let req = ChatRequest::from_user("What's the current weather like? Brief answer.")
+		.with_tools(vec![Tool::web_search().with_web_search_config(config)]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	if let Some(text) = res.content.first_text() {
+		println!("Response:\n{}\n", text);
+	}
+
+	// -- Example 4: Tracking web search usage for billing
+	println!("\n=== Example 4: Usage Tracking ===\n");
+
+	let req =
+		ChatRequest::from_user("What's new in the tech world today?").with_tools(vec![Tool::web_search()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	println!("Token Usage:");
+	println!("  Prompt tokens: {:?}", res.usage.prompt_tokens);
+	println!("  Completion tokens: {:?}", res.usage.completion_tokens);
+
+	if let Some(details) = &res.usage.completion_tokens_details {
+		if let Some(searches) = details.web_search_requests {
+			println!("  Web searches performed: {}", searches);
+			println!("  Estimated search cost: ${:.4}", searches as f64 * 0.01);
+		}
+	}
+
+	// -- Example 5: Examining all content parts
+	println!("\n=== Example 5: Content Part Analysis ===\n");
+
+	let req =
+		ChatRequest::from_user("Search for the latest Rust release notes").with_tools(vec![Tool::web_search()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	for (i, part) in res.content.parts().iter().enumerate() {
+		match part {
+			ContentPart::Text(text) => {
+				println!("Part {}: Text ({} chars)", i, text.len());
+			}
+			ContentPart::TextWithCitations(twc) => {
+				println!(
+					"Part {}: TextWithCitations ({} chars, {} citations)",
+					i,
+					twc.text.len(),
+					twc.citations.len()
+				);
+			}
+			ContentPart::ServerToolUse(stu) => {
+				println!("Part {}: ServerToolUse (tool: {}, id: {})", i, stu.name, stu.id);
+			}
+			ContentPart::WebSearchToolResult(wsr) => {
+				println!(
+					"Part {}: WebSearchToolResult ({} results)",
+					i,
+					wsr.results.len()
+				);
+				for result in &wsr.results {
+					println!("  - {}: {}", result.title, result.url);
+				}
+			}
+			_ => {
+				println!("Part {}: Other type", i);
+			}
+		}
+	}
+
+	Ok(())
+}

--- a/examples/c17-web-fetch.rs
+++ b/examples/c17-web-fetch.rs
@@ -1,0 +1,182 @@
+//! Example demonstrating Anthropic's web fetch tool.
+//!
+//! This example shows how to:
+//! 1. Enable web fetch with default settings
+//! 2. Configure web fetch with domain filtering and usage limits
+//! 3. Enable citations for fetched content
+//! 4. Combine web fetch with web search
+//! 5. Track web fetch billing
+//!
+//! Requires: ANTHROPIC_API_KEY environment variable
+//!
+//! Run with: `cargo run --example c17-web-fetch`
+
+use genai::chat::{ChatRequest, ContentPart, Tool, WebFetchConfig};
+use genai::Client;
+
+// Web fetch supported models: Claude Sonnet 4/4.5, Claude Haiku 3.5/4.5, Claude Opus 4/4.1/4.5
+const MODEL: &str = "claude-sonnet-4-20250514";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let client = Client::default();
+
+	// -- Example 1: Simple web fetch
+	println!("=== Example 1: Simple Web Fetch ===\n");
+
+	let req = ChatRequest::from_user(
+		"Fetch the content from https://httpbin.org/html and summarize what you find. Be brief.",
+	)
+	.with_tools(vec![Tool::web_fetch()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	// Print the text response
+	if let Some(text) = res.content.first_text() {
+		println!("Response:\n{}\n", text);
+	}
+
+	// Check for web fetch results
+	for part in res.content.parts() {
+		if let ContentPart::WebFetchToolResult(wfr) = part {
+			println!("Fetched URL: {}", wfr.url);
+			println!("Content type: {}", wfr.content.media_type);
+			println!("Content length: {} chars", wfr.content.data.len());
+			if let Some(title) = &wfr.content.title {
+				println!("Title: {}", title);
+			}
+			if let Some(retrieved_at) = &wfr.retrieved_at {
+				println!("Retrieved at: {}", retrieved_at);
+			}
+		}
+	}
+
+	// -- Example 2: Configured web fetch with domain filtering
+	println!("\n=== Example 2: Configured Web Fetch ===\n");
+
+	let config = WebFetchConfig::default()
+		.with_max_uses(3)
+		.with_allowed_domains(vec!["rust-lang.org".into(), "docs.rs".into(), "crates.io".into()]);
+
+	let req = ChatRequest::from_user(
+		"Fetch the main page of docs.rs and tell me what documentation hosting features it offers. Brief answer.",
+	)
+	.with_tools(vec![Tool::web_fetch().with_web_fetch_config(config)]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	if let Some(text) = res.content.first_text() {
+		println!("Response:\n{}\n", text);
+	}
+
+	// -- Example 3: Web fetch with citations enabled
+	println!("\n=== Example 3: Web Fetch with Citations ===\n");
+
+	let config = WebFetchConfig::default()
+		.with_max_uses(2)
+		.with_citations_enabled();
+
+	let req = ChatRequest::from_user(
+		"Fetch https://httpbin.org/robots.txt and explain what it says. Include citations.",
+	)
+	.with_tools(vec![Tool::web_fetch().with_web_fetch_config(config)]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	if let Some(text) = res.content.first_text() {
+		println!("Response:\n{}\n", text);
+	}
+
+	// Check for text with citations
+	for part in res.content.parts() {
+		if let ContentPart::TextWithCitations(twc) = part {
+			println!("Text with {} citations:\n{}\n", twc.citations.len(), twc.text);
+			for citation in &twc.citations {
+				println!("  - {} ({})", citation.title, citation.url);
+			}
+		}
+	}
+
+	// -- Example 4: Combined web search and web fetch
+	println!("\n=== Example 4: Combined Search and Fetch ===\n");
+
+	let req = ChatRequest::from_user(
+		"Search for the official Rust documentation, then fetch the main page and summarize what topics it covers. Brief answer.",
+	)
+	.with_tools(vec![Tool::web_search(), Tool::web_fetch()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	if let Some(text) = res.content.first_text() {
+		println!("Response:\n{}\n", text);
+	}
+
+	// -- Example 5: Tracking web fetch usage for billing
+	println!("\n=== Example 5: Usage Tracking ===\n");
+
+	let req = ChatRequest::from_user("Fetch https://httpbin.org/json and describe the JSON structure.")
+		.with_tools(vec![Tool::web_fetch()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	println!("Token Usage:");
+	println!("  Prompt tokens: {:?}", res.usage.prompt_tokens);
+	println!("  Completion tokens: {:?}", res.usage.completion_tokens);
+
+	if let Some(details) = &res.usage.completion_tokens_details {
+		if let Some(fetches) = details.web_fetch_requests {
+			println!("  Web fetches performed: {}", fetches);
+		}
+		if let Some(searches) = details.web_search_requests {
+			println!("  Web searches performed: {}", searches);
+		}
+	}
+
+	// -- Example 6: Examining all content parts
+	println!("\n=== Example 6: Content Part Analysis ===\n");
+
+	let req =
+		ChatRequest::from_user("Fetch https://httpbin.org/headers and show me what headers were sent.")
+			.with_tools(vec![Tool::web_fetch()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	for (i, part) in res.content.parts().iter().enumerate() {
+		match part {
+			ContentPart::Text(text) => {
+				println!("Part {}: Text ({} chars)", i, text.len());
+			}
+			ContentPart::TextWithCitations(twc) => {
+				println!(
+					"Part {}: TextWithCitations ({} chars, {} citations)",
+					i,
+					twc.text.len(),
+					twc.citations.len()
+				);
+			}
+			ContentPart::ServerToolUse(stu) => {
+				println!("Part {}: ServerToolUse (tool: {}, id: {})", i, stu.name, stu.id);
+			}
+			ContentPart::WebFetchToolResult(wfr) => {
+				println!(
+					"Part {}: WebFetchToolResult (url: {}, {} bytes)",
+					i,
+					wfr.url,
+					wfr.content.data.len()
+				);
+			}
+			ContentPart::WebSearchToolResult(wsr) => {
+				println!(
+					"Part {}: WebSearchToolResult ({} results)",
+					i,
+					wsr.results.len()
+				);
+			}
+			_ => {
+				println!("Part {}: Other type", i);
+			}
+		}
+	}
+
+	Ok(())
+}

--- a/examples/c17-web-fetch.rs
+++ b/examples/c17-web-fetch.rs
@@ -39,7 +39,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	// Check for web fetch results
 	for part in res.content.parts() {
 		if let ContentPart::WebFetchToolResult(wfr) = part {
-			println!("Fetched URL: {}", wfr.url);
+			if let Some(url) = &wfr.url {
+				println!("Fetched URL: {}", url);
+			}
 			println!("Content type: {}", wfr.content.media_type);
 			println!("Content length: {} chars", wfr.content.data.len());
 			if let Some(title) = &wfr.content.title {
@@ -159,7 +161,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			}
 			ContentPart::WebFetchToolResult(wfr) => {
 				println!(
-					"Part {}: WebFetchToolResult (url: {}, {} bytes)",
+					"Part {}: WebFetchToolResult (url: {:?}, {} bytes)",
 					i,
 					wfr.url,
 					wfr.content.data.len()

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -906,12 +906,12 @@ impl AnthropicAdapter {
 				.into_iter()
 				.map(|tool| {
 					// Handle web_search tool specially
-					if tool.name == "web_search" {
+					if tool.name == "web_search" && tool.schema.is_none() {
 						return Self::serialize_web_search_tool(tool.config);
 					}
 
 					// Handle web_fetch tool specially
-					if tool.name == "web_fetch" {
+					if tool.name == "web_fetch" && tool.schema.is_none() {
 						return Self::serialize_web_fetch_tool(tool.config);
 					}
 

--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -1,6 +1,6 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatOptionsSet, CompletionTokensDetails, PromptTokensDetails, ToolCall, Usage};
+use crate::chat::{ChatOptionsSet, CompletionTokensDetails, ToolCall, Usage};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
 use serde_json::{Map, Value};
@@ -93,6 +93,10 @@ impl futures::Stream for AnthropicStreamer {
 								Ok("web_fetch_tool_result") => {
 									// Web fetch results - content is delivered as a complete block
 									self.in_progress_block = InProgressBlock::WebFetchToolResult;
+								}
+								Ok("web_search_tool_result_error") | Ok("web_fetch_tool_error") => {
+									// Error responses - delivered as complete blocks
+									self.in_progress_block = InProgressBlock::ServerToolUse;
 								}
 								Ok(txt) => {
 									tracing::warn!("unhandled content type: {txt}");

--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -27,6 +27,7 @@ enum InProgressBlock {
 	ServerToolUse,
 	WebSearchToolResult,
 	WebFetchToolResult,
+	Unknown,
 }
 
 impl AnthropicStreamer {
@@ -100,9 +101,11 @@ impl futures::Stream for AnthropicStreamer {
 								}
 								Ok(txt) => {
 									tracing::warn!("unhandled content type: {txt}");
+									self.in_progress_block = InProgressBlock::Unknown;
 								}
 								Err(e) => {
 									tracing::error!("{e:?}");
+									self.in_progress_block = InProgressBlock::Unknown;
 								}
 							}
 
@@ -158,7 +161,8 @@ impl futures::Stream for AnthropicStreamer {
 								}
 								InProgressBlock::ServerToolUse
 							| InProgressBlock::WebSearchToolResult
-							| InProgressBlock::WebFetchToolResult => {
+							| InProgressBlock::WebFetchToolResult
+							| InProgressBlock::Unknown => {
 								// These block types don't have deltas in the same way text does
 								// The content is delivered as a complete block
 								continue;

--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -1,6 +1,6 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatOptionsSet, ToolCall, Usage};
+use crate::chat::{ChatOptionsSet, CompletionTokensDetails, PromptTokensDetails, ToolCall, Usage};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
 use serde_json::{Map, Value};
@@ -24,6 +24,8 @@ enum InProgressBlock {
 	Text,
 	ToolUse { id: String, name: String, input: String },
 	Thinking,
+	ServerToolUse,
+	WebSearchToolResult,
 }
 
 impl AnthropicStreamer {
@@ -78,6 +80,14 @@ impl futures::Stream for AnthropicStreamer {
 										name: data.x_take("/content_block/name")?,
 										input: String::new(),
 									};
+								}
+								Ok("server_tool_use") => {
+									// Server tool use (like web_search) - we don't need to accumulate input
+									self.in_progress_block = InProgressBlock::ServerToolUse;
+								}
+								Ok("web_search_tool_result") => {
+									// Web search results - content is delivered as a complete block
+									self.in_progress_block = InProgressBlock::WebSearchToolResult;
 								}
 								Ok(txt) => {
 									tracing::warn!("unhandled content type: {txt}");
@@ -136,6 +146,11 @@ impl futures::Stream for AnthropicStreamer {
 										);
 										continue;
 									}
+								}
+								InProgressBlock::ServerToolUse | InProgressBlock::WebSearchToolResult => {
+									// These block types don't have deltas in the same way text does
+									// The content is delivered as a complete block
+									continue;
 								}
 							}
 						}
@@ -264,6 +279,22 @@ impl AnthropicStreamer {
 					.completion_tokens
 					.get_or_insert(0);
 				*val += output_tokens;
+			}
+
+			// -- Capture web_search_requests (present in message_delta)
+			if message_type == "message_delta" {
+				let web_search_requests = data
+					.get("usage")
+					.and_then(|u| u.get("server_tool_use"))
+					.and_then(|s| s.get("web_search_requests"))
+					.and_then(|v| v.as_i64())
+					.map(|v| v as i32);
+
+				if let Some(requests) = web_search_requests {
+					let usage = self.captured_data.usage.get_or_insert(Usage::default());
+					let details = usage.completion_tokens_details.get_or_insert(CompletionTokensDetails::default());
+					details.web_search_requests = Some(requests);
+				}
 			}
 		}
 

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -452,20 +452,16 @@ impl GeminiAdapter {
 			(Some(c_tokens), Some(t_tokens)) => (
 				Some(c_tokens + t_tokens),
 				Some(CompletionTokensDetails {
-					accepted_prediction_tokens: None,
-					rejected_prediction_tokens: None,
 					reasoning_tokens: Some(t_tokens),
-					audio_tokens: None,
+					..Default::default()
 				}),
 			),
 			(None, Some(t_tokens)) => {
 				(
 					None,
 					Some(CompletionTokensDetails {
-						accepted_prediction_tokens: None,
-						rejected_prediction_tokens: None,
 						reasoning_tokens: Some(t_tokens), // should be safe enough
-						audio_tokens: None,
+						..Default::default()
 					}),
 				)
 			}
@@ -558,6 +554,10 @@ impl GeminiAdapter {
 									"thoughtSignature": thought
 								}));
 							}
+							// Web search types are Anthropic-only response types; skip gracefully.
+							ContentPart::TextWithCitations(_) => {}
+							ContentPart::ServerToolUse(_) => {}
+							ContentPart::WebSearchToolResult(_) => {}
 						}
 					}
 
@@ -625,6 +625,10 @@ impl GeminiAdapter {
 									parts_values.push(json!({"thoughtSignature": thought}));
 								}
 							}
+							// Web search types are Anthropic-only response types; skip gracefully.
+							ContentPart::TextWithCitations(_) => {}
+							ContentPart::ServerToolUse(_) => {}
+							ContentPart::WebSearchToolResult(_) => {}
 						}
 					}
 					if let Some(thought) = pending_thought {
@@ -662,6 +666,10 @@ impl GeminiAdapter {
 									"thoughtSignature": thought
 								}));
 							}
+							// Web search types are Anthropic-only response types; skip gracefully.
+							ContentPart::TextWithCitations(_)
+							| ContentPart::ServerToolUse(_)
+							| ContentPart::WebSearchToolResult(_) => {}
 							_ => {
 								return Err(Error::MessageContentTypeNotSupported {
 									model_iden: model_iden.clone(),

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -558,7 +558,7 @@ impl GeminiAdapter {
 							ContentPart::TextWithCitations(_) => {}
 							ContentPart::ServerToolUse(_) => {}
 							ContentPart::WebSearchToolResult(_) => {}
-							ContentPart::WebFetchToolResult(_) => {}
+							ContentPart::WebFetchToolResult(_) | ContentPart::ServerToolError(_) => {}
 						}
 					}
 
@@ -630,7 +630,7 @@ impl GeminiAdapter {
 							ContentPart::TextWithCitations(_) => {}
 							ContentPart::ServerToolUse(_) => {}
 							ContentPart::WebSearchToolResult(_) => {}
-							ContentPart::WebFetchToolResult(_) => {}
+							ContentPart::WebFetchToolResult(_) | ContentPart::ServerToolError(_) => {}
 						}
 					}
 					if let Some(thought) = pending_thought {

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -554,10 +554,11 @@ impl GeminiAdapter {
 									"thoughtSignature": thought
 								}));
 							}
-							// Web search types are Anthropic-only response types; skip gracefully.
+							// Web search/fetch types are Anthropic-only response types; skip gracefully.
 							ContentPart::TextWithCitations(_) => {}
 							ContentPart::ServerToolUse(_) => {}
 							ContentPart::WebSearchToolResult(_) => {}
+							ContentPart::WebFetchToolResult(_) => {}
 						}
 					}
 
@@ -625,10 +626,11 @@ impl GeminiAdapter {
 									parts_values.push(json!({"thoughtSignature": thought}));
 								}
 							}
-							// Web search types are Anthropic-only response types; skip gracefully.
+							// Web search/fetch types are Anthropic-only response types; skip gracefully.
 							ContentPart::TextWithCitations(_) => {}
 							ContentPart::ServerToolUse(_) => {}
 							ContentPart::WebSearchToolResult(_) => {}
+							ContentPart::WebFetchToolResult(_) => {}
 						}
 					}
 					if let Some(thought) = pending_thought {

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -457,7 +457,7 @@ impl OpenAIAdapter {
 								ContentPart::TextWithCitations(_) => (),
 								ContentPart::ServerToolUse(_) => (),
 								ContentPart::WebSearchToolResult(_) => (),
-								ContentPart::WebFetchToolResult(_) => (),
+								ContentPart::WebFetchToolResult(_) | ContentPart::ServerToolError(_) => (),
 							}
 						}
 						messages.push(json! ({"role": "user", "content": values}));
@@ -492,7 +492,7 @@ impl OpenAIAdapter {
 							ContentPart::TextWithCitations(_) => (),
 							ContentPart::ServerToolUse(_) => (),
 							ContentPart::WebSearchToolResult(_) => (),
-							ContentPart::WebFetchToolResult(_) => (),
+							ContentPart::WebFetchToolResult(_) | ContentPart::ServerToolError(_) => (),
 						}
 					}
 					let content = texts.join("\n\n");

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -453,6 +453,10 @@ impl OpenAIAdapter {
 								ContentPart::ToolCall(_) => (),
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
+								// Web search types are Anthropic-only response types; skip gracefully.
+								ContentPart::TextWithCitations(_) => (),
+								ContentPart::ServerToolUse(_) => (),
+								ContentPart::WebSearchToolResult(_) => (),
 							}
 						}
 						messages.push(json! ({"role": "user", "content": values}));
@@ -482,7 +486,11 @@ impl OpenAIAdapter {
 							// TODO: Probably need towarn on this one (probably need to add binary here)
 							ContentPart::Binary(_) => (),
 							ContentPart::ToolResponse(_) => (),
-							ContentPart::ThoughtSignature(_) => {}
+							ContentPart::ThoughtSignature(_) => {},
+							// Web search types are Anthropic-only response types; skip gracefully.
+							ContentPart::TextWithCitations(_) => (),
+							ContentPart::ServerToolUse(_) => (),
+							ContentPart::WebSearchToolResult(_) => (),
 						}
 					}
 					let content = texts.join("\n\n");

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -453,10 +453,11 @@ impl OpenAIAdapter {
 								ContentPart::ToolCall(_) => (),
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
-								// Web search types are Anthropic-only response types; skip gracefully.
+								// Web search/fetch types are Anthropic-only response types; skip gracefully.
 								ContentPart::TextWithCitations(_) => (),
 								ContentPart::ServerToolUse(_) => (),
 								ContentPart::WebSearchToolResult(_) => (),
+								ContentPart::WebFetchToolResult(_) => (),
 							}
 						}
 						messages.push(json! ({"role": "user", "content": values}));
@@ -487,10 +488,11 @@ impl OpenAIAdapter {
 							ContentPart::Binary(_) => (),
 							ContentPart::ToolResponse(_) => (),
 							ContentPart::ThoughtSignature(_) => {},
-							// Web search types are Anthropic-only response types; skip gracefully.
+							// Web search/fetch types are Anthropic-only response types; skip gracefully.
 							ContentPart::TextWithCitations(_) => (),
 							ContentPart::ServerToolUse(_) => (),
 							ContentPart::WebSearchToolResult(_) => (),
+							ContentPart::WebFetchToolResult(_) => (),
 						}
 					}
 					let content = texts.join("\n\n");

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -392,10 +392,11 @@ impl OpenAIRespAdapter {
 								ContentPart::ToolCall(_) => (),
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
-								// Web search types are Anthropic-only response types; skip gracefully.
+								// Web search/fetch types are Anthropic-only response types; skip gracefully.
 								ContentPart::TextWithCitations(_) => (),
 								ContentPart::ServerToolUse(_) => (),
 								ContentPart::WebSearchToolResult(_) => (),
+								ContentPart::WebFetchToolResult(_) => (),
 							}
 						}
 						input_items.push(json! ({"role": "user", "content": values}));
@@ -439,10 +440,11 @@ impl OpenAIRespAdapter {
 							ContentPart::Binary(_) => {}
 							ContentPart::ToolResponse(_) => {}
 							ContentPart::ThoughtSignature(_) => {}
-							// Web search types are Anthropic-only response types; skip gracefully.
+							// Web search/fetch types are Anthropic-only response types; skip gracefully.
 							ContentPart::TextWithCitations(_) => {}
 							ContentPart::ServerToolUse(_) => {}
 							ContentPart::WebSearchToolResult(_) => {}
+							ContentPart::WebFetchToolResult(_) => {}
 						}
 					}
 

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -396,7 +396,7 @@ impl OpenAIRespAdapter {
 								ContentPart::TextWithCitations(_) => (),
 								ContentPart::ServerToolUse(_) => (),
 								ContentPart::WebSearchToolResult(_) => (),
-								ContentPart::WebFetchToolResult(_) => (),
+								ContentPart::WebFetchToolResult(_) | ContentPart::ServerToolError(_) => (),
 							}
 						}
 						input_items.push(json! ({"role": "user", "content": values}));
@@ -444,7 +444,7 @@ impl OpenAIRespAdapter {
 							ContentPart::TextWithCitations(_) => {}
 							ContentPart::ServerToolUse(_) => {}
 							ContentPart::WebSearchToolResult(_) => {}
-							ContentPart::WebFetchToolResult(_) => {}
+							ContentPart::WebFetchToolResult(_) | ContentPart::ServerToolError(_) => {}
 						}
 					}
 

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -392,6 +392,10 @@ impl OpenAIRespAdapter {
 								ContentPart::ToolCall(_) => (),
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
+								// Web search types are Anthropic-only response types; skip gracefully.
+								ContentPart::TextWithCitations(_) => (),
+								ContentPart::ServerToolUse(_) => (),
+								ContentPart::WebSearchToolResult(_) => (),
 							}
 						}
 						input_items.push(json! ({"role": "user", "content": values}));
@@ -435,6 +439,10 @@ impl OpenAIRespAdapter {
 							ContentPart::Binary(_) => {}
 							ContentPart::ToolResponse(_) => {}
 							ContentPart::ThoughtSignature(_) => {}
+							// Web search types are Anthropic-only response types; skip gracefully.
+							ContentPart::TextWithCitations(_) => {}
+							ContentPart::ServerToolUse(_) => {}
+							ContentPart::WebSearchToolResult(_) => {}
 						}
 					}
 

--- a/src/adapter/adapters/openai_resp/resp_types/resp_usage.rs
+++ b/src/adapter/adapters/openai_resp/resp_types/resp_usage.rs
@@ -106,6 +106,7 @@ impl From<OutputTokensDetails> for CompletionTokensDetails {
 			rejected_prediction_tokens: value.rejected_prediction_tokens,
 			reasoning_tokens: value.reasoning_tokens,
 			audio_tokens: value.audio_tokens,
+			web_search_requests: None,
 		}
 	}
 }

--- a/src/adapter/adapters/openai_resp/resp_types/resp_usage.rs
+++ b/src/adapter/adapters/openai_resp/resp_types/resp_usage.rs
@@ -107,6 +107,7 @@ impl From<OutputTokensDetails> for CompletionTokensDetails {
 			reasoning_tokens: value.reasoning_tokens,
 			audio_tokens: value.audio_tokens,
 			web_search_requests: None,
+			web_fetch_requests: None,
 		}
 	}
 }

--- a/src/chat/content_part.rs
+++ b/src/chat/content_part.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::chat::{Binary, ServerToolUse, TextWithCitations, ToolCall, ToolResponse, WebFetchToolResult, WebSearchToolResult};
+use crate::chat::{Binary, ServerToolError, ServerToolUse, TextWithCitations, ToolCall, ToolResponse, WebFetchToolResult, WebSearchToolResult};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -43,6 +43,10 @@ pub enum ContentPart {
 	/// Results from a web fetch tool execution.
 	#[from]
 	WebFetchToolResult(WebFetchToolResult),
+
+	/// Error from a server tool execution (web search or web fetch).
+	#[from]
+	ServerToolError(ServerToolError),
 }
 
 /// Constructors
@@ -274,6 +278,7 @@ impl ContentPart {
 			ContentPart::ServerToolUse(stu) => stu.size(),
 			ContentPart::WebSearchToolResult(wsr) => wsr.size(),
 			ContentPart::WebFetchToolResult(wfr) => wfr.size(),
+			ContentPart::ServerToolError(e) => e.tool_use_id.len() + e.tool_name.len() + e.error_code.len(),
 		}
 	}
 }

--- a/src/chat/content_part.rs
+++ b/src/chat/content_part.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::chat::{Binary, ServerToolUse, TextWithCitations, ToolCall, ToolResponse, WebSearchToolResult};
+use crate::chat::{Binary, ServerToolUse, TextWithCitations, ToolCall, ToolResponse, WebFetchToolResult, WebSearchToolResult};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -26,19 +26,23 @@ pub enum ContentPart {
 	#[from(ignore)]
 	ThoughtSignature(String),
 
-	// -- Web Search variants (Anthropic)
+	// -- Web Search / Web Fetch variants (Anthropic)
 
-	/// Text content with inline citations from web search.
+	/// Text content with inline citations from web search/fetch.
 	#[from]
 	TextWithCitations(TextWithCitations),
 
-	/// Server-initiated tool use (e.g., web search query).
+	/// Server-initiated tool use (e.g., web search query, web fetch).
 	#[from]
 	ServerToolUse(ServerToolUse),
 
 	/// Results from a web search tool execution.
 	#[from]
 	WebSearchToolResult(WebSearchToolResult),
+
+	/// Results from a web fetch tool execution.
+	#[from]
+	WebFetchToolResult(WebFetchToolResult),
 }
 
 /// Constructors
@@ -230,6 +234,24 @@ impl ContentPart {
 			None
 		}
 	}
+
+	/// Borrow the web fetch tool result if present.
+	pub fn as_web_fetch_tool_result(&self) -> Option<&WebFetchToolResult> {
+		if let ContentPart::WebFetchToolResult(wfr) = self {
+			Some(wfr)
+		} else {
+			None
+		}
+	}
+
+	/// Extract the web fetch tool result, consuming the part.
+	pub fn into_web_fetch_tool_result(self) -> Option<WebFetchToolResult> {
+		if let ContentPart::WebFetchToolResult(wfr) = self {
+			Some(wfr)
+		} else {
+			None
+		}
+	}
 }
 
 /// Computed accessors
@@ -251,6 +273,7 @@ impl ContentPart {
 			ContentPart::TextWithCitations(twc) => twc.size(),
 			ContentPart::ServerToolUse(stu) => stu.size(),
 			ContentPart::WebSearchToolResult(wsr) => wsr.size(),
+			ContentPart::WebFetchToolResult(wfr) => wfr.size(),
 		}
 	}
 }
@@ -315,5 +338,10 @@ impl ContentPart {
 	/// Returns true if this part contains web search tool results.
 	pub fn is_web_search_tool_result(&self) -> bool {
 		matches!(self, ContentPart::WebSearchToolResult(_))
+	}
+
+	/// Returns true if this part contains web fetch tool results.
+	pub fn is_web_fetch_tool_result(&self) -> bool {
+		matches!(self, ContentPart::WebFetchToolResult(_))
 	}
 }

--- a/src/chat/message_content.rs
+++ b/src/chat/message_content.rs
@@ -1,5 +1,5 @@
 /// Note: MessageContent is used for ChatRequest and ChatResponse.
-use crate::chat::{Binary, ContentPart, ToolCall, ToolResponse};
+use crate::chat::{Binary, Citation, ContentPart, ToolCall, ToolResponse};
 use serde::{Deserialize, Serialize};
 
 /// Message content container used in ChatRequest and ChatResponse.
@@ -308,6 +308,40 @@ impl MessageContent {
 	/// True if at least one part is a ToolResponse.
 	pub fn contains_tool_response(&self) -> bool {
 		self.parts.iter().any(|p| p.is_tool_response())
+	}
+
+	/// True if at least one part contains text with citations.
+	pub fn contains_text_with_citations(&self) -> bool {
+		self.parts.iter().any(|p| p.is_text_with_citations())
+	}
+
+	/// True if at least one part contains web search results.
+	pub fn contains_web_search_result(&self) -> bool {
+		self.parts.iter().any(|p| p.is_web_search_tool_result())
+	}
+}
+
+/// Web Search accessors
+impl MessageContent {
+	/// Return all citations from TextWithCitations parts.
+	///
+	/// This is a convenience method for accessing web search citations
+	/// without manually iterating through ContentParts.
+	pub fn citations(&self) -> Vec<&Citation> {
+		self.parts
+			.iter()
+			.filter_map(|p| p.as_text_with_citations())
+			.flat_map(|twc| twc.citations.iter())
+			.collect()
+	}
+
+	/// Consume and return all citations from TextWithCitations parts.
+	pub fn into_citations(self) -> Vec<Citation> {
+		self.parts
+			.into_iter()
+			.filter_map(|p| p.into_text_with_citations())
+			.flat_map(|twc| twc.citations)
+			.collect()
 	}
 }
 

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -14,6 +14,7 @@ mod content_part;
 mod message_content;
 mod tool;
 mod usage;
+mod web_search_result;
 
 // -- Flatten
 pub use binary::*;
@@ -27,6 +28,7 @@ pub use content_part::*;
 pub use message_content::*;
 pub use tool::*;
 pub use usage::*;
+pub use web_search_result::*;
 
 #[doc = "Printing helpers for chat requests and streaming output."]
 pub mod printer;

--- a/src/chat/tool/mod.rs
+++ b/src/chat/tool/mod.rs
@@ -10,6 +10,7 @@
 mod tool_base;
 mod tool_call;
 mod tool_response;
+mod web_search;
 
 /// Base traits and specifications for declaring tools.
 pub use tool_base::*;
@@ -19,5 +20,8 @@ pub use tool_call::*;
 
 /// Types for returning results produced by a tool.
 pub use tool_response::*;
+
+/// Web search configuration types.
+pub use web_search::*;
 
 // endregion: --- Modules

--- a/src/chat/tool/mod.rs
+++ b/src/chat/tool/mod.rs
@@ -10,6 +10,7 @@
 mod tool_base;
 mod tool_call;
 mod tool_response;
+mod web_fetch;
 mod web_search;
 
 /// Base traits and specifications for declaring tools.
@@ -20,6 +21,9 @@ pub use tool_call::*;
 
 /// Types for returning results produced by a tool.
 pub use tool_response::*;
+
+/// Web fetch configuration types.
+pub use web_fetch::*;
 
 /// Web search configuration types.
 pub use web_search::*;

--- a/src/chat/tool/tool_base.rs
+++ b/src/chat/tool/tool_base.rs
@@ -1,4 +1,4 @@
-use super::WebSearchConfig;
+use super::{WebFetchConfig, WebSearchConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -99,6 +99,26 @@ impl Tool {
 			config: None,
 		}
 	}
+
+	/// Create an Anthropic web_fetch tool with default configuration.
+	///
+	/// This creates a tool that enables Claude to fetch content from URLs.
+	/// The web fetch tool is only supported by Anthropic models.
+	///
+	/// # Example
+	/// ```rust
+	/// use genai::chat::Tool;
+	///
+	/// let tool = Tool::web_fetch();
+	/// ```
+	pub fn web_fetch() -> Self {
+		Self {
+			name: "web_fetch".to_string(),
+			description: None,
+			schema: None,
+			config: None,
+		}
+	}
 }
 
 // region:    --- Setters
@@ -138,6 +158,27 @@ impl Tool {
 	/// let tool = Tool::web_search().with_web_search_config(config);
 	/// ```
 	pub fn with_web_search_config(mut self, config: WebSearchConfig) -> Self {
+		// Serialize the config to Value, defaulting to null on error (unlikely)
+		self.config = serde_json::to_value(config).ok();
+		self
+	}
+
+	/// Set web fetch configuration for an Anthropic web_fetch tool.
+	///
+	/// This is a convenience method that serializes the WebFetchConfig
+	/// and stores it in the config field.
+	///
+	/// # Example
+	/// ```rust
+	/// use genai::chat::{Tool, WebFetchConfig};
+	///
+	/// let config = WebFetchConfig::default()
+	///     .with_max_uses(5)
+	///     .with_allowed_domains(vec!["rust-lang.org".into()]);
+	///
+	/// let tool = Tool::web_fetch().with_web_fetch_config(config);
+	/// ```
+	pub fn with_web_fetch_config(mut self, config: WebFetchConfig) -> Self {
 		// Serialize the config to Value, defaulting to null on error (unlikely)
 		self.config = serde_json::to_value(config).ok();
 		self

--- a/src/chat/tool/tool_base.rs
+++ b/src/chat/tool/tool_base.rs
@@ -1,3 +1,4 @@
+use super::WebSearchConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -78,6 +79,26 @@ impl Tool {
 			config: None,
 		}
 	}
+
+	/// Create an Anthropic web_search tool with default configuration.
+	///
+	/// This creates a tool that enables Claude to search the web in real-time.
+	/// The web search tool is only supported by Anthropic models.
+	///
+	/// # Example
+	/// ```rust
+	/// use genai::chat::Tool;
+	///
+	/// let tool = Tool::web_search();
+	/// ```
+	pub fn web_search() -> Self {
+		Self {
+			name: "web_search".to_string(),
+			description: None,
+			schema: None,
+			config: None,
+		}
+	}
 }
 
 // region:    --- Setters
@@ -98,6 +119,27 @@ impl Tool {
 	/// Set provider-specific configuration (if any). Returns self for chaining.
 	pub fn with_config(mut self, config: Value) -> Self {
 		self.config = Some(config);
+		self
+	}
+
+	/// Set web search configuration for an Anthropic web_search tool.
+	///
+	/// This is a convenience method that serializes the WebSearchConfig
+	/// and stores it in the config field.
+	///
+	/// # Example
+	/// ```rust
+	/// use genai::chat::{Tool, WebSearchConfig};
+	///
+	/// let config = WebSearchConfig::default()
+	///     .with_max_uses(5)
+	///     .with_allowed_domains(vec!["rust-lang.org".into()]);
+	///
+	/// let tool = Tool::web_search().with_web_search_config(config);
+	/// ```
+	pub fn with_web_search_config(mut self, config: WebSearchConfig) -> Self {
+		// Serialize the config to Value, defaulting to null on error (unlikely)
+		self.config = serde_json::to_value(config).ok();
 		self
 	}
 }

--- a/src/chat/tool/web_fetch.rs
+++ b/src/chat/tool/web_fetch.rs
@@ -1,0 +1,97 @@
+//! Web fetch configuration types for Anthropic's built-in web fetch tool.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for Anthropic's web_fetch tool.
+///
+/// This allows customizing the behavior of the built-in web fetch tool,
+/// including domain filtering, usage limits, and content settings.
+///
+/// # Example
+/// ```rust
+/// use genai::chat::WebFetchConfig;
+///
+/// let config = WebFetchConfig::default()
+///     .with_max_uses(5)
+///     .with_allowed_domains(vec!["rust-lang.org".into(), "docs.rs".into()]);
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WebFetchConfig {
+	/// Maximum number of web fetches allowed per request.
+	/// If not set, the model decides how many fetches to perform.
+	pub max_uses: Option<u32>,
+
+	/// Only URLs from these domains will be fetched.
+	/// Cannot be used together with `blocked_domains`.
+	pub allowed_domains: Option<Vec<String>>,
+
+	/// URLs from these domains will not be fetched.
+	/// Cannot be used together with `allowed_domains`.
+	pub blocked_domains: Option<Vec<String>>,
+
+	/// Citation configuration for the web fetch tool.
+	pub citations: Option<WebFetchCitations>,
+
+	/// Maximum number of content tokens to return per fetch.
+	/// Limits the size of fetched content.
+	pub max_content_tokens: Option<u32>,
+}
+
+impl WebFetchConfig {
+	/// Set the maximum number of web fetches allowed.
+	pub fn with_max_uses(mut self, max_uses: u32) -> Self {
+		self.max_uses = Some(max_uses);
+		self
+	}
+
+	/// Set allowed domains (allowlist).
+	/// Only URLs from these domains will be fetched.
+	pub fn with_allowed_domains(mut self, domains: Vec<String>) -> Self {
+		self.allowed_domains = Some(domains);
+		self
+	}
+
+	/// Set blocked domains (blocklist).
+	/// URLs from these domains will not be fetched.
+	pub fn with_blocked_domains(mut self, domains: Vec<String>) -> Self {
+		self.blocked_domains = Some(domains);
+		self
+	}
+
+	/// Set citation configuration.
+	pub fn with_citations(mut self, citations: WebFetchCitations) -> Self {
+		self.citations = Some(citations);
+		self
+	}
+
+	/// Enable citations with default settings.
+	pub fn with_citations_enabled(mut self) -> Self {
+		self.citations = Some(WebFetchCitations { enabled: true });
+		self
+	}
+
+	/// Set the maximum number of content tokens per fetch.
+	pub fn with_max_content_tokens(mut self, max_tokens: u32) -> Self {
+		self.max_content_tokens = Some(max_tokens);
+		self
+	}
+}
+
+/// Citation configuration for web fetch results.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WebFetchCitations {
+	/// Whether citations are enabled for fetched content.
+	pub enabled: bool,
+}
+
+impl WebFetchCitations {
+	/// Create a new citations config with citations enabled.
+	pub fn enabled() -> Self {
+		Self { enabled: true }
+	}
+
+	/// Create a new citations config with citations disabled.
+	pub fn disabled() -> Self {
+		Self { enabled: false }
+	}
+}

--- a/src/chat/tool/web_search.rs
+++ b/src/chat/tool/web_search.rs
@@ -1,0 +1,122 @@
+//! Web search configuration types for Anthropic's built-in web search tool.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for Anthropic's web_search tool.
+///
+/// This allows customizing the behavior of the built-in web search tool,
+/// including domain filtering, usage limits, and user location for localized results.
+///
+/// # Example
+/// ```rust
+/// use genai::chat::WebSearchConfig;
+///
+/// let config = WebSearchConfig::default()
+///     .with_max_uses(5)
+///     .with_allowed_domains(vec!["rust-lang.org".into(), "docs.rs".into()]);
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WebSearchConfig {
+	/// Maximum number of web searches allowed per request.
+	/// If not set, the model decides how many searches to perform.
+	pub max_uses: Option<u32>,
+
+	/// Only search results from these domains will be included.
+	/// Cannot be used together with `blocked_domains`.
+	pub allowed_domains: Option<Vec<String>>,
+
+	/// Search results from these domains will be excluded.
+	/// Cannot be used together with `allowed_domains`.
+	pub blocked_domains: Option<Vec<String>>,
+
+	/// Approximate user location for localized search results.
+	pub user_location: Option<UserLocation>,
+}
+
+impl WebSearchConfig {
+	/// Set the maximum number of web searches allowed.
+	pub fn with_max_uses(mut self, max_uses: u32) -> Self {
+		self.max_uses = Some(max_uses);
+		self
+	}
+
+	/// Set allowed domains (allowlist).
+	/// Only results from these domains will be included.
+	pub fn with_allowed_domains(mut self, domains: Vec<String>) -> Self {
+		self.allowed_domains = Some(domains);
+		self
+	}
+
+	/// Set blocked domains (blocklist).
+	/// Results from these domains will be excluded.
+	pub fn with_blocked_domains(mut self, domains: Vec<String>) -> Self {
+		self.blocked_domains = Some(domains);
+		self
+	}
+
+	/// Set the user location for localized search results.
+	pub fn with_user_location(mut self, location: UserLocation) -> Self {
+		self.user_location = Some(location);
+		self
+	}
+}
+
+/// Approximate user location for localized search results.
+///
+/// All fields are optional. Providing more location details can improve
+/// the relevance of localized search results.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UserLocation {
+	/// City name (e.g., "San Francisco")
+	pub city: Option<String>,
+
+	/// Region/state (e.g., "California")
+	pub region: Option<String>,
+
+	/// Country code or name (e.g., "US" or "United States")
+	pub country: Option<String>,
+
+	/// Timezone (e.g., "America/Los_Angeles")
+	pub timezone: Option<String>,
+}
+
+impl UserLocation {
+	/// Create a new UserLocation with all fields.
+	pub fn new(
+		city: impl Into<Option<String>>,
+		region: impl Into<Option<String>>,
+		country: impl Into<Option<String>>,
+		timezone: impl Into<Option<String>>,
+	) -> Self {
+		Self {
+			city: city.into(),
+			region: region.into(),
+			country: country.into(),
+			timezone: timezone.into(),
+		}
+	}
+
+	/// Set the city.
+	pub fn with_city(mut self, city: impl Into<String>) -> Self {
+		self.city = Some(city.into());
+		self
+	}
+
+	/// Set the region/state.
+	pub fn with_region(mut self, region: impl Into<String>) -> Self {
+		self.region = Some(region.into());
+		self
+	}
+
+	/// Set the country.
+	pub fn with_country(mut self, country: impl Into<String>) -> Self {
+		self.country = Some(country.into());
+		self
+	}
+
+	/// Set the timezone.
+	pub fn with_timezone(mut self, timezone: impl Into<String>) -> Self {
+		self.timezone = Some(timezone.into());
+		self
+	}
+}

--- a/src/chat/usage.rs
+++ b/src/chat/usage.rs
@@ -78,6 +78,10 @@ pub struct CompletionTokensDetails {
 	/// Billed at $10 per 1,000 searches.
 	#[serde(default, deserialize_with = "crate::support::zero_as_none")]
 	pub web_search_requests: Option<i32>,
+
+	/// Number of web fetch requests performed (Anthropic only).
+	#[serde(default, deserialize_with = "crate::support::zero_as_none")]
+	pub web_fetch_requests: Option<i32>,
 }
 
 impl CompletionTokensDetails {
@@ -88,5 +92,6 @@ impl CompletionTokensDetails {
 			&& self.reasoning_tokens.is_none()
 			&& self.audio_tokens.is_none()
 			&& self.web_search_requests.is_none()
+			&& self.web_fetch_requests.is_none()
 	}
 }

--- a/src/chat/usage.rs
+++ b/src/chat/usage.rs
@@ -74,6 +74,10 @@ pub struct CompletionTokensDetails {
 	pub reasoning_tokens: Option<i32>,
 	#[serde(default, deserialize_with = "crate::support::zero_as_none")]
 	pub audio_tokens: Option<i32>,
+	/// Number of web search requests performed (Anthropic only).
+	/// Billed at $10 per 1,000 searches.
+	#[serde(default, deserialize_with = "crate::support::zero_as_none")]
+	pub web_search_requests: Option<i32>,
 }
 
 impl CompletionTokensDetails {
@@ -83,5 +87,6 @@ impl CompletionTokensDetails {
 			&& self.rejected_prediction_tokens.is_none()
 			&& self.reasoning_tokens.is_none()
 			&& self.audio_tokens.is_none()
+			&& self.web_search_requests.is_none()
 	}
 }

--- a/src/chat/web_search_result.rs
+++ b/src/chat/web_search_result.rs
@@ -1,0 +1,135 @@
+//! Response types for Anthropic's web search tool results.
+//!
+//! When using the web_search tool, the response may contain:
+//! - `ServerToolUse`: The model's invocation of the web search tool
+//! - `WebSearchToolResult`: The results returned by the web search
+//! - `TextWithCitations`: Text content that includes inline citations
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A citation referencing a web search result.
+///
+/// Citations link text content back to the source documents
+/// from which the information was derived.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Citation {
+	/// URL of the source document.
+	pub url: String,
+
+	/// Title of the source document.
+	pub title: String,
+
+	/// The specific text that was cited from the source.
+	/// May be None if the citation is for the source as a whole.
+	pub cited_text: Option<String>,
+
+	/// Start index in the text where this citation applies.
+	pub start_index: Option<u32>,
+
+	/// End index in the text where this citation applies.
+	pub end_index: Option<u32>,
+}
+
+impl Citation {
+	/// Returns an approximate in-memory size of this `Citation`, in bytes.
+	pub fn size(&self) -> usize {
+		self.url.len()
+			+ self.title.len()
+			+ self.cited_text.as_ref().map(|s| s.len()).unwrap_or(0)
+	}
+}
+
+/// Text content with inline citations from web search.
+///
+/// This represents a text block where the model has incorporated
+/// information from web search results and provided citations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextWithCitations {
+	/// The text content.
+	pub text: String,
+
+	/// Citations for sources referenced in this text.
+	pub citations: Vec<Citation>,
+}
+
+impl TextWithCitations {
+	/// Returns an approximate in-memory size of this `TextWithCitations`, in bytes.
+	pub fn size(&self) -> usize {
+		self.text.len() + self.citations.iter().map(|c| c.size()).sum::<usize>()
+	}
+}
+
+/// A single web search result item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebSearchResultItem {
+	/// URL of the search result.
+	pub url: String,
+
+	/// Title of the search result.
+	pub title: String,
+
+	/// Age of the page (e.g., "2 days ago").
+	pub page_age: Option<String>,
+
+	/// Encrypted content for multi-turn conversations.
+	/// This allows Claude to reference the content in follow-up turns.
+	pub encrypted_content: Option<String>,
+}
+
+impl WebSearchResultItem {
+	/// Returns an approximate in-memory size of this `WebSearchResultItem`, in bytes.
+	pub fn size(&self) -> usize {
+		self.url.len()
+			+ self.title.len()
+			+ self.page_age.as_ref().map(|s| s.len()).unwrap_or(0)
+			+ self.encrypted_content.as_ref().map(|s| s.len()).unwrap_or(0)
+	}
+}
+
+/// Server-initiated tool use (e.g., web search query).
+///
+/// This represents the model's invocation of a server-side tool
+/// like web_search. The actual execution happens on Anthropic's servers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerToolUse {
+	/// Unique identifier for this tool use.
+	pub id: String,
+
+	/// Name of the tool being used (e.g., "web_search").
+	pub name: String,
+
+	/// Input parameters for the tool (e.g., search query).
+	pub input: Value,
+}
+
+impl ServerToolUse {
+	/// Returns an approximate in-memory size of this `ServerToolUse`, in bytes.
+	pub fn size(&self) -> usize {
+		self.id.len()
+			+ self.name.len()
+			+ serde_json::to_string(&self.input)
+				.map(|s| s.len())
+				.unwrap_or(0)
+	}
+}
+
+/// Results from a web search tool execution.
+///
+/// This contains the search results returned by Anthropic's
+/// web search infrastructure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebSearchToolResult {
+	/// The tool_use_id this result corresponds to.
+	pub tool_use_id: String,
+
+	/// The search results.
+	pub results: Vec<WebSearchResultItem>,
+}
+
+impl WebSearchToolResult {
+	/// Returns an approximate in-memory size of this `WebSearchToolResult`, in bytes.
+	pub fn size(&self) -> usize {
+		self.tool_use_id.len() + self.results.iter().map(|r| r.size()).sum::<usize>()
+	}
+}

--- a/tests/tests_p_anthropic_web_search.rs
+++ b/tests/tests_p_anthropic_web_search.rs
@@ -1,0 +1,193 @@
+//! Integration tests for Anthropic web search functionality.
+//!
+//! These tests require the ANTHROPIC_API_KEY environment variable to be set.
+//! Run with: `cargo test --test tests_p_anthropic_web_search -- --ignored`
+
+mod support;
+
+use genai::chat::{ChatRequest, ContentPart, Tool, WebSearchConfig};
+use genai::Client;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+// Web search is supported on these models
+const MODEL: &str = "claude-sonnet-4-20250514";
+
+/// Test basic web search tool serialization
+#[tokio::test]
+#[ignore]
+async fn test_web_search_basic_ok() -> TestResult<()> {
+	let client = Client::default();
+
+	let req = ChatRequest::from_user("What is the current version of Rust? Give a brief answer.")
+		.with_tools(vec![Tool::web_search()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	// Should have some response content
+	assert!(
+		res.content.first_text().is_some() || res.content.contains_text_with_citations(),
+		"Expected text or text with citations in response"
+	);
+
+	Ok(())
+}
+
+/// Test web search with configuration
+#[tokio::test]
+#[ignore]
+async fn test_web_search_with_config_ok() -> TestResult<()> {
+	let client = Client::default();
+
+	let config = WebSearchConfig::default()
+		.with_max_uses(3)
+		.with_allowed_domains(vec!["rust-lang.org".into(), "docs.rs".into()]);
+
+	let req = ChatRequest::from_user("What's new in the latest Rust release? Brief answer please.")
+		.with_tools(vec![Tool::web_search().with_web_search_config(config)]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	// Should have some response content
+	assert!(!res.content.is_empty(), "Expected non-empty response");
+
+	Ok(())
+}
+
+/// Test that web search results contain citations when used
+#[tokio::test]
+#[ignore]
+async fn test_web_search_citations_ok() -> TestResult<()> {
+	let client = Client::default();
+
+	let req = ChatRequest::from_user("What are the main features of Rust 2024 edition? Cite your sources.")
+		.with_tools(vec![Tool::web_search()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	// Check content parts for various web search result types
+	let mut has_text_content = false;
+	let mut has_server_tool_use = false;
+	let mut has_web_search_result = false;
+	let mut has_text_with_citations = false;
+
+	for part in res.content.parts() {
+		match part {
+			ContentPart::Text(_) => has_text_content = true,
+			ContentPart::ServerToolUse(stu) => {
+				has_server_tool_use = true;
+				assert_eq!(stu.name, "web_search", "Expected web_search tool use");
+			}
+			ContentPart::WebSearchToolResult(wsr) => {
+				has_web_search_result = true;
+				// Results should have a tool_use_id linking back to the ServerToolUse
+				assert!(!wsr.tool_use_id.is_empty(), "Expected non-empty tool_use_id");
+			}
+			ContentPart::TextWithCitations(twc) => {
+				has_text_with_citations = true;
+				// Text should not be empty
+				assert!(!twc.text.is_empty(), "Expected non-empty text");
+				// Note: Citations may or may not be present depending on the model's response
+			}
+			_ => {}
+		}
+	}
+
+	// At minimum we should have some form of text content
+	assert!(
+		has_text_content || has_text_with_citations,
+		"Expected text content in response"
+	);
+
+	// Log what we found for debugging
+	println!("Response analysis:");
+	println!("  - has_text_content: {}", has_text_content);
+	println!("  - has_server_tool_use: {}", has_server_tool_use);
+	println!("  - has_web_search_result: {}", has_web_search_result);
+	println!("  - has_text_with_citations: {}", has_text_with_citations);
+
+	Ok(())
+}
+
+/// Test web search usage tracking (billing info)
+#[tokio::test]
+#[ignore]
+async fn test_web_search_usage_tracking_ok() -> TestResult<()> {
+	let client = Client::default();
+
+	let req = ChatRequest::from_user("What is today's weather in Tokyo? Brief answer.")
+		.with_tools(vec![Tool::web_search()]);
+
+	let res = client.exec_chat(MODEL, req, None).await?;
+
+	// Check usage
+	println!("Usage: {:?}", res.usage);
+
+	// Basic usage should always be present
+	assert!(res.usage.prompt_tokens.is_some(), "Expected prompt_tokens in usage");
+	assert!(
+		res.usage.completion_tokens.is_some(),
+		"Expected completion_tokens in usage"
+	);
+
+	// Web search requests may be present in completion_tokens_details
+	if let Some(details) = &res.usage.completion_tokens_details {
+		if let Some(requests) = details.web_search_requests {
+			println!("Web search requests: {}", requests);
+			assert!(requests > 0, "Expected positive web search request count");
+		}
+	}
+
+	Ok(())
+}
+
+/// Test web search with streaming
+#[tokio::test]
+#[ignore]
+async fn test_web_search_streaming_ok() -> TestResult<()> {
+	use futures::StreamExt;
+	use genai::chat::{ChatOptions, ChatStreamEvent};
+
+	let client = Client::default();
+
+	let req = ChatRequest::from_user("What is the latest news about Rust programming language?")
+		.with_tools(vec![Tool::web_search()]);
+
+	let options = ChatOptions::default()
+		.with_capture_usage(true)
+		.with_capture_content(true);
+
+	let res = client.exec_chat_stream(MODEL, req, Some(&options)).await?;
+	let mut stream = res.stream;
+
+	let mut chunks_received = 0;
+	let mut stream_end: Option<genai::chat::StreamEnd> = None;
+
+	while let Some(result) = stream.next().await {
+		let event = result?;
+		chunks_received += 1;
+
+		// Process stream events
+		match event {
+			ChatStreamEvent::Chunk(chunk) => {
+				print!("{}", chunk.content);
+			}
+			ChatStreamEvent::End(end) => {
+				stream_end = Some(end);
+			}
+			_ => {}
+		}
+	}
+
+	println!("\n\nTotal chunks: {}", chunks_received);
+	assert!(chunks_received > 0, "Expected to receive stream chunks");
+
+	// Check captured data
+	if let Some(end) = stream_end {
+		if let Some(usage) = end.captured_usage {
+			println!("Captured usage: {:?}", usage);
+		}
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary
- Distinguish native `web_search`/`web_fetch` server tools from user-defined function tools sharing the same name by checking for absent schema
- Handle unknown content block types in the streamer to avoid stale `in_progress_block` state corrupting subsequent delta processing

Depends on #133