### PR TITLE
- openai - fix openai-cache add OpenAI prompt cache options to ChatOp…

### DIFF
--- a/doc/for-llm/api-reference-for-llm.md
+++ b/doc/for-llm/api-reference-for-llm.md
@@ -228,8 +228,10 @@ All fields are `Option<T>` (unset = defer to client default or provider default)
 - `capture_raw_body`: Capture raw HTTP response body.
 - `seed`: Deterministic generation.
 - `service_tier`: `Flex`, `Auto`, `Default` (OpenAI).
+- `prompt_cache_key`: OpenAI prompt cache key.
+- `prompt_cache_retention`: `PromptCacheRetention` enum (OpenAI).
 - `extra_headers`: `Headers` added to the request.
-- **Chainable setters**: `with_temperature(f64)`, `with_max_tokens(u32)`, `with_top_p(f64)`, `with_capture_usage(bool)`, `with_capture_content(bool)`, `with_capture_reasoning_content(bool)`, `with_capture_tool_calls(bool)`, `with_capture_raw_body(bool)`, `with_stop_sequences(vec)`, `with_normalize_reasoning_content(bool)`, `with_response_format(format)`, `with_reasoning_effort(effort)`, `with_verbosity(v)`, `with_seed(u64)`, `with_service_tier(tier)`, `with_extra_headers(headers)`.
+- **Chainable setters**: `with_temperature(f64)`, `with_max_tokens(u32)`, `with_top_p(f64)`, `with_capture_usage(bool)`, `with_capture_content(bool)`, `with_capture_reasoning_content(bool)`, `with_capture_tool_calls(bool)`, `with_capture_raw_body(bool)`, `with_stop_sequences(vec)`, `with_normalize_reasoning_content(bool)`, `with_response_format(format)`, `with_reasoning_effort(effort)`, `with_verbosity(v)`, `with_seed(u64)`, `with_service_tier(tier)`, `with_prompt_cache_key(key)`, `with_prompt_cache_retention(retention)`, `with_extra_headers(headers)`.
 - Deprecated: `with_json_mode(bool)` in favor of `with_response_format(ChatResponseFormat::JsonMode)`.
 
 ### `ChatResponseFormat`
@@ -270,6 +272,15 @@ OpenAI service tier preference for flex processing.
 
 - Variants: `Flex`, `Auto`, `Default`.
 - `variant_name()`, `as_keyword()`, `from_keyword(name)`.
+- Implements `Display`, `FromStr`.
+
+### `PromptCacheRetention`
+
+OpenAI prompt cache retention policy.
+
+- Variants: `InMemory`, `Hours24`.
+- `variant_name()`, `as_keyword()`, `from_keyword(name)`.
+- Serializes as `"in_memory"` / `"24h"`.
 - Implements `Display`, `FromStr`.
 
 ## Embedding

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -188,6 +188,16 @@ impl OpenAIAdapter {
 			payload.x_insert("service_tier", keyword)?;
 		}
 
+		// -- OpenAI prompt cache options
+		if let Some(prompt_cache_key) = options_set.prompt_cache_key() {
+			payload.x_insert("prompt_cache_key", prompt_cache_key)?;
+		}
+		if let Some(prompt_cache_retention) = options_set.prompt_cache_retention()
+			&& let Some(keyword) = prompt_cache_retention.as_keyword()
+		{
+			payload.x_insert("prompt_cache_retention", keyword)?;
+		}
+
 		Ok(WebRequestData { url, headers, payload })
 	}
 

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -184,6 +184,16 @@ impl Adapter for OpenAIRespAdapter {
 			payload.x_insert("seed", seed)?;
 		}
 
+		// -- OpenAI prompt cache options
+		if let Some(prompt_cache_key) = chat_options.prompt_cache_key() {
+			payload.x_insert("prompt_cache_key", prompt_cache_key)?;
+		}
+		if let Some(prompt_cache_retention) = chat_options.prompt_cache_retention()
+			&& let Some(keyword) = prompt_cache_retention.as_keyword()
+		{
+			payload.x_insert("prompt_cache_retention", keyword)?;
+		}
+
 		Ok(WebRequestData { url, headers, payload })
 	}
 

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -68,6 +68,13 @@ pub struct ChatOptions {
 
 	/// Additional HTTP headers to include with the request.
 	pub extra_headers: Option<Headers>,
+
+	// -- OpenAI prompt cache options
+	/// OpenAI prompt cache key.
+	pub prompt_cache_key: Option<String>,
+
+	/// OpenAI prompt cache retention policy.
+	pub prompt_cache_retention: Option<PromptCacheRetention>,
 }
 
 /// Chainable Setters
