### PR TITLE
feat: OpenAIResp — use `instructions` field for system prompt

### DIFF
--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -90,19 +90,33 @@ impl Adapter for OpenAIRespAdapter {
 				(None, model_name)
 			};
 
+		// -- Extract system prompt before consuming chat_req.
+		// Use the Responses API `instructions` field instead of an input system message.
+		// `instructions` is the canonical way to set system prompt in the Responses API:
+		// - It overrides on each call (important for stateful sessions with previous_response_id)
+		// - It separates instructions from conversation items
+		// - Inline system messages (ChatRole::System in messages) still go to input as-is
+		let instructions = chat_req.system.clone();
+		let mut chat_req = chat_req;
+		chat_req.system = None;
+
 		// -- Build the basic payload
 		let OpenAIRespRequestParts {
 			input_items: messages,
 			tools,
 		} = Self::into_openai_request_parts(&model, chat_req)?;
 
-		// IMPORTANT: `store = false` - To maintain consistent behavior with other chat completions, store is set to false
 		let mut payload = json!({
 			"store": false,
 			"model": model_name,
 			"input": messages,
 			"stream": stream,
 		});
+
+		// -- System prompt as instructions
+		if let Some(instructions) = &instructions {
+			payload.x_insert("instructions", instructions.as_str())?;
+		}
 
 		// -- Set reasoning effort
 		if let Some(reasoning_effort) = reasoning_effort


### PR DESCRIPTION
## Motivation

The OpenAI Responses API has a dedicated [`instructions`](https://platform.openai.com/docs/api-reference/responses/create) field for system prompts, separate from `input` conversation items. Currently genai puts `ChatRequest.system` as a `{"role": "system"}` message in the `input` array (the code has a comment: "For now we do not use the top `.instructions`").

Using `instructions` is better because:

1. **Stateful sessions**: When using `previous_response_id` (#168), the `instructions` field overrides on each call. System messages in `input` would be duplicated — the cached conversation already has the original system message, and the new call appends another one. With `instructions`, the model always sees exactly one, up-to-date system prompt.

2. **API correctness**: `instructions` is the canonical way per OpenAI docs. It cleanly separates developer instructions from conversation items.

3. **No behavior change for inline system messages**: Only `ChatRequest.system` (top-level) moves to `instructions`. System messages in `ChatRequest.messages` (inline, contextual) still go to `input` as before.

## Scope

**Only the OpenAIResp adapter is affected.** Other providers (Anthropic, Gemini, Cohere, Ollama) and OpenAI Chat Completions are unchanged.

## Change

In `OpenAIRespAdapter::to_web_request_data`:
- Extract `chat_req.system` before `into_openai_request_parts`
- Set `chat_req.system = None` to prevent it from going into `input`
- Add `"instructions": system_text` to the payload

Before:
```json
{"input": [{"role": "system", "content": "..."}, {"role": "user", ...}]}
```

After:
```json
{"instructions": "...", "input": [{"role": "user", ...}]}
```

## Testing

- Unit tests pass (49/49)
- Tested with GPT-5.4 in production — 30+ turn stateful sessions with function calling, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)