### PR TITLE
fix(gemini): support parallel tool calls in streaming adapter

### DIFF
--- a/src/adapter/adapters/gemini/streamer.rs
+++ b/src/adapter/adapters/gemini/streamer.rs
@@ -108,11 +108,13 @@ impl futures::Stream for GeminiStreamer {
 								self.captured_data.stop_reason = stop_reason;
 							}
 
-							// -- Extract text and toolcall
-							// WARNING: Assume that only ONE tool call per message (or take the last one)
+							// -- Extract text, reasoning, and tool calls from content parts.
+							// Gemini can return multiple functionCall parts in a single
+							// streaming chunk (parallel tool calls), so we collect all of
+							// them instead of keeping only the last one.
 							let mut stream_text_content: String = String::new();
 							let mut stream_reasoning_content: Option<String> = None;
-							let mut stream_tool_call: Option<ToolCall> = None;
+							let mut stream_tool_calls: Vec<ToolCall> = Vec::new();
 							let mut stream_thought: Option<String> = None;
 
 							for g_content_item in content {
@@ -122,11 +124,9 @@ impl futures::Stream for GeminiStreamer {
 									}
 									GeminiChatContent::Text(text) => stream_text_content.push_str(&text),
 									GeminiChatContent::Binary(_) => {
-										// For now, we do not stream binary content, as Gemini may send binary content in multiple chunks and we don't want to emit incomplete binary data.
-										// Instead, we will capture the binary content in the captured_data and emit it at the end of the stream.
-										// We can consider adding a streaming event for binary content in the future if there is a use case for it.
+										// For now, we do not stream binary content.
 									}
-									GeminiChatContent::ToolCall(tool_call) => stream_tool_call = Some(tool_call),
+									GeminiChatContent::ToolCall(tool_call) => stream_tool_calls.push(tool_call),
 									GeminiChatContent::ThoughtSignature(thought) => stream_thought = Some(thought),
 								}
 							}
@@ -180,8 +180,8 @@ impl futures::Stream for GeminiStreamer {
 								self.pending_events.push_back(InterStreamEvent::Chunk(stream_text_content));
 							}
 
-							// 3. Tool Call
-							if let Some(tool_call) = stream_tool_call {
+							// 3. Tool Calls (supports parallel tool calls from Gemini)
+							for tool_call in stream_tool_calls {
 								if self.options.capture_tool_calls {
 									match self.captured_data.tool_calls {
 										Some(ref mut tool_calls) => tool_calls.push(tool_call.clone()),
@@ -189,7 +189,7 @@ impl futures::Stream for GeminiStreamer {
 									}
 								}
 								if self.options.capture_usage {
-									self.captured_data.usage = Some(usage);
+									self.captured_data.usage = Some(usage.clone());
 								}
 								self.pending_events.push_back(InterStreamEvent::ToolCallChunk(tool_call));
 							}


### PR DESCRIPTION
## Problem

Gemini's native streaming API (`streamGenerateContent`) can return multiple `functionCall` parts in a single SSE chunk when the model decides to invoke tools in parallel. The current streaming adapter uses `Option<ToolCall>` (`stream_tool_call`) which only keeps the **last** tool call per chunk, silently dropping all preceding ones.

This means that when Gemini returns 2+ parallel tool calls (e.g., reading multiple files simultaneously), only one is actually processed. The others are lost.

## Root Cause

In `src/adapter/adapters/gemini/streamer.rs` (line ~115):

```rust
// WARNING: Assume that only ONE tool call per message (or take the last one)
let mut stream_tool_call: Option<ToolCall> = None;
// ...
GeminiChatContent::ToolCall(tool_call) => stream_tool_call = Some(tool_call),  // overwrites!
```

## Fix

Changed `stream_tool_call: Option<ToolCall>` → `stream_tool_calls: Vec<ToolCall>`, and emit each tool call as a separate `ToolCallChunk` event.

## Verification

Tested with `gemini-2.5-flash` asking to read two files simultaneously:

- **Non-streaming API**: Returns 2 tool calls ✅
- **Streaming API before fix**: Returns 1 tool call ❌ (second one dropped)
- **Streaming API after fix**: Returns 2 tool calls ✅

## Impact

This affects any agent framework using genai with Gemini models that support parallel tool calls (gemini-2.5-flash, gemini-2.5-pro, gemini-3.x). Without this fix, agent performance is significantly degraded as models can only execute one tool per inference round.