### PR TITLE
+ feat(chat): expose provider stop_reason in responses

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -3,8 +3,8 @@ use crate::adapter::anthropic::AnthropicStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	Binary, BinarySource, CacheControl, CacheCreationDetails, ChatOptionsSet, ChatRequest, ChatResponse, ChatRole,
-	ChatStream, ChatStreamResponse, ContentPart, MessageContent, PromptTokensDetails, ReasoningEffort, Tool, ToolCall,
-	ToolConfig, ToolName, Usage,
+	ChatStream, ChatStreamResponse, ContentPart, MessageContent, PromptTokensDetails, ReasoningEffort, StopReason, Tool,
+	ToolCall, ToolConfig, ToolName, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{EventSourceStream, WebResponse};
@@ -306,6 +306,7 @@ impl Adapter for AnthropicAdapter {
 		let usage = body.x_take::<Value>("usage");
 
 		let usage = usage.map(Self::into_usage).unwrap_or_default();
+		let stop_reason = body.x_take::<Option<String>>("stop_reason").ok().flatten().map(StopReason::from);
 
 		// -- Capture the content
 		let mut content: MessageContent = MessageContent::default();
@@ -359,6 +360,7 @@ impl Adapter for AnthropicAdapter {
 			reasoning_content,
 			model_iden,
 			provider_model_iden,
+			stop_reason,
 			usage,
 			captured_raw_body: None, // Set by the client exec_chat
 		})

--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -1,7 +1,7 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::anthropic::parse_cache_creation_details;
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatOptionsSet, PromptTokensDetails, ToolCall, Usage};
+use crate::chat::{ChatOptionsSet, PromptTokensDetails, StopReason, ToolCall, Usage};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
 use serde_json::{Map, Value};
