### PR TITLE
feat: add reasoning_content content part

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -565,6 +565,7 @@ impl AnthropicAdapter {
 									}));
 								}
 								ContentPart::ThoughtSignature(_) => {}
+								ContentPart::ReasoningContent(_) => {}
 								// Custom are ignored for this logic
 								ContentPart::Custom(_) => {}
 							}
@@ -600,6 +601,7 @@ impl AnthropicAdapter {
 							ContentPart::Binary(_) => {}
 							ContentPart::ToolResponse(_) => {}
 							ContentPart::ThoughtSignature(_) => {}
+							ContentPart::ReasoningContent(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -653,11 +653,7 @@ impl GeminiAdapter {
 									parts_values.push(json!({"thoughtSignature": thought}));
 								}
 							}
-							ContentPart::ReasoningContent(_) => {
-								if let Some(thought) = pending_thought.take() {
-									parts_values.push(json!({"thoughtSignature": thought}));
-								}
-							}
+							ContentPart::ReasoningContent(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -583,6 +583,7 @@ impl GeminiAdapter {
 								}));
 							}
 
+							ContentPart::ReasoningContent(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}
@@ -652,6 +653,11 @@ impl GeminiAdapter {
 									parts_values.push(json!({"thoughtSignature": thought}));
 								}
 							}
+							ContentPart::ReasoningContent(_) => {
+								if let Some(thought) = pending_thought.take() {
+									parts_values.push(json!({"thoughtSignature": thought}));
+								}
+							}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}
@@ -691,6 +697,7 @@ impl GeminiAdapter {
 									"thoughtSignature": thought
 								}));
 							}