@@ -165,6 +172,18 @@ impl ChatOptions {
 	/// Adds extra HTTP headers.
 	pub fn with_extra_headers(mut self, headers: impl Into<Headers>) -> Self {
 		self.extra_headers = Some(headers.into());
+		self
+	}
+
+	/// Sets the OpenAI prompt cache key.
+	pub fn with_prompt_cache_key(mut self, key: impl Into<String>) -> Self {
+		self.prompt_cache_key = Some(key.into());
+		self
+	}
+
+	/// Sets the OpenAI prompt cache retention policy.
+	pub fn with_prompt_cache_retention(mut self, retention: PromptCacheRetention) -> Self {
+		self.prompt_cache_retention = Some(retention);
 		self
 	}
 
@@ -426,6 +445,58 @@ impl std::str::FromStr for ServiceTier {
 
 // endregion: --- ServiceTier
 
+// region:    --- PromptCacheRetention
+
+/// OpenAI prompt cache retention policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PromptCacheRetention {
+	#[serde(rename = "in_memory")]
+	InMemory,
+	#[serde(rename = "24h")]
+	Hours24,
+}
+
+impl PromptCacheRetention {
+	/// Returns the API keyword.
+	pub fn variant_name(&self) -> &'static str {
+		match self {
+			PromptCacheRetention::InMemory => "in_memory",
+			PromptCacheRetention::Hours24 => "24h",
+		}
+	}
+
+	/// Returns the keyword for API usage.
+	pub fn as_keyword(&self) -> Option<&'static str> {
+		Some(self.variant_name())
+	}
+
+	/// Parses a prompt cache retention keyword.
+	pub fn from_keyword(name: &str) -> Option<Self> {
+		match name {
+			"in_memory" => Some(PromptCacheRetention::InMemory),
+			"24h" => Some(PromptCacheRetention::Hours24),
+			_ => None,
+		}
+	}
+}
+
+impl std::fmt::Display for PromptCacheRetention {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", self.variant_name())
+	}
+}
+
+impl std::str::FromStr for PromptCacheRetention {
+	type Err = Error;
+
+	/// Parses a prompt cache retention keyword.
+	fn from_str(s: &str) -> Result<Self> {
+		Self::from_keyword(s).ok_or(Error::PromptCacheRetentionParsing { actual: s.to_string() })
+	}
+}
+
+// endregion: --- PromptCacheRetention
+
 // region:    --- ChatOptionsSet
 
 /// This is an internal crate struct to resolve the ChatOptions value in a cascading manner.
@@ -545,6 +616,18 @@ impl ChatOptionsSet<'_, '_> {
 		self.chat
 			.and_then(|chat| chat.extra_headers.as_ref())
 			.or_else(|| self.client.and_then(|client| client.extra_headers.as_ref()))
+	}
+
+	pub fn prompt_cache_key(&self) -> Option<&str> {
+		self.chat
+			.and_then(|chat| chat.prompt_cache_key.as_deref())
+			.or_else(|| self.client.and_then(|client| client.prompt_cache_key.as_deref()))
+	}
+
+	pub fn prompt_cache_retention(&self) -> Option<&PromptCacheRetention> {
+		self.chat
+			.and_then(|chat| chat.prompt_cache_retention.as_ref())
+			.or_else(|| self.client.and_then(|client| client.prompt_cache_retention.as_ref()))
 	}
 
 	/// Returns true only if there is a ChatResponseFormat::JsonMode

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,9 @@ pub enum Error {
 	#[display("Failed to parse service tier. Actual: '{actual}'")]
 	ServiceTierParsing { actual: String },
 
+	#[display("Failed to parse prompt cache retention. Actual: '{actual}'")]
+	PromptCacheRetentionParsing { actual: String },
+
 	// -- Chat Output
 	#[display("No chat response from model '{model_iden}'")]
 	NoChatResponse { model_iden: ModelIden },


### PR DESCRIPTION
## Problem
OpenAI prompt cache options (`prompt_cache_key`, `prompt_cache_retention`) were not exposed in `ChatOptions` or forwarded to the OpenAI / OpenAI Responses adapters, so callers couldn’t enable prompt caching.
## Fix
- Add prompt cache fields and chainable setters to `ChatOptions`, plus a `PromptCacheRetention` enum and parsing error.
- Plumb these options through `ChatOptionsSet` into the OpenAI and OpenAI Responses request payloads.
- Document the new options and enum in the API reference.
## Impact
- Enables prompt cache configuration for OpenAI Chat Completions and OpenAI Responses adapters.
- No behavior change when options are unset.
- Other adapters/providers unaffected.

<img width="419" height="774" alt="image" src="https://github.com/user-attachments/assets/aadbc2e9-f3b7-4bdd-bbdd-9e5af5ddfa60" />