@@ -61,6 +61,12 @@ impl futures::Stream for AnthropicStreamer {
 						}
 						"message_delta" => {
 							self.capture_usage(message_type, &message.data)?;
+							// Capture stop_reason from delta (e.g., "end_turn", "max_tokens", "tool_use")
+							if let Ok(data) = self.parse_message_data(&message.data) {
+								if let Ok(reason) = data.x_get::<String>("/delta/stop_reason") {
+									self.captured_data.stop_reason = Some(reason);
+								}
+							}
 							continue;
 						}
 						"content_block_start" => {
@@ -197,6 +203,7 @@ impl futures::Stream for AnthropicStreamer {
 
 							let inter_stream_end = InterStreamEnd {
 								captured_usage,
+								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 								captured_text_content: self.captured_data.content.take(),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
 								captured_tool_calls: self.captured_data.tool_calls.take(),

--- a/src/adapter/adapters/cohere/adapter_impl.rs
+++ b/src/adapter/adapters/cohere/adapter_impl.rs
@@ -2,7 +2,8 @@ use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::cohere::CohereStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
-	ChatOptionsSet, ChatRequest, ChatResponse, ChatRole, ChatStream, ChatStreamResponse, MessageContent, Usage,
+	ChatOptionsSet, ChatRequest, ChatResponse, ChatRole, ChatStream, ChatStreamResponse, MessageContent, StopReason,
+	Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebResponse, WebStream};
@@ -133,6 +134,9 @@ impl Adapter for CohereAdapter {
 		let provider_model_name = None;
 		let provider_model_iden = model_iden.from_optional_name(provider_model_name);
 
+		// -- Get stop_reason
+		let stop_reason = body.x_take::<Option<String>>("finish_reason").ok().flatten().map(StopReason::from);
+
 		// -- Get usage
 		let usage = body.x_take("/meta/tokens").map(Self::into_usage).unwrap_or_default();
 
@@ -151,6 +155,7 @@ impl Adapter for CohereAdapter {
 			reasoning_content: None,
 			model_iden,
 			provider_model_iden,
+			stop_reason,
 			usage,
 			captured_raw_body: None, // Set by the client exec_chat
 		})

--- a/src/adapter/adapters/cohere/streamer.rs
+++ b/src/adapter/adapters/cohere/streamer.rs
@@ -1,7 +1,7 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::cohere::CohereAdapter;
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::ChatOptionsSet;
+use crate::chat::{ChatOptionsSet, StopReason};
 use crate::webc::WebStream;
 use crate::{Error, ModelIden, Result};
 use serde::Deserialize;
@@ -38,6 +38,7 @@ struct CohereStreamMessage {
 	is_finished: bool,
 	event_type: String,
 	text: Option<String>,
+	finish_reason: Option<String>,
 	response: Option<CohereStreamMessageResponse>,
 }
 #[derive(Deserialize, Debug)]
@@ -84,6 +85,9 @@ impl futures::Stream for CohereStreamer {
 									}
 								}
 								"stream-end" => {
+									// -- Capture stop_reason
+									self.captured_data.stop_reason = cohere_message.finish_reason;
+
 									// -- Capture usage
 									let meta = cohere_message.response.and_then(|r| r.meta);
 									let captured_usage = if self.options.capture_usage {
@@ -105,6 +109,7 @@ impl futures::Stream for CohereStreamer {
 
 									let inter_stream_end = InterStreamEnd {
 										captured_usage,
+										captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 										captured_text_content: self.captured_data.content.take(),
 										captured_reasoning_content: self.captured_data.reasoning_content.take(),
 										captured_tool_calls: self.captured_data.tool_calls.take(),

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -4,7 +4,7 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	Binary, BinarySource, ChatOptionsSet, ChatRequest, ChatResponse, ChatResponseFormat, ChatRole, ChatStream,
 	ChatStreamResponse, CompletionTokensDetails, ContentPart, MessageContent, PromptTokensDetails, ReasoningEffort,
-	Tool, ToolCall, ToolConfig, ToolName, Usage,
+	StopReason, Tool, ToolCall, ToolConfig, ToolName, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebResponse, WebStream};
@@ -260,7 +260,9 @@ impl Adapter for GeminiAdapter {
 		let GeminiChatResponse {
 			content: gemini_content,
 			usage,
+			stop_reason,
 		} = gemini_response;
+		let stop_reason = stop_reason.map(StopReason::from);
 
 		let mut thoughts: Vec<String> = Vec::new();
 		let mut reasonings: Vec<String> = Vec::new();
@@ -318,6 +320,7 @@ impl Adapter for GeminiAdapter {
 			reasoning_content: Some(reasoning_text),
 			model_iden,
 			provider_model_iden,
+			stop_reason,
 			usage,
 			captured_raw_body: None, // Set by the client exec_chat
 		})
@@ -448,9 +451,10 @@ impl GeminiAdapter {
 				}
 			}
 		}
+		let stop_reason: Option<String> = body.x_take("/candidates/0/finishReason").ok();
 		let usage = body.x_take::<Value>("usageMetadata").map(Self::into_usage).unwrap_or_default();
 
-		Ok(GeminiChatResponse { content, usage })
+		Ok(GeminiChatResponse { content, usage, stop_reason })
 	}
 
 	/// See gemini doc: https://ai.google.dev/api/generate-content#UsageMetadata
@@ -808,6 +812,7 @@ pub enum GeminiTool {
 pub(super) struct GeminiChatResponse {
 	pub content: Vec<GeminiChatContent>,
 	pub usage: Usage,
+	pub stop_reason: Option<String>,
 }
 
 pub(super) enum GeminiChatContent {

--- a/src/adapter/adapters/gemini/streamer.rs
+++ b/src/adapter/adapters/gemini/streamer.rs
@@ -1,7 +1,7 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::gemini::{GeminiAdapter, GeminiChatResponse};
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatOptionsSet, ToolCall};
+use crate::chat::{ChatOptionsSet, StopReason, ToolCall};
 use crate::webc::WebStream;
 use crate::{Error, ModelIden, Result};
 use serde_json::Value;
@@ -61,6 +61,7 @@ impl futures::Stream for GeminiStreamer {
 						"]" => {
 							let inter_stream_end = InterStreamEnd {
 								captured_usage: self.captured_data.usage.take(),
+								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 								captured_text_content: self.captured_data.content.take(),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
 								captured_tool_calls: self.captured_data.tool_calls.take(),
@@ -95,7 +96,12 @@ impl futures::Stream for GeminiStreamer {
 									}
 								};
 
-							let GeminiChatResponse { content, usage } = gemini_response;
+							let GeminiChatResponse { content, usage, stop_reason } = gemini_response;
+
+							// -- Capture stop_reason if present (typically in the last chunk)
+							if stop_reason.is_some() {
+								self.captured_data.stop_reason = stop_reason;
+							}
 
 							// -- Extract text and toolcall
 							// WARNING: Assume that only ONE tool call per message (or take the last one)

--- a/src/adapter/adapters/ollama/adapter_impl.rs
+++ b/src/adapter/adapters/ollama/adapter_impl.rs
@@ -5,7 +5,7 @@ use crate::adapter::ollama::OllamaStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	Binary, BinarySource, ChatOptionsSet, ChatRequest, ChatResponse, ChatStream, ChatStreamResponse, ContentPart,
-	MessageContent, Tool, ToolCall, ToolName, Usage,
+	MessageContent, StopReason, Tool, ToolCall, ToolName, Usage,
 };
 use crate::embed::{EmbedResponse, Embedding};
 use crate::resolver::{AuthData, Endpoint};
@@ -190,6 +190,7 @@ impl Adapter for OllamaAdapter {
 			reasoning_content,
 			model_iden: model_iden.clone(),
 			provider_model_iden: model_iden,
+			stop_reason: body.x_take::<Option<String>>("done_reason").ok().flatten().map(StopReason::from),
 			usage,
 			captured_raw_body,
 		})

--- a/src/adapter/adapters/ollama/streamer.rs
+++ b/src/adapter/adapters/ollama/streamer.rs
@@ -1,6 +1,6 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatOptionsSet, ToolCall, Usage};
+use crate::chat::{ChatOptionsSet, StopReason, ToolCall, Usage};
 use crate::webc::WebStream;
 use crate::{Error, ModelIden, Result};
 use serde_json::Value;
@@ -137,6 +137,9 @@ impl futures::Stream for OllamaStreamer {
 						if done {
 							self.done = true;
 
+							// Capture done_reason (e.g., "stop", "length")
+							self.captured_data.stop_reason = data.x_take::<String>("done_reason").ok();
+
 							if self.options.capture_usage {
 								let prompt_tokens = data.x_get::<i32>("/prompt_eval_count").ok();
 								let completion_tokens = data.x_get::<i32>("/eval_count").ok();
@@ -155,6 +158,7 @@ impl futures::Stream for OllamaStreamer {
 
 							let inter_stream_end = InterStreamEnd {
 								captured_usage: self.captured_data.usage.take(),
+								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 								captured_text_content: self.captured_data.content.take(),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
 								captured_tool_calls: self.captured_data.tool_calls.take(),
@@ -177,6 +181,7 @@ impl futures::Stream for OllamaStreamer {
 						self.done = true;
 						let inter_stream_end = InterStreamEnd {
 							captured_usage: self.captured_data.usage.take(),
+							captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 							captured_text_content: self.captured_data.content.take(),
 							captured_reasoning_content: self.captured_data.reasoning_content.take(),
 							captured_tool_calls: self.captured_data.tool_calls.take(),

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -1,7 +1,7 @@
 use crate::adapter::openai::OpenAIStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
-	ChatOptionsSet, ChatRequest, ChatResponse, ChatStream, ChatStreamResponse, MessageContent, ToolCall,
+	ChatOptionsSet, ChatRequest, ChatResponse, ChatStream, ChatStreamResponse, MessageContent, StopReason, ToolCall,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{EventSourceStream, WebResponse};
@@ -71,8 +71,15 @@ impl Adapter for OpenAIAdapter {
 		// -- Capture the content
 		let mut content: MessageContent = MessageContent::default();
 		let mut reasoning_content: Option<String> = None;
+		let mut stop_reason: Option<StopReason> = None;
 
 		if let Ok(Some(mut first_choice)) = body.x_take::<Option<Value>>("/choices/0") {
+			stop_reason = first_choice
+				.x_take::<Option<String>>("finish_reason")
+				.ok()
+				.flatten()
+				.map(StopReason::from);
+
 			// Check if reasoning is present
 			// Can be in two places:
 			// - /message/reasoning
@@ -122,6 +129,7 @@ impl Adapter for OpenAIAdapter {
 			reasoning_content,
 			model_iden,
 			provider_model_iden,
+			stop_reason,
 			usage,
 			captured_raw_body: None, // Set by the client exec_chat
 		})
@@ -250,3 +258,56 @@ fn parse_tool_call(raw_tool_call: Value) -> Result<ToolCall> {
 }
 
 // endregion: --- Support
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::adapter::AdapterKind;
+	use reqwest::StatusCode;
+
+	fn test_model() -> ModelIden {
+		ModelIden::new(AdapterKind::OpenAI, "gpt-4o-mini")
+	}
+
+	#[test]
+	fn test_to_chat_response_captures_finish_reason_as_stop_reason() {
+		let web_response = WebResponse {
+			status: StatusCode::OK,
+			body: serde_json::json!({
+				"id": "chatcmpl-test",
+				"model": "gpt-4o-mini-2024-07-18",
+				"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+				"choices": [{
+					"finish_reason": "stop",
+					"message": {"role": "assistant", "content": "hello"}
+				}]
+			}),
+		};
+
+		let response = OpenAIAdapter::to_chat_response(test_model(), web_response, ChatOptionsSet::default())
+			.expect("chat response");
+
+		assert_eq!(response.stop_reason, Some(StopReason::Completed("stop".to_string())));
+		assert_eq!(response.first_text(), Some("hello"));
+	}
+
+	#[test]
+	fn test_to_chat_response_stop_reason_none_when_missing() {
+		let web_response = WebResponse {
+			status: StatusCode::OK,
+			body: serde_json::json!({
+				"id": "chatcmpl-test",
+				"model": "gpt-4o-mini-2024-07-18",
+				"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+				"choices": [{
+					"message": {"role": "assistant", "content": "hello"}
+				}]
+			}),
+		};
+
+		let response = OpenAIAdapter::to_chat_response(test_model(), web_response, ChatOptionsSet::default())
+			.expect("chat response");
+
+		assert_eq!(response.stop_reason, None);
+	}
+}

--- a/src/adapter/adapters/openai/streamer.rs
+++ b/src/adapter/adapters/openai/streamer.rs
@@ -2,7 +2,7 @@ use crate::adapter::AdapterKind;
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
 use crate::adapter::openai::OpenAIAdapter;
-use crate::chat::{ChatOptionsSet, ToolCall};
+use crate::chat::{ChatOptionsSet, StopReason, ToolCall};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
 use serde_json::Value;
@@ -141,6 +141,7 @@ impl futures::Stream for OpenAIStreamer {
 						// Return the internal stream end
 						let inter_stream_end = InterStreamEnd {
 							captured_usage,
+							captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 							captured_text_content: self.captured_data.content.take(),
 							captured_reasoning_content: self.captured_data.reasoning_content.take(),
 							captured_tool_calls,
@@ -173,7 +174,8 @@ impl futures::Stream for OpenAIStreamer {
 						// Since we support only a single choice, we can proceed,
 						// as there might be other messages, and the last one contains data: `[DONE]`
 						// NOTE: xAI has no `finish_reason` when not finished, so, need to just account for both null/absent
-						if let Ok(_finish_reason) = first_choice.x_take::<String>("finish_reason") {
+						if let Ok(Some(finish_reason)) = first_choice.x_take::<Option<String>>("finish_reason") {
+							self.captured_data.stop_reason = Some(finish_reason);
 							// NOTE: Some providers (e.g., Ollama) send tool_calls AND finish_reason in the same message.
 							// We need to capture tool_calls here before continuing to the next message.
 							if let Ok(delta_tool_calls) = first_choice.x_take::<Value>("/delta/tool_calls")

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -5,7 +5,7 @@ use crate::adapter::openai_resp::resp_types::RespResponse;
 use crate::adapter::{Adapter, AdapterDispatcher, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	ChatOptionsSet, ChatRequest, ChatResponse, ChatResponseFormat, ChatRole, ChatStream, ChatStreamResponse,
-	ContentPart, MessageContent, ReasoningEffort, Tool, ToolConfig, ToolName, Usage,
+	ContentPart, MessageContent, ReasoningEffort, StopReason, Tool, ToolConfig, ToolName, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{EventSourceStream, WebResponse};
@@ -219,6 +219,7 @@ impl Adapter for OpenAIRespAdapter {
 			reasoning_content,
 			model_iden,
 			provider_model_iden,
+			stop_reason: Some(StopReason::from(resp.status)),
 			usage,
 			captured_raw_body,
 		})

--- a/src/adapter/adapters/openai_resp/streamer.rs
+++ b/src/adapter/adapters/openai_resp/streamer.rs
@@ -1,7 +1,7 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
 use crate::adapter::openai_resp::resp_types::RespResponse;
-use crate::chat::{ChatOptionsSet, ToolCall};
+use crate::chat::{ChatOptionsSet, StopReason, ToolCall};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
 use serde::Deserialize;
@@ -180,6 +180,7 @@ impl futures::Stream for OpenAIRespStreamer {
 
 						RespStreamEvent::ResponseCompleted { response } => {
 							self.done = true;
+							self.captured_data.stop_reason = Some(response.status.clone());
 
 							if self.options.capture_usage {
 								self.captured_data.usage = response.usage.map(Into::into);
@@ -202,6 +203,7 @@ impl futures::Stream for OpenAIRespStreamer {
 
 							let inter_stream_end = InterStreamEnd {
 								captured_usage: self.captured_data.usage.take(),
+								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 								captured_text_content: self.captured_data.content.take(),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
 								captured_tool_calls: self.captured_data.tool_calls.take(),
@@ -227,10 +229,12 @@ impl futures::Stream for OpenAIRespStreamer {
 
 						RespStreamEvent::ResponseIncomplete { response } => {
 							self.done = true;
+							self.captured_data.stop_reason = Some(response.status.clone());
 							// For incomplete, we might still want to return what we have?
 							// But for now, let's treat it as a successful end but with whatever we captured.
 							let inter_stream_end = InterStreamEnd {
 								captured_usage: response.usage.map(Into::into),
+								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 								captured_text_content: self.captured_data.content.take(),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
 								captured_tool_calls: self.captured_data.tool_calls.take(),
@@ -258,6 +262,7 @@ impl futures::Stream for OpenAIRespStreamer {
 						self.done = true;
 						let inter_stream_end = InterStreamEnd {
 							captured_usage: self.captured_data.usage.take(),
+							captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
 							captured_text_content: self.captured_data.content.take(),
 							captured_reasoning_content: self.captured_data.reasoning_content.take(),
 							captured_tool_calls: self.captured_data.tool_calls.take(),

--- a/src/adapter/adapters/support.rs
+++ b/src/adapter/adapters/support.rs
@@ -43,6 +43,7 @@ impl StreamerOptions {
 #[derive(Debug, Default)]
 pub struct StreamerCapturedData {
 	pub usage: Option<Usage>,
+	pub stop_reason: Option<String>,
 	pub content: Option<String>,
 	pub reasoning_content: Option<String>,
 	pub tool_calls: Option<Vec<crate::chat::ToolCall>>,

--- a/src/adapter/inter_stream.rs
+++ b/src/adapter/inter_stream.rs
@@ -5,12 +5,15 @@
 //!
 //! NOTE: This might be removed at some point as it may not be needed, and we could go directly to the GenAI stream.
 
-use crate::chat::Usage;
+use crate::chat::{StopReason, Usage};
 
 #[derive(Debug, Default)]
 pub struct InterStreamEnd {
 	// When `ChatOptions..capture_usage == true`
 	pub captured_usage: Option<Usage>,
+
+	// Normalised stop reason.
+	pub captured_stop_reason: Option<StopReason>,
 
 	// When `ChatOptions..capture_content == true`
 	pub captured_text_content: Option<String>,

--- a/src/chat/chat_response.rs
+++ b/src/chat/chat_response.rs
@@ -5,6 +5,93 @@ use serde::{Deserialize, Serialize};
 use crate::ModelIden;
 use crate::chat::{ChatStream, MessageContent, ToolCall, Usage};
 
+// region:    --- StopReason
+
+/// Provider-agnostic stop reason.
+///
+/// All known provider strings are mapped automatically via `From<String>`:
+///
+/// | StopReason      | Provider strings                                                         |
+/// |-----------------|--------------------------------------------------------------------------|
+/// | `Completed`     | `stop`, `end_turn`, `STOP`, `COMPLETE`, `completed`                      |
+/// | `MaxTokens`     | `length`, `max_tokens`, `MAX_TOKENS`, `incomplete`                       |
+/// | `ToolCall`      | `tool_calls`, `tool_use`, `function_call`                                |
+/// | `ContentFilter` | `content_filter`, `SAFETY`, `RECITATION`, `BLOCKLIST`, …                 |
+/// | `StopSequence`  | `stop_sequence`, `STOP_SEQUENCE`                                         |
+/// | `Other(s)`      | anything else (`failed`, `cancelled`, `ERROR`, `load`, …)                |
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StopReason {
+	/// Model finished generating naturally.
+	Completed(String),
+	/// Output was truncated due to max_tokens limit.
+	MaxTokens(String),
+	/// Model invoked one or more tools.
+	ToolCall(String),
+	/// Content was filtered by safety / content-filter systems.
+	ContentFilter(String),
+	/// A caller-supplied stop sequence was matched.
+	StopSequence(String),
+	/// Provider-specific reason not covered above.
+	Other(String),
+}
+
+impl From<String> for StopReason {
+	fn from(reason: String) -> Self {
+		match reason.as_str() {
+			// -- Normal completion
+			"stop" | "end_turn" | "STOP" | "COMPLETE" | "completed" => Self::Completed(reason),
+
+			// -- Truncated by token limit
+			"length" | "max_tokens" | "MAX_TOKENS" | "incomplete" => Self::MaxTokens(reason),
+
+			// -- Tool invocation
+			"tool_calls" | "tool_use" | "function_call" => Self::ToolCall(reason),
+
+			// -- Content / safety filter
+			"content_filter" | "SAFETY" | "RECITATION" | "BLOCKLIST" | "PROHIBITED_CONTENT" | "SPII"
+			| "IMAGE_SAFETY" | "ERROR_TOXIC" => Self::ContentFilter(reason),
+
+			// -- Stop sequence
+			"stop_sequence" | "STOP_SEQUENCE" => Self::StopSequence(reason),
+
+			// -- Fallback
+			_ => Self::Other(reason),
+		}
+	}
+}
+
+impl StopReason {
+	/// Returns the original provider-specific string.
+	pub fn raw(&self) -> &str {
+		match self {
+			Self::Completed(s) | Self::MaxTokens(s) | Self::ToolCall(s) | Self::ContentFilter(s)
+			| Self::StopSequence(s) | Self::Other(s) => s,
+		}
+	}
+
+	/// Returns `true` when the response was truncated by a token limit.
+	pub fn is_max_tokens(&self) -> bool {
+		matches!(self, Self::MaxTokens(_))
+	}
+}
+
+impl PartialEq for StopReason {
+	/// Compares by variant only, ignoring the raw provider string.
+	fn eq(&self, other: &Self) -> bool {
+		core::mem::discriminant(self) == core::mem::discriminant(other)
+	}
+}
+
+impl Eq for StopReason {}
+
+impl std::fmt::Display for StopReason {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", self.raw())
+	}
+}
+
+// endregion: --- StopReason
+
 // region:    --- ChatResponse
 
 /// Response returned by a non-streaming chat request.
@@ -26,7 +113,9 @@ pub struct ChatResponse {
 	/// Set explicitly by construction code; no implicit defaulting at the type level.
 	pub provider_model_iden: ModelIden,
 
-	// pub model
+	/// Normalised stop reason (see [`StopReason`]).
+	pub stop_reason: Option<StopReason>,
+
 	/// Token usage reported by the provider.
 	pub usage: Usage,
 

--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -1,5 +1,5 @@
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatMessage, ContentPart, MessageContent, ToolCall, Usage};
+use crate::chat::{ChatMessage, ContentPart, MessageContent, StopReason, ToolCall, Usage};
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
@@ -107,6 +107,9 @@ pub struct StreamEnd {
 	/// Captured usage if `ChatOptions.capture_usage` is enabled.
 	pub captured_usage: Option<Usage>,
 
+	/// Normalised stop reason captured at stream end (see [`StopReason`]).
+	pub captured_stop_reason: Option<StopReason>,
+
 	/// Captured final content (text and tool calls) if `ChatOptions.capture_content`
 	/// or `capture_tool_calls` is enabled.
 	/// Note: Since 0.4.0 this includes tool calls as well (for API symmetry with `ChatResponse`);
@@ -169,6 +172,7 @@ impl From<InterStreamEnd> for StreamEnd {
 		// -- Return result
 		StreamEnd {
 			captured_usage: inter_end.captured_usage,
+			captured_stop_reason: inter_end.captured_stop_reason,
 			captured_content,
 			captured_reasoning_content: inter_end.captured_reasoning_content,
 		}
@@ -264,3 +268,18 @@ impl StreamEnd {
 }
 
 // endregion: --- ChatStreamEvent
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_stream_end_preserves_captured_stop_reason() {
+		let inter_end = InterStreamEnd {
+			captured_stop_reason: Some(StopReason::Completed("stop".to_string())),
+			..Default::default()
+		};
+		let stream_end = StreamEnd::from(inter_end);
+		assert_eq!(stream_end.captured_stop_reason, Some(StopReason::Completed("stop".to_string())));
+	}
+}


### PR DESCRIPTION
  - Propagate stop_reason from all 6 LLM providers (OpenAI, Anthropic, Gemini, Cohere, Ollama, OpenAI Responses) in both streaming and non-streaming paths                              
  - Normalize raw provider strings into a provider-agnostic StopReason enum: Completed, MaxTokens, ToolCall, ContentFilter, StopSequence, Other
  - Each variant preserves the original provider string via .raw()                                                                                                                      
                                                                                                                                                                                        
  Motivation

  MaxTokens is the key signal for automatic truncation recovery — without it, callers cannot distinguish a naturally completed response from one that was cut short mid-output, making
  seamless continuation impossible.

  Test plan

  - All 27 existing library tests pass
  - Unit tests for StopReason mapping (both present and missing finish_reason)
  - Unit test for StreamEnd preserving captured_stop_reason
