### PR TITLE
fix: reasoning content roundtrip for deepseek/kimi models

### DIFF
--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -303,7 +303,7 @@ impl OpenAIAdapter {
 
 				// Assistant - For now support Text and ToolCalls
 				ChatRole::Assistant => {
-					// -- If we have only text, then, we jjust returned the joined_texts
+					let reasoning = msg.reasoning_content; // move out before iterating content
 					let mut texts: Vec<String> = Vec::new();
 					let mut tool_calls: Vec<Value> = Vec::new();
 					for part in msg.content {
@@ -333,6 +333,10 @@ impl OpenAIAdapter {
 					let mut message = json!({"role": "assistant", "content": content});
 					if !tool_calls.is_empty() {
 						message.x_insert("tool_calls", tool_calls)?;
+					}
+					// Echo reasoning_content back for providers that require it (Kimi, DeepSeek)
+					if let Some(reasoning) = reasoning {
+						message.x_insert("reasoning_content", reasoning)?;
 					}
 					messages.push(message);
 				}

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -437,3 +437,73 @@ struct OpenAIRequestParts {
 }
 
 // endregion: --- Support
+
+// region:    --- Tests
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::adapter::AdapterKind;
+	use crate::chat::{ChatMessage, ContentPart, MessageContent, ToolCall};
+
+	fn test_model() -> ModelIden {
+		ModelIden::new(AdapterKind::OpenAI, "test-model")
+	}
+
+	/// When an assistant message carries reasoning_content, it must appear
+	/// in the serialized JSON so providers that require it (Kimi, DeepSeek)
+	/// don't reject the request.
+	#[test]
+	fn test_reasoning_content_serialized_on_assistant_message() {
+		let tool_call = ToolCall {
+			call_id: "call_1".to_string(),
+			fn_name: "get_weather".to_string(),
+			fn_arguments: serde_json::json!({"city": "Paris"}),
+			thought_signatures: None,
+		};
+
+		let assistant_msg = ChatMessage::assistant(MessageContent::from_parts(vec![
+			ContentPart::Text("Let me check.".to_string()),
+			ContentPart::ToolCall(tool_call),
+		]))
+		.with_reasoning_content(Some("I should look up the weather.".to_string()));
+
+		let chat_req = ChatRequest::new(vec![
+			ChatMessage::user("What's the weather in Paris?"),
+			assistant_msg,
+		]);
+
+		let parts = OpenAIAdapter::into_openai_request_parts(&test_model(), chat_req)
+			.expect("should serialize");
+
+		// The assistant message is the second message (after user)
+		let assistant_json = &parts.messages[1];
+		assert_eq!(assistant_json["role"], "assistant");
+		assert_eq!(
+			assistant_json["reasoning_content"],
+			"I should look up the weather.",
+			"reasoning_content should be present in serialized assistant message"
+		);
+	}
+
+	/// When reasoning_content is None, the field should not appear in the JSON.
+	#[test]
+	fn test_no_reasoning_content_when_absent() {
+		let chat_req = ChatRequest::new(vec![
+			ChatMessage::user("Hello"),
+			ChatMessage::assistant("Hi there!"),
+		]);
+
+		let parts = OpenAIAdapter::into_openai_request_parts(&test_model(), chat_req)
+			.expect("should serialize");
+
+		let assistant_json = &parts.messages[1];
+		assert_eq!(assistant_json["role"], "assistant");
+		assert!(
+			assistant_json.get("reasoning_content").is_none(),
+			"reasoning_content should be absent when not set"
+		);
+	}
+}
+
+// endregion: --- Tests

--- a/src/chat/chat_message.rs
+++ b/src/chat/chat_message.rs
@@ -19,6 +19,12 @@ pub struct ChatMessage {
 
 	/// Optional per-message options (e.g., cache control).
 	pub options: Option<MessageOptions>,
+
+	/// Reasoning/thinking content from models that support it (e.g., DeepSeek, Kimi).
+	/// When present on an assistant message, adapters should serialize it back
+	/// so providers that require it for tool-call continuations get it.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub reasoning_content: Option<String>,
 }
 
 /// Constructors
@@ -29,6 +35,7 @@ impl ChatMessage {
 			role: ChatRole::System,
 			content: content.into(),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 
@@ -38,6 +45,7 @@ impl ChatMessage {
 			role: ChatRole::Assistant,
 			content: content.into(),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 
@@ -47,6 +55,7 @@ impl ChatMessage {
 			role: ChatRole::User,
 			content: content.into(),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 }
@@ -65,6 +74,12 @@ impl ChatMessage {
 	/// Attaches options to this message.
 	pub fn with_options(mut self, options: impl Into<MessageOptions>) -> Self {
 		self.options = Some(options.into());
+		self
+	}
+
+	/// Attaches reasoning content to this message.
+	pub fn with_reasoning_content(mut self, reasoning: Option<String>) -> Self {
+		self.reasoning_content = reasoning;
 		self
 	}
 
@@ -153,6 +168,7 @@ impl From<Vec<ToolCall>> for ChatMessage {
 			role: ChatRole::Assistant,
 			content: MessageContent::from(tool_calls),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 }
@@ -163,6 +179,7 @@ impl From<ToolResponse> for ChatMessage {
 			role: ChatRole::Tool,
 			content: MessageContent::from(value),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 }


### PR DESCRIPTION
I had Claude look through this, fix seems straightforward enough, just add a reasoning_content optional parameter to the message and allow sending it back.

This should be seen as a patch while it remains unclear what exactly should be done with these models that now break the OpenAI adapter API.

As an example for how an integrator would use this:

When the LLM responds with tool calls, you send the assistant message back in the next request. Kimi/DeepSeek expect reasoning_content to be  included on that assistant message, or they error out.                                                                                     
```                                                                                                                                             
  let reasoning_content = response.reasoning_content.clone();
  let tool_calls = response.into_tool_calls(); 

  // Build the assistant message for the next LLM call
  let assistant_msg = ChatMessage::from(tool_calls).with_reasoning_content(reasoning_content);
  messages.push(assistant_msg); 
 ```                                                                                                                              
Without this, the provider (e.g. kimi k2.5 thinking) rejects the request because the reasoning chain is broken.

Basically, you need to clone `response.reasoning_content` before consuming the response, and send it back in tool-use loops. Everything else is optional or automatic.

Related issue: https://github.com/jeremychone/rust-genai/issues/138