### PR TITLE
Fix Gemini adapter tool serialization to use functionDeclarations camelCase

### DIFF
--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -697,7 +697,7 @@ impl GeminiAdapter {
 				}
 			}
 			if !function_declarations.is_empty() {
-				tools.push(json!({"function_declarations": function_declarations}));
+				tools.push(json!({"functionDeclarations": function_declarations}));
 			}
 			Some(tools)
 		} else {


### PR DESCRIPTION
## Summary
This PR fixes a serialization issue in `src/adapter/adapters/gemini/adapter_impl.rs` where the tool definition key was being sent in snake_case (`function_declarations`). The API requires camelCase (`functionDeclarations`) to correctly recognize the `tool_type` oneof field.

## The Issue
When attempting to call tools with the current implementation, the API rejects the request with a `400 Bad Request` error, indicating that the tool type was not initialized.

**Error Message:**
> "The GenerateContentRequest proto is invalid: tools[0].tool_type: required one_of 'tool_type' must have one initialized field"

**Problematic Code Logic:**
The API does not recognize `function_declarations` as a valid key for the `tool_type` oneof wrapper, resulting in an "empty" tool object.

```rust
// Current implementation (causes 400 error):
if !function_declarations.is_empty() {
    // The API fails to map this key to the internal oneof definition
    tools.push(json!({"function_declarations": function_declarations}));
}