+							ContentPart::ReasoningContent(_) => {}
 							_ => {
 								return Err(Error::MessageContentTypeNotSupported {
 									model_iden: model_iden.clone(),

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -303,7 +303,7 @@ impl OpenAIAdapter {
 
 				// Assistant - For now support Text and ToolCalls
 				ChatRole::Assistant => {
-					// -- If we have only text, then, we jjust returned the joined_texts
+					let reasoning = msg.reasoning_content; // move out before iterating content
 					let mut texts: Vec<String> = Vec::new();
 					let mut tool_calls: Vec<Value> = Vec::new();
 					for part in msg.content {
@@ -333,6 +333,10 @@ impl OpenAIAdapter {
 					let mut message = json!({"role": "assistant", "content": content});
 					if !tool_calls.is_empty() {
 						message.x_insert("tool_calls", tool_calls)?;
+					}
+					// Echo reasoning_content back for providers that require it (Kimi, DeepSeek)
+					if let Some(reasoning) = reasoning {
+						message.x_insert("reasoning_content", reasoning)?;
 					}
 					messages.push(message);
 				}

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -293,6 +293,7 @@ impl OpenAIAdapter {
 								ContentPart::ToolCall(_) => (),
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
+								ContentPart::ReasoningContent(_) => (),
 								// Custom are ignored for this logic
 								ContentPart::Custom(_) => {}
 							}
@@ -303,9 +304,9 @@ impl OpenAIAdapter {
 
 				// Assistant - For now support Text and ToolCalls
 				ChatRole::Assistant => {
-					let reasoning = msg.reasoning_content; // move out before iterating content
 					let mut texts: Vec<String> = Vec::new();
 					let mut tool_calls: Vec<Value> = Vec::new();
+					let mut reasoning_parts: Vec<String> = Vec::new();
 					for part in msg.content {
 						match part {
 							ContentPart::Text(text) => texts.push(text),
@@ -320,6 +321,8 @@ impl OpenAIAdapter {
 									}
 								}))
 							}
+							// Extract reasoning content parts to hoist into sibling field
+							ContentPart::ReasoningContent(reasoning) => reasoning_parts.push(reasoning),
 
 							// TODO: Probably need towarn on this one (probably need to add binary here)
 							ContentPart::Binary(_) => (),
@@ -335,8 +338,10 @@ impl OpenAIAdapter {
 						message.x_insert("tool_calls", tool_calls)?;
 					}
 					// Echo reasoning_content back for providers that require it (Kimi, DeepSeek)
-					if let Some(reasoning) = reasoning {
-						message.x_insert("reasoning_content", reasoning)?;
+					// Note: In practice there is at most one ReasoningContent part per message,
+					//       but we join defensively in case multiple parts are present.
+					if !reasoning_parts.is_empty() {
+						message.x_insert("reasoning_content", reasoning_parts.join("\n"))?;
 					}
 					messages.push(message);
 				}

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -437,3 +437,73 @@ struct OpenAIRequestParts {
 }
 
 // endregion: --- Support
+
+// region:    --- Tests
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::adapter::AdapterKind;
+	use crate::chat::{ChatMessage, ContentPart, MessageContent, ToolCall};
+
+	fn test_model() -> ModelIden {
+		ModelIden::new(AdapterKind::OpenAI, "test-model")
+	}
+
+	/// When an assistant message carries reasoning_content, it must appear
+	/// in the serialized JSON so providers that require it (Kimi, DeepSeek)
+	/// don't reject the request.
+	#[test]
+	fn test_reasoning_content_serialized_on_assistant_message() {
+		let tool_call = ToolCall {
+			call_id: "call_1".to_string(),
+			fn_name: "get_weather".to_string(),
+			fn_arguments: serde_json::json!({"city": "Paris"}),
+			thought_signatures: None,
+		};
+
+		let assistant_msg = ChatMessage::assistant(MessageContent::from_parts(vec![
+			ContentPart::Text("Let me check.".to_string()),
+			ContentPart::ToolCall(tool_call),
+		]))
+		.with_reasoning_content(Some("I should look up the weather.".to_string()));
+
+		let chat_req = ChatRequest::new(vec![
+			ChatMessage::user("What's the weather in Paris?"),
+			assistant_msg,
+		]);
+
+		let parts = OpenAIAdapter::into_openai_request_parts(&test_model(), chat_req)
+			.expect("should serialize");
+
+		// The assistant message is the second message (after user)
+		let assistant_json = &parts.messages[1];
+		assert_eq!(assistant_json["role"], "assistant");
+		assert_eq!(
+			assistant_json["reasoning_content"],
+			"I should look up the weather.",
+			"reasoning_content should be present in serialized assistant message"
+		);
+	}
+
+	/// When reasoning_content is None, the field should not appear in the JSON.
+	#[test]
+	fn test_no_reasoning_content_when_absent() {
+		let chat_req = ChatRequest::new(vec![
+			ChatMessage::user("Hello"),
+			ChatMessage::assistant("Hi there!"),
+		]);
+
+		let parts = OpenAIAdapter::into_openai_request_parts(&test_model(), chat_req)
+			.expect("should serialize");
+
+		let assistant_json = &parts.messages[1];
+		assert_eq!(assistant_json["role"], "assistant");
+		assert!(
+			assistant_json.get("reasoning_content").is_none(),
+			"reasoning_content should be absent when not set"
+		);
+	}
+}
+
+// endregion: --- Tests

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -385,6 +385,7 @@ impl OpenAIRespAdapter {
 								ContentPart::ToolCall(_) => (),
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
+								ContentPart::ReasoningContent(_) => (),
 								// Custom are ignored for this logic
 								ContentPart::Custom(_) => {}
 							}
@@ -430,6 +431,7 @@ impl OpenAIRespAdapter {
 							ContentPart::Binary(_) => {}
 							ContentPart::ToolResponse(_) => {}
 							ContentPart::ThoughtSignature(_) => {}
+							ContentPart::ReasoningContent(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}

--- a/src/chat/chat_message.rs
+++ b/src/chat/chat_message.rs
@@ -19,12 +19,6 @@ pub struct ChatMessage {
 
 	/// Optional per-message options (e.g., cache control).
 	pub options: Option<MessageOptions>,
-
-	/// Reasoning/thinking content from models that support it (e.g., DeepSeek, Kimi).
-	/// When present on an assistant message, adapters should serialize it back
-	/// so providers that require it for tool-call continuations get it.
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub reasoning_content: Option<String>,
 }
 
 /// Constructors
@@ -35,7 +29,6 @@ impl ChatMessage {
 			role: ChatRole::System,
 			content: content.into(),
 			options: None,
-			reasoning_content: None,
 		}
 	}
 
@@ -45,7 +38,6 @@ impl ChatMessage {
 			role: ChatRole::Assistant,
 			content: content.into(),
 			options: None,
-			reasoning_content: None,
 		}
 	}
 
@@ -55,7 +47,6 @@ impl ChatMessage {
 			role: ChatRole::User,
 			content: content.into(),
 			options: None,
-			reasoning_content: None,
 		}
 	}
 }
@@ -77,9 +68,12 @@ impl ChatMessage {
 		self
 	}
 
-	/// Attaches reasoning content to this message.
+	/// Attach reasoning content to this message as a `ContentPart::ReasoningContent` part.
+	/// This is used for round-tripping assistant reasoning (e.g., DeepSeek, Kimi).
 	pub fn with_reasoning_content(mut self, reasoning: Option<String>) -> Self {
-		self.reasoning_content = reasoning;
+		if let Some(reasoning) = reasoning {
+			self.content.push(ContentPart::ReasoningContent(reasoning));
+		}
 		self
 	}
 
@@ -168,7 +162,6 @@ impl From<Vec<ToolCall>> for ChatMessage {
 			role: ChatRole::Assistant,
 			content: MessageContent::from(tool_calls),
 			options: None,
-			reasoning_content: None,
 		}
 	}
 }
