### PR TITLE
feat: Implement Gemini Image Generation and Binary Response Parsing

### DIFF
--- a/examples/c08-image-gen.rs
+++ b/examples/c08-image-gen.rs
@@ -1,0 +1,62 @@
+//! This example demonstrates how to use the Gemini model to generate images and save them locally.
+
+use genai::Client;
+use genai::chat::{ChatMessage, ChatRequest};
+use std::fs;
+
+const MODEL: &str = "gemini-3-pro-image-preview"; // Or other Gemini model that supports image generation
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	// Reads GEMINI_API_KEY from environment variable by default
+	let client = Client::default();
+
+	let prompt = "Generate a picture of a cat, cartoon style, 512x512 resolution";
+	println!("Prompt: {prompt}");
+
+	let chat_req = ChatRequest::new(vec![ChatMessage::user(prompt)]);
+
+	// Call exec_chat to get the response
+	let chat_res = client.exec_chat(MODEL, chat_req, None).await?;
+
+	// Check if the response contains binary data (image)
+	let mut image_count = 0;
+	for part in &chat_res.content {
+		if let Some(binary) = part.as_binary() {
+			// For Gemini, the binary content is expected to be the complete image data with proper MIME type, so we can directly save it as a file.
+			if binary.content_type.starts_with("image/") {
+				image_count += 1;
+				let file_ext = match binary.content_type.as_str() {
+					"image/png" => "png",
+					"image/jpeg" => "jpg",
+					"image/webp" => "webp",
+					_ => "bin",
+				};
+				let filename = format!("generated_image_{}.{}", image_count, file_ext);
+
+				// In rust-genai, BinarySource::Base64 holds the base64 string
+				use genai::chat::BinarySource;
+				let data = match &binary.source {
+					BinarySource::Base64(base64_str) => {
+						use base64::{Engine as _, engine::general_purpose};
+						general_purpose::STANDARD.decode(base64_str.as_ref())?
+					}
+					_ => continue,
+				};
+
+				fs::write(&filename, data)?;
+				println!("Image saved to: {}", filename);
+			}
+		}
+	}
+
+	if image_count == 0 {
+		if let Some(text) = chat_res.first_text() {
+			println!("No image generated. Model response: {}", text);
+		} else {
+			println!("No image generated and no text response.");
+		}
+	}
+
+	Ok(())
+}

--- a/src/adapter/adapters/gemini/streamer.rs
+++ b/src/adapter/adapters/gemini/streamer.rs
@@ -110,6 +110,11 @@ impl futures::Stream for GeminiStreamer {
 										stream_reasoning_content = Some(reasoning)
 									}
 									GeminiChatContent::Text(text) => stream_text_content.push_str(&text),
+									GeminiChatContent::Binary(_) => {
+										// For now, we do not stream binary content, as Gemini may send binary content in multiple chunks and we don't want to emit incomplete binary data.
+										// Instead, we will capture the binary content in the captured_data and emit it at the end of the stream.
+										// We can consider adding a streaming event for binary content in the future if there is a use case for it.
+									}
 									GeminiChatContent::ToolCall(tool_call) => stream_tool_call = Some(tool_call),
 									GeminiChatContent::ThoughtSignature(thought) => stream_thought = Some(thought),
 								}

--- a/tests/tests_p_gemini_image.rs
+++ b/tests/tests_p_gemini_image.rs
@@ -1,0 +1,30 @@
+use genai::Client;
+use genai::chat::{ChatMessage, ChatOptions, ChatRequest};
+
+const MODEL: &str = "gemini-3-pro-image-preview";
+
+#[tokio::test]
+async fn test_p_gemini_image_generation() -> Result<(), Box<dyn std::error::Error>> {
+	let client = Client::default();
+	let prompt = "Generate a small icon of a star";
+	let chat_req = ChatRequest::new(vec![ChatMessage::user(prompt)]);
+
+	// Test with capture_raw_body to ensure we can see the underlying JSON if needed
+	let options = ChatOptions {
+		capture_raw_body: Some(true),
+		..Default::default()
+	};
+
+	let chat_res = client.exec_chat(MODEL, chat_req, Some(&options)).await?;
+
+	assert!(chat_res.captured_raw_body.is_some(), "Raw body should be captured");
+
+	// Check if we got any binary parts
+	let has_image = chat_res.content.into_iter().any(|part| part.is_image());
+
+	// Note: Since this is a provider test, it depends on API availability.
+	// We expect an image if the model is working correctly for image generation.
+	println!("Has image: {}", has_image);
+
+	Ok(())
+}

