### PR TITLE
- chat - add xhigh reasoning effort mapping

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -44,7 +44,7 @@ fn insert_anthropic_reasoning(payload: &mut Value, model_name: &str, effort: &Re
 			ReasoningEffort::Minimal => "low",
 			ReasoningEffort::Low => "low",
 			ReasoningEffort::Medium => "medium",
-			ReasoningEffort::High => "high",
+			ReasoningEffort::High | ReasoningEffort::XHigh => "high",
 			ReasoningEffort::Max if support_reasoning_max => "max",
 			ReasoningEffort::Max => "high",
 			// we apture for later
@@ -89,7 +89,7 @@ fn insert_anthropic_reasoning(payload: &mut Value, model_name: &str, effort: &Re
 			ReasoningEffort::Budget(budget) => Some(*budget),
 			ReasoningEffort::Low | ReasoningEffort::Minimal => Some(REASONING_LOW),
 			ReasoningEffort::Medium => Some(REASONING_MEDIUM),
-			ReasoningEffort::High | ReasoningEffort::Max => Some(REASONING_HIGH),
+			ReasoningEffort::High | ReasoningEffort::Max | ReasoningEffort::XHigh => Some(REASONING_HIGH),
 		};
 
 		if let Some(thinking_budget) = thinking_budget {

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -30,7 +30,7 @@ fn insert_gemini_thinking_budget_value(payload: &mut Value, effort: &ReasoningEf
 		ReasoningEffort::None => None,
 		ReasoningEffort::Low | ReasoningEffort::Minimal => Some(REASONING_LOW),
 		ReasoningEffort::Medium => Some(REASONING_MEDIUM),
-		ReasoningEffort::High | ReasoningEffort::Max => Some(REASONING_HIGH),
+		ReasoningEffort::High | ReasoningEffort::Max | ReasoningEffort::XHigh => Some(REASONING_HIGH),
 		ReasoningEffort::Budget(budget) => Some(*budget),
 	};
 

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -20,6 +20,7 @@ fn insert_openai_reasoning_effort(payload: &mut Value, effort: &ReasoningEffort)
 		ReasoningEffort::Low => "low",
 		ReasoningEffort::Medium => "medium",
 		ReasoningEffort::High | ReasoningEffort::Max => "high",
+		ReasoningEffort::XHigh => "xhigh",
 		ReasoningEffort::Minimal => "minimal",
 		ReasoningEffort::Budget(_) => return Ok(()),
 	};

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -192,6 +192,7 @@ pub enum ReasoningEffort {
 	Low,
 	Medium,
 	High,
+	XHigh,
 	Max,
 	Budget(u32),
 
@@ -207,6 +208,7 @@ impl ReasoningEffort {
 			ReasoningEffort::Low => "low",
 			ReasoningEffort::Medium => "medium",
 			ReasoningEffort::High => "high",
+			ReasoningEffort::XHigh => "xhigh",
 			ReasoningEffort::Max => "max",
 			ReasoningEffort::Budget(_) => "budget",
 			// Legacy
@@ -221,6 +223,7 @@ impl ReasoningEffort {
 			ReasoningEffort::Low => Some("low"),
 			ReasoningEffort::Medium => Some("medium"),
 			ReasoningEffort::High => Some("high"),
+			ReasoningEffort::XHigh => Some("xhigh"),
 			ReasoningEffort::Max => Some("max"),
 			ReasoningEffort::Budget(_) => None,
 			// Legacy
@@ -235,6 +238,7 @@ impl ReasoningEffort {
 			"low" => Some(ReasoningEffort::Low),
 			"medium" => Some(ReasoningEffort::Medium),
 			"high" => Some(ReasoningEffort::High),
+			"xhigh" => Some(ReasoningEffort::XHigh),
 			"max" => Some(ReasoningEffort::Max),
 			// legacy
 			"minimal" => Some(ReasoningEffort::Minimal),
@@ -262,6 +266,7 @@ impl std::fmt::Display for ReasoningEffort {
 			ReasoningEffort::Low => write!(f, "low"),
 			ReasoningEffort::Medium => write!(f, "medium"),
 			ReasoningEffort::High => write!(f, "high"),
+			ReasoningEffort::XHigh => write!(f, "xhigh"),
 			ReasoningEffort::Max => write!(f, "max"),
 			ReasoningEffort::Budget(n) => write!(f, "{n}"),
 			// Legacy


### PR DESCRIPTION
PR Description:
# Problem
A higher-level reasoning effort (xhigh) is needed for providers supporting this capability, but the current enumeration and adapter mappings only go up to high/max, preventing callers from expressing xhigh or forcing them to use high/max as substitutes.

# Fix
Added ReasoningEffort::XHigh and completed string parsing/display mappings; OpenAI requests are mapped to "xhigh"; Anthropic/Gemini treat XHigh as high for compatibility.

# Impact
OpenAI can explicitly request xhigh reasoning effort; Anthropic/Gemini behavior remains unchanged (xhigh → high); other adapters are unaffected.