@@ -179,7 +172,6 @@ impl From<ToolResponse> for ChatMessage {
 			role: ChatRole::Tool,
 			content: MessageContent::from(value),
 			options: None,
-			reasoning_content: None,
 		}
 	}
 }

--- a/src/chat/chat_message.rs
+++ b/src/chat/chat_message.rs
@@ -19,6 +19,12 @@ pub struct ChatMessage {
 
 	/// Optional per-message options (e.g., cache control).
 	pub options: Option<MessageOptions>,
+
+	/// Reasoning/thinking content from models that support it (e.g., DeepSeek, Kimi).
+	/// When present on an assistant message, adapters should serialize it back
+	/// so providers that require it for tool-call continuations get it.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub reasoning_content: Option<String>,
 }
 
 /// Constructors
@@ -29,6 +35,7 @@ impl ChatMessage {
 			role: ChatRole::System,
 			content: content.into(),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 
@@ -38,6 +45,7 @@ impl ChatMessage {
 			role: ChatRole::Assistant,
 			content: content.into(),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 
@@ -47,6 +55,7 @@ impl ChatMessage {
 			role: ChatRole::User,
 			content: content.into(),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 }
@@ -65,6 +74,12 @@ impl ChatMessage {
 	/// Attaches options to this message.
 	pub fn with_options(mut self, options: impl Into<MessageOptions>) -> Self {
 		self.options = Some(options.into());
+		self
+	}
+
+	/// Attaches reasoning content to this message.
+	pub fn with_reasoning_content(mut self, reasoning: Option<String>) -> Self {
+		self.reasoning_content = reasoning;
 		self
 	}
 
@@ -153,6 +168,7 @@ impl From<Vec<ToolCall>> for ChatMessage {
 			role: ChatRole::Assistant,
 			content: MessageContent::from(tool_calls),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 }
@@ -163,6 +179,7 @@ impl From<ToolResponse> for ChatMessage {
 			role: ChatRole::Tool,
 			content: MessageContent::from(value),
 			options: None,
+			reasoning_content: None,
 		}
 	}
 }

--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -256,10 +256,10 @@ impl StreamEnd {
 		if tool_calls.is_empty() {
 			return None;
 		}
-		Some(ChatMessage::assistant_tool_calls_with_thoughts(
-			tool_calls,
-			thought_signatures,
-		))
+		Some(
+			ChatMessage::assistant_tool_calls_with_thoughts(tool_calls, thought_signatures)
+				.with_reasoning_content(self.captured_reasoning_content),
+		)
 	}
 }
 

--- a/src/chat/content_part/common.rs
+++ b/src/chat/content_part/common.rs
@@ -26,6 +26,13 @@ pub enum ContentPart {
 	#[from(ignore)]
 	ThoughtSignature(String),
 
+	/// Reasoning/thinking content from models that support it (e.g., DeepSeek, kimi).
+	/// Adapters extract provider-specific reasoning and normalize it into this variant.
+	/// On the request path, adapters hoist these parts back into the provider wire format
+	/// (e.g., sibling `reasoning_content` field for OpenAI-compatible providers).
+	#[from(ignore)]
+	ReasoningContent(String),
+
 	#[from]
 	Custom(CustomPart),
 }
@@ -169,13 +176,31 @@ impl ContentPart {
 			None
 		}
 	}