--- a/tests/tests_p_gemini_image.rs
+++ b/tests/tests_p_gemini_image.rs
@@ -1,5 +1,5 @@
 use genai::Client;
-use genai::chat::{ChatMessage, ChatOptions, ChatRequest};
+use genai::chat::{ChatMessage, ChatRequest};
 
 const MODEL: &str = "gemini-3-pro-image-preview";
 
@@ -9,15 +9,7 @@ async fn test_p_gemini_image_generation() -> Result<(), Box<dyn std::error::Erro
 	let prompt = "Generate a small icon of a star";
 	let chat_req = ChatRequest::new(vec![ChatMessage::user(prompt)]);
 
-	// Test with capture_raw_body to ensure we can see the underlying JSON if needed
-	let options = ChatOptions {
-		capture_raw_body: Some(true),
-		..Default::default()
-	};
-
-	let chat_res = client.exec_chat(MODEL, chat_req, Some(&options)).await?;
-
-	assert!(chat_res.captured_raw_body.is_some(), "Raw body should be captured");
+	let chat_res = client.exec_chat(MODEL, chat_req, None).await?;
 
 	// Check if we got any binary parts
 	let has_image = chat_res.content.into_iter().any(|part| part.is_image());
@@ -25,6 +17,11 @@ async fn test_p_gemini_image_generation() -> Result<(), Box<dyn std::error::Erro
 	// Note: Since this is a provider test, it depends on API availability.
 	// We expect an image if the model is working correctly for image generation.
 	println!("Has image: {}", has_image);
+
+	assert!(
+		has_image,
+		"Expected to receive an image content part from the Gemini response"
+	);
 
 	Ok(())
 }


### PR DESCRIPTION
### Overview
This PR introduces support for image generation using Gemini model. The implementation parses the `inlineData` field from the Gemini API response, extracts it as a `Binary` object, and integrates it into the existing `ContentPart` system.

### Key Changes

#### Core Implementation
*   **`src/adapter/adapters/gemini/adapter_impl.rs`**:
    *   Added the `Binary(Binary)` variant to the `GeminiChatContent` enum to hold parsed binary data.
    *   Updated `body_to_gemini_chat_response` to support parsing `inlineData` (Base64) and converting it into a `Binary` object.
    *   Updated `to_chat_response` to correctly map `GeminiChatContent::Binary` to `ContentPart::Binary`.
*   **`src/adapter/adapters/gemini/streamer.rs`**:
    *   Updated the `GeminiStreamer` match arms to handle the new `Binary` variant, preventing runtime panics.

#### Examples & Tests
*   **`examples/c08-image-gen.rs`**:
    *   Added a new example demonstrating how to use the `gemini-3-pro-image-preview` model for image generation.
    *   Includes logic to decode Base64 data and save it as a local file (`.png` / `.jpg`).
*   **`tests/tests_p_gemini_image.rs`**:
    *   Added a provider test to verify the image generation API call.

### Technical Considerations
*   **Binary Reuse**: Following the existing architecture, the `Binary` type is reused to carry generated image data, ensuring compatibility with the rest of the system

### Verification Steps
1.  Set the environment variable: `set GEMINI_API_KEY=your_key`
2.  Run the example: `cargo run --example c08-image-gen`
3.  Verify the result: A file named `generated_image_1.png` should be created in the current directory with success messages in the console.
4.  Run the test: `cargo test --test tests_p_gemini_image` to ensure the API communication is functional.