### PR TITLE
fix: thread auth resolver through all_model_names()

### DIFF
--- a/src/adapter/adapter_types.rs
+++ b/src/adapter/adapter_types.rs
@@ -16,7 +16,7 @@ pub trait Adapter {
 	fn default_endpoint() -> Endpoint;
 
 	// NOTE: Adapter is a crate trait, so it is acceptable to use async fn here.
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>>;
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>>;
 
 	/// The base service URL for this AdapterKind for the given service type.
 	/// NOTE: For some services, the URL will be further updated in the to_web_request_data method.

--- a/src/adapter/adapters/aliyun/adapter_impl.rs
+++ b/src/adapter/adapters/aliyun/adapter_impl.rs
@@ -70,7 +70,7 @@ impl Adapter for AliyunAdapter {
 	}
 
 	/// Returns all supported model names for Aliyun
-	async fn all_model_names(_kind: AdapterKind) -> Result<Vec<String>> {
+	async fn all_model_names(_kind: AdapterKind, _endpoint: Endpoint, _auth: AuthData) -> Result<Vec<String>> {
 		Ok(MODELS.iter().map(|s| s.to_string()).collect())
 	}
 

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -124,8 +124,8 @@ impl Adapter for AnthropicAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		Self::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		Self::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(_model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/bigmodel/adapter_impl.rs
+++ b/src/adapter/adapters/bigmodel/adapter_impl.rs
@@ -31,8 +31,8 @@ impl Adapter for BigModelAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(_model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -43,7 +43,7 @@ impl Adapter for CohereAdapter {
 	}
 
 	/// Note: For now, it returns the common ones (see above)
-	async fn all_model_names(_kind: AdapterKind) -> Result<Vec<String>> {
+	async fn all_model_names(_kind: AdapterKind, _endpoint: Endpoint, _auth: AuthData) -> Result<Vec<String>> {
 		Ok(MODELS.iter().map(|s| s.to_string()).collect())
 	}
 

--- a/src/adapter/adapters/deepseek/adapter_impl.rs
+++ b/src/adapter/adapters/deepseek/adapter_impl.rs
@@ -29,8 +29,8 @@ impl Adapter for DeepSeekAdapter {
 		Endpoint::from_static(BASE_URL)
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/fireworks/adapter_impl.rs
+++ b/src/adapter/adapters/fireworks/adapter_impl.rs
@@ -40,8 +40,8 @@ impl Adapter for FireworksAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -64,10 +64,7 @@ impl Adapter for GeminiAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		let endpoint = Self::default_endpoint();
-		let auth = Self::default_auth();
-
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
 		// -- url
 		let base_url = endpoint.base_url();
 		let url = format!("{base_url}models");

--- a/src/adapter/adapters/groq/adapter_impl.rs
+++ b/src/adapter/adapters/groq/adapter_impl.rs
@@ -29,8 +29,8 @@ impl Adapter for GroqAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/mimo/adapter_impl.rs
+++ b/src/adapter/adapters/mimo/adapter_impl.rs
@@ -28,8 +28,8 @@ impl Adapter for MimoAdapter {
 		Endpoint::from_static(BASE_URL)
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/nebius/adapter_impl.rs
+++ b/src/adapter/adapters/nebius/adapter_impl.rs
@@ -29,8 +29,8 @@ impl Adapter for NebiusAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/ollama/adapter_impl.rs
+++ b/src/adapter/adapters/ollama/adapter_impl.rs
@@ -35,8 +35,7 @@ impl Adapter for OllamaAdapter {
 		}
 	}
 
-	async fn all_model_names(adapter_kind: AdapterKind) -> Result<Vec<String>> {
-		let endpoint = Self::default_endpoint();
+	async fn all_model_names(adapter_kind: AdapterKind, endpoint: Endpoint, _auth: AuthData) -> Result<Vec<String>> {
 		let base_url = endpoint.base_url();
 		let url = format!("{base_url}api/tags");
 

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -34,8 +34,8 @@ impl Adapter for OpenAIAdapter {
 	}
 
 	/// Note: Currently returns the common models (see above)
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -37,14 +37,9 @@ impl Adapter for OpenAIRespAdapter {
 	}
 
 	/// Note: Currently returns the common models (see above)
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
 		//
-		OpenAIAdapter::list_model_names_for_end_target(
-			kind,
-			OpenAIAdapter::default_endpoint(),
-			OpenAIAdapter::default_auth(),
-		)
-		.await
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/together/adapter_impl.rs
+++ b/src/adapter/adapters/together/adapter_impl.rs
@@ -30,8 +30,8 @@ impl Adapter for TogetherAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/xai/adapter_impl.rs
+++ b/src/adapter/adapters/xai/adapter_impl.rs
@@ -29,8 +29,8 @@ impl Adapter for XaiAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/adapters/zai/adapter_impl.rs
+++ b/src/adapter/adapters/zai/adapter_impl.rs
@@ -86,8 +86,8 @@ impl Adapter for ZaiAdapter {
 		}
 	}
 
-	async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
-		OpenAIAdapter::list_model_names_for_end_target(kind, Self::default_endpoint(), Self::default_auth()).await
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
 	}
 
 	fn get_service_url(_model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -73,24 +73,24 @@ impl AdapterDispatcher {
 		}
 	}
 
-	pub async fn all_model_names(kind: AdapterKind) -> Result<Vec<String>> {
+	pub async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
 		match kind {
-			AdapterKind::OpenAI => OpenAIAdapter::all_model_names(kind).await,
-			AdapterKind::OpenAIResp => OpenAIRespAdapter::all_model_names(kind).await,
-			AdapterKind::Gemini => GeminiAdapter::all_model_names(kind).await,
-			AdapterKind::Anthropic => AnthropicAdapter::all_model_names(kind).await,
-			AdapterKind::Fireworks => FireworksAdapter::all_model_names(kind).await,
-			AdapterKind::Together => TogetherAdapter::all_model_names(kind).await,
-			AdapterKind::Groq => GroqAdapter::all_model_names(kind).await,
-			AdapterKind::Mimo => MimoAdapter::all_model_names(kind).await,
-			AdapterKind::Nebius => NebiusAdapter::all_model_names(kind).await,
-			AdapterKind::Xai => XaiAdapter::all_model_names(kind).await,
-			AdapterKind::DeepSeek => DeepSeekAdapter::all_model_names(kind).await,
-			AdapterKind::Zai => ZaiAdapter::all_model_names(kind).await,
-			AdapterKind::BigModel => BigModelAdapter::all_model_names(kind).await,
-			AdapterKind::Aliyun => AliyunAdapter::all_model_names(kind).await,
-			AdapterKind::Cohere => CohereAdapter::all_model_names(kind).await,
-			AdapterKind::Ollama => OllamaAdapter::all_model_names(kind).await,
+			AdapterKind::OpenAI => OpenAIAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::OpenAIResp => OpenAIRespAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Gemini => GeminiAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Anthropic => AnthropicAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Fireworks => FireworksAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Together => TogetherAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Groq => GroqAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Mimo => MimoAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Nebius => NebiusAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Xai => XaiAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::DeepSeek => DeepSeekAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Zai => ZaiAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::BigModel => BigModelAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Aliyun => AliyunAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Cohere => CohereAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Ollama => OllamaAdapter::all_model_names(kind, endpoint, auth).await,
 		}
 	}
 

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -22,7 +22,8 @@ impl Client {
 	/// - Adapters should filter non-chat models until more skills are supported.
 	///   Future: `model_names(adapter_kind, Option<&[Skill]>)`.
 	pub async fn all_model_names(&self, adapter_kind: AdapterKind) -> Result<Vec<String>> {
-		let models = AdapterDispatcher::all_model_names(adapter_kind).await?;
+		let (auth, endpoint) = self.config().resolve_adapter_config(adapter_kind).await?;
+		let models = AdapterDispatcher::all_model_names(adapter_kind, endpoint, auth).await?;
 		Ok(models)
 	}
 

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -2,7 +2,7 @@ use crate::adapter::{AdapterDispatcher, AdapterKind};
 use crate::chat::ChatOptions;
 use crate::client::{ModelSpec, ServiceTarget};
 use crate::embed::EmbedOptions;
-use crate::resolver::{AuthData, AuthResolver, ModelMapper, ServiceTargetResolver};
+use crate::resolver::{AuthData, AuthResolver, Endpoint, ModelMapper, ServiceTargetResolver};
 use crate::{Error, ModelIden, Result, WebConfig};
 
 /// Configuration for building and customizing a `Client`.
@@ -96,6 +96,16 @@ impl ClientConfig {
 
 /// Resolvers
 impl ClientConfig {
+	/// Resolves auth and endpoint for the given adapter kind.
+	///
+	/// Used by `Client::all_model_names()` where no specific model name is available.
+	pub(crate) async fn resolve_adapter_config(&self, adapter_kind: AdapterKind) -> Result<(AuthData, Endpoint)> {
+		let model = ModelIden::new(adapter_kind, "");
+		let auth = self.run_auth_resolver(model).await?;
+		let endpoint = AdapterDispatcher::default_endpoint(adapter_kind);
+		Ok((auth, endpoint))
+	}
+
 	/// Resolves a ServiceTarget for the given model.
 	///
 	/// Applies the ModelMapper (if any), resolves auth (via AuthResolver or adapter default),


### PR DESCRIPTION
Client::all_model_names() previously called AdapterDispatcher::all_model_names() as a static method, ignoring the client's configured AuthResolver. Each adapter then fell back to default_auth() (env var lookup), causing 401 errors when auth was provided via with_auth_resolver_fn().

Changes:
- Add ClientConfig::resolve_adapter_config() to resolve auth and endpoint for an AdapterKind without requiring a specific model name
- Update Adapter trait signature to accept endpoint and auth parameters
- Thread resolved endpoint and auth from client through dispatcher to adapters
- Update all 16 adapter implementations to use passed parameters

The public API (Client::all_model_names(&self, AdapterKind)) is unchanged.