+
+	/// Borrow the reasoning content if present.
+	pub fn as_reasoning_content(&self) -> Option<&str> {
+		if let ContentPart::ReasoningContent(reasoning) = self {
+			Some(reasoning)
+		} else {
+			None
+		}
+	}
+
+	/// Extract the reasoning content, consuming the part.
+	pub fn into_reasoning_content(self) -> Option<String> {
+		if let ContentPart::ReasoningContent(reasoning) = self {
+			Some(reasoning)
+		} else {
+			None
+		}
+	}
 }
 
 /// Computed accessors
 impl ContentPart {
 	/// Returns an approximate in-memory size of this `ContentPart`, in bytes.
 	///
-	/// - For `Text` and `ThoughtSignature`: the UTF-8 length of the string.
+	/// - For `Text`, `ThoughtSignature`, and `ReasoningContent`: the UTF-8 length of the string.
 	/// - For `Binary`: delegates to `Binary::size()`.
 	/// - For `ToolCall`: delegates to `ToolCall::size()`.
 	/// - For `ToolResponse`: delegates to `ToolResponse::size()`.
@@ -186,6 +211,7 @@ impl ContentPart {
 			ContentPart::ToolCall(tool_call) => tool_call.size(),
 			ContentPart::ToolResponse(tool_response) => tool_response.size(),
 			ContentPart::ThoughtSignature(thought) => thought.len(),
+			ContentPart::ReasoningContent(reasoning) => reasoning.len(),
 			ContentPart::Custom(_value) => 0, // TODO: will need to compute this size
 		}
 	}
@@ -236,5 +262,10 @@ impl ContentPart {
 	/// Returns true if this part is a thought.
 	pub fn is_thought_signature(&self) -> bool {
 		matches!(self, ContentPart::ThoughtSignature(_))
+	}
+
+	/// Returns true if this part is reasoning content.
+	pub fn is_reasoning_content(&self) -> bool {
+		matches!(self, ContentPart::ReasoningContent(_))
 	}
 }

--- a/src/chat/message_content.rs
+++ b/src/chat/message_content.rs
@@ -220,6 +220,29 @@ impl MessageContent {
 		self.parts.len()
 	}
 
+	/// Return references to all ReasoningContent parts as &str.
+	pub fn reasoning_contents(&self) -> Vec<&str> {
+		self.parts.iter().filter_map(|p| p.as_reasoning_content()).collect()
+	}
+
+	/// Consume and return all ReasoningContent parts as owned Strings.
+	pub fn into_reasoning_contents(self) -> Vec<String> {
+		self.parts
+			.into_iter()
+			.filter_map(|p| p.into_reasoning_content())
+			.collect()
+	}
+
+	/// Join all reasoning content parts with a newline separator.
+	/// Returns None if there are no reasoning content parts.
+	pub fn joined_reasoning_content(&self) -> Option<String> {
+		let parts = self.reasoning_contents();
+		if parts.is_empty() {
+			return None;
+		}
+		Some(parts.join("\n"))
+	}
+
 	/// True if empty, or if all parts are text whose content is empty or whitespace.
 	pub fn is_text_empty(&self) -> bool {
 		if self.parts.is_empty() {
@@ -306,6 +329,11 @@ impl MessageContent {
 	/// True if at least one part is a ToolResponse.
 	pub fn contains_tool_response(&self) -> bool {
 		self.parts.iter().any(|p| p.is_tool_response())
+	}
+
+	/// True if at least one part is ReasoningContent.
+	pub fn contains_reasoning_content(&self) -> bool {
+		self.parts.iter().any(|p| p.is_reasoning_content())
 	}
 }
 

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -682,16 +682,16 @@ pub async fn common_test_chat_stream_capture_content_ok(model: &str) -> TestResu
 		"StreamEnd should not have any meta_usage"
 	);
 
-	// -- Check captured_content
-	let captured_content = get_option_value!(stream_end.captured_content);
-	assert!(!captured_content.is_empty(), "captured_content.length should be > 0");
-
 	// -- Check Reasoning Content
 	// Should always be none, as it was not instructed to be captured.
 	assert!(
 		stream_end.captured_reasoning_content.is_none(),
 		"The captured_reasoning_content should be None"
 	);
+
+	// -- Check captured_content
+	let captured_content = get_option_value!(stream_end.captured_content);
+	assert!(!captured_content.is_empty(), "captured_content.length should be > 0");
 
 	Ok(())
 }


### PR DESCRIPTION
Following up from #138 and PR #147.

This pull request refactors reasoning_content into a new `content_part` which, in the openai adapter, is hoisted as a top-level field, similar to Gemini's `thought_signature` field.

This is needed for kimi reasoning models and deepseek as far as I know. The usage is still the same, integrators have access to a  `.with_reasoning_content()`  builder that attaches reasoning content to the `ChatMessage` as a content part.