### PR TITLE
fix: GPT-5 Responses API compat — routing, max_tokens

### DIFF
--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -197,7 +197,7 @@ impl AdapterKind {
 			|| model.starts_with("text-embedding")
 		// migh be a little generic on this one
 		{
-			if model.starts_with("gpt") && (model.contains("codex") || model.contains("pro")) {
+			if model.starts_with("gpt-5") || (model.starts_with("gpt") && (model.contains("codex") || model.contains("pro"))) {
 				Ok(Self::OpenAIResp)
 			} else {
 				Ok(Self::OpenAI)

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -169,12 +169,22 @@ impl OpenAIAdapter {
 			payload.x_insert("stop", options_set.stop_sequences())?;
 		}
 
+		// GPT-5.x and o-series models require "max_completion_tokens" instead of "max_tokens"
+		let max_tokens_key = if model_name.starts_with("gpt-5")
+			|| model_name.starts_with("o1")
+			|| model_name.starts_with("o3")
+			|| model_name.starts_with("o4")
+		{
+			"max_completion_tokens"
+		} else {
+			"max_tokens"
+		};
 		if let Some(max_tokens) = options_set.max_tokens() {
-			payload.x_insert("max_tokens", max_tokens)?;
+			payload.x_insert(max_tokens_key, max_tokens)?;
 		} else if let Some(custom) = custom.as_ref()
 			&& let Some(max_tokens) = custom.default_max_tokens
 		{
-			payload.x_insert("max_tokens", max_tokens)?;
+			payload.x_insert(max_tokens_key, max_tokens)?;
 		}
 		if let Some(top_p) = options_set.top_p() {
 			payload.x_insert("top_p", top_p)?;

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -175,7 +175,7 @@ impl Adapter for OpenAIRespAdapter {
 		}
 
 		if let Some(max_tokens) = chat_options.max_tokens() {
-			payload.x_insert("max_tokens", max_tokens)?;
+			payload.x_insert("max_output_tokens", max_tokens)?;
 		}
 		if let Some(top_p) = chat_options.top_p() {
 			payload.x_insert("top_p", top_p)?;


### PR DESCRIPTION
## Problem

GPT-5.x models are broken in genai:

1. **Wrong adapter**: `gpt-5*` models route to `OpenAI` (Chat Completions) instead of `OpenAIResp` (Responses API). OpenAI ships GPT-5 as a Responses API model — Chat Completions returns errors or degraded behavior.

2. **Wrong token param in Responses API**: The adapter sends `max_tokens` but the Responses API expects `max_output_tokens`. Results in the parameter being silently ignored.

3. **Wrong token param in Chat Completions**: GPT-5.x and o-series models (o1, o3, o4) require `max_completion_tokens` instead of `max_tokens`. Sending `max_tokens` causes 400 errors.

## Fix

- Route `gpt-5*` → `OpenAIResp` adapter (alongside existing codex/pro routing)
- Use `max_output_tokens` in the Responses API adapter
- Use `max_completion_tokens` for gpt-5/o1/o3/o4 in the Chat Completions adapter

## Testing

- Unit tests pass (49/49)
- Tested with `gpt-5.4` in production (real-time sales coaching agent, 30+ turns per session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)