### PR TITLE
fix(openai-streamer): do not drop delta content co-located with finish_reason

### DIFF
--- a/src/adapter/adapters/openai/streamer.rs
+++ b/src/adapter/adapters/openai/streamer.rs
@@ -223,6 +223,38 @@ impl futures::Stream for OpenAIStreamer {
 								}
 							}
 
+							// NOTE: Some providers (e.g., mistral) send delta/content AND finish_reason
+							// in the same SSE message. We must capture and emit that final content chunk
+							// before continuing to the next message, otherwise it is silently lost.
+							let content = first_choice.x_take::<Option<String>>("/delta/content").ok().flatten();
+							let reasoning_content = first_choice
+								.x_take::<Option<String>>("/delta/reasoning_content")
+								.ok()
+								.flatten()
+								.or_else(|| first_choice.x_take::<Option<String>>("/delta/reasoning").ok().flatten());
+
+							if let Some(content) = content
+								&& !content.is_empty()
+							{
+								if self.options.capture_content {
+									match self.captured_data.content {
+										Some(ref mut c) => c.push_str(&content),
+										None => self.captured_data.content = Some(content.clone()),
+									}
+								}
+								return Poll::Ready(Some(Ok(InterStreamEvent::Chunk(content))));
+							} else if let Some(reasoning_content) = reasoning_content
+								&& !reasoning_content.is_empty()
+							{
+								if self.options.capture_reasoning_content {
+									match self.captured_data.reasoning_content {
+										Some(ref mut c) => c.push_str(&reasoning_content),
+										None => self.captured_data.reasoning_content = Some(reasoning_content.clone()),
+									}
+								}
+								return Poll::Ready(Some(Ok(InterStreamEvent::ReasoningChunk(reasoning_content))));
+							}
+
 							continue;
 						}
 						// -- Tool Call


### PR DESCRIPTION
PR Description

## Problem
Some OpenAI-compatible providers (mistral, and potentially others) send `delta.content` alongside `finish_reason` in the **same** SSE message. The OpenAI streamer's `finish_reason` branch captured `stop_reason`, `tool_calls`, and `usage`, but then issued a bare `continue` — skipping the `delta/content` read entirely. This silently dropped the **last content chunk** of every streamed response from affected providers.
Reported via downstream usage in a TUI application where responses consistently lost their final character(s).

## Fix
After processing `stop_reason`, `tool_calls`, and `usage` in the `finish_reason` branch, the code now also reads `delta/content` and `delta/reasoning_content` from the same `first_choice` object. If non-empty, the content is captured and emitted as a `Chunk` (or `ReasoningChunk`) event before continuing. If empty, behavior is unchanged (`continue` to the next message).
## Impact
- **OpenAI-compatible streaming** via mistral and any provider that co-locates `delta.content` with `finish_reason`
- No change in behavior for providers that send `finish_reason` without content (OpenAI, Groq, etc.)
- No change to other adapter streamers (Anthropic, Gemini, Cohere, Ollama native, OpenAI Responses)