### PR TITLE
Add yakbak HTTP record/replay integration test infrastructure

### DIFF
--- a/.github/workflows/yakbak-replay-tests.yml
+++ b/.github/workflows/yakbak-replay-tests.yml
@@ -1,0 +1,36 @@
+name: Yakbak Replay Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  replay-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run OpenAI replay tests
+        run: cargo test --test tests_yakbak_openai_resp
+
+      - name: Run Gemini replay tests
+        run: cargo test --test tests_yakbak_gemini

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,7 @@ serial_test = "3.2"
 base64 = "0.22.0"  # Check for the latest version
 bitflags = "2.8"
 gcp_auth = "0.12"
+# -- Yakbak (HTTP record/replay for integration tests)
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1"] }
+http-body-util = "0.1"

--- a/tests/data/yakbak/gemini/thinking_nostream/response_000.txt
+++ b/tests/data/yakbak/gemini/thinking_nostream/response_000.txt
@@ -1,0 +1,34 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**My Concise Explanation of the Sky's Color**\n\nAlright, a single sentence, as requested. The user, being the expert they are, just needs the core concept. Let's see... the question is why the sky is blue. My thought process here is to hit the key points directly: Sunlight, the atmosphere, scattering, and the crucial element of wavelength. The first draft: \"The sky is blue because sunlight is scattered by molecules in Earth's atmosphere, and blue light (which has shorter wavelengths) is scattered more efficiently than other colors.\" Yup, that works. It's all there: sunlight interacting with the atmosphere and the wavelength-dependent nature of Rayleigh scattering, which explains why blue is the dominant color we see. Length is fine; clarity is good. Delivered.\n",
+            "thought": true
+          },
+          {
+            "text": "The sky is blue because sunlight scatters off molecules in Earth's atmosphere, with blue light (which has shorter wavelengths) scattering more efficiently in all directions than other colors."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "candidatesTokenCount": 35,
+    "totalTokenCount": 181,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 134
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDab-3GseQkdUPwtKu2Ak"
+}

--- a/tests/data/yakbak/gemini/thinking_stream/response_000.txt
+++ b/tests/data/yakbak/gemini/thinking_stream/response_000.txt
@@ -1,0 +1,121 @@
+[{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**Defining Sky Color**\n\nI'm now focusing on a concise explanation for why the sky appears blue. I've pinpointed the key aspects: sunlight's interaction with Earth's atmosphere, and the critical role of Rayleigh scattering in dispersing light. It is essential to ensure a clear and accurate one-sentence response. I will now work on integrating the key elements, so that it is easily understood.\n\n\n",
+            "thought": true
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "totalTokenCount": 81,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 69
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**Refining Concise Explanation**\n\nI've crafted a single-sentence response: \"The sky appears blue because sunlight scatters off atmospheric molecules, with blue light scattered more intensely due to its shorter wavelength.\" I've confirmed that this encapsulates the core reason for the sky's blue hue, emphasizing both the scattering mechanism and the wavelength dependence. It's accurate, concise, and direct, ensuring it will communicate the answer effectively.\n\n\n",
+            "thought": true
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "totalTokenCount": 215,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 203
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The sky is blue because molecules in Earth's atmosphere scatter shorter"
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "candidatesTokenCount": 11,
+    "totalTokenCount": 226,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 203
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "-wavelength blue light from the sun more efficiently than longer-wavelength red light."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "candidatesTokenCount": 27,
+    "totalTokenCount": 242,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 203
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+]

--- a/tests/data/yakbak/gemini/thinking_stream_tools/response_000.txt
+++ b/tests/data/yakbak/gemini/thinking_stream_tools/response_000.txt
@@ -1,0 +1,100 @@
+[{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**Gathering Weather Information**\n\nI'm currently focused on retrieving the weather details for Paris, France. I've determined that the `get_weather` tool is the appropriate one to use. I've also correctly set the `unit` parameter to 'C' to ensure Celsius readings, and I have the `city` parameter set to 'Paris'. I am about to set the `country` parameter.\n\n\n",
+            "thought": true
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 107,
+    "totalTokenCount": 170,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 107
+      }
+    ],
+    "thoughtsTokenCount": 63
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaaOcGtmWvdIPuqb0qA0"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**Refining Data Retrieval**\n\nI've successfully set the city and unit parameters, and now the country has been set to 'France'. I am retrieving weather data as requested. I realize the `get_weather` tool only provides temperature, not a comprehensive weather description, so I will inform the user about this shortly after I return the temperature. I will clarify the tool's limitations to ensure the user has complete information.\n\n\n",
+            "thought": true
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 107,
+    "totalTokenCount": 219,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 107
+      }
+    ],
+    "thoughtsTokenCount": 112
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaaOcGtmWvdIPuqb0qA0"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "name": "get_weather",
+              "args": {
+                "country": "France",
+                "unit": "C",
+                "city": "Paris"
+              }
+            },
+            "thoughtSignature": "CmYBvj72+2f+ejt7tXAIds2JkUOed1CaH/dBNbTjCltv4W44sCmu9gacHB0HUOX3FT0hdNmT264Q40CJeltRZ3JbiZciQd81KICGvlUddYlzASQ3e5AEnrRSrsktDi+Tmv415Kua6iEK1wEBvj72+49g3Im5cUZjk2iGIqmWAVIby9CqE2v1lxldGU/ERXDBnhc2sPnDYZXbqnKU2fpkEyoftZazuuH3eLtxRq9CtXVSkXRMDH600eO16s8lSOkSyXQ0FrkwCsWQY98iWJuLkXbzV5kfajogrSV4AYSR7m/IFx3ilM65In9TBBiCwD21aqkymxbi703tbOPn1u6h7wiYvEVKoUqLUbU8ZlFTFpEuEOnNEDUfI74Bk1ZuoQCtN8F1w3QhIZ7eKqEBy9132bTc3MnPXQ+3NCC1hd5sM6iVRQqCAgG+Pvb7Y9p8EYWMB2UB+dcIKkL+rN0bM5TtI69akv7DGnkrkNoUekffMkIKd02xEUdiz1WaLAPFUCj1IIa3rOpzC95+94KXOIc/m+ZcXVdDb94JLLUKJkjZxMSqWGQ3iwYPb7K4SSd8LnYC4/JupJVqwa64rT8k3wHIi+8gUAyPzbqKyJKwE0r9kka+E9NDhlrz+6miFoamo+95aTq+DFudeLAyJrAMWChQEL3/bf3k2bmhlj8ZnHsR1uKkwOQ/p75jzt/dvWkN8qVR6F717EbWs9eG8y/NyYXe7LrSPt3FMKo7D44W+6Vgit3L0dZyshBjNZYIifw8XBTrs7Z2KvBbLQ=="
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "finishMessage": "Model generated function call(s)."
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 107,
+    "candidatesTokenCount": 23,
+    "totalTokenCount": 242,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 107
+      }
+    ],
+    "thoughtsTokenCount": 112
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaaOcGtmWvdIPuqb0qA0"
+}
+]

--- a/tests/data/yakbak/openai_resp/reasoning_stream/response_000.txt
+++ b/tests/data/yakbak/openai_resp/reasoning_stream/response_000.txt
@@ -1,0 +1,132 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_0fc1e46549626e100169c30ba7bb2481918c90d1bebfa72bc3","object":"response","created_at":1774390183,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Answer in one sentence.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fa18f078-7b78-4fc2-81f4-e5207782c871","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":null},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_0fc1e46549626e100169c30ba7bb2481918c90d1bebfa72bc3","object":"response","created_at":1774390183,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Answer in one sentence.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fa18f078-7b78-4fc2-81f4-e5207782c871","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":null},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"rs_0fc1e46549626e100169c30ba8082c81918cdce9d4cbd024a0","type":"reasoning","summary":[]},"output_index":0,"sequence_number":2}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"rs_0fc1e46549626e100169c30ba8082c81918cdce9d4cbd024a0","type":"reasoning","summary":[]},"output_index":0,"sequence_number":3}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":4}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":5}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"AVX2l40minB6o","output_index":1,"sequence_number":6}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" sky","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"R7jXdfF1F7Ih","output_index":1,"sequence_number":7}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" looks","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"p05ComJRFB","output_index":1,"sequence_number":8}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" blue","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"cbPVhvaOLvc","output_index":1,"sequence_number":9}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" because","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"AaTBvbeo","output_index":1,"sequence_number":10}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" molecules","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"iDGgKb","output_index":1,"sequence_number":11}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" in","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"IwRHyb81y7HQR","output_index":1,"sequence_number":12}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" Earth","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"WwKKXMGBUI","output_index":1,"sequence_number":13}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"’s","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"f7e6XNe2DUD248","output_index":1,"sequence_number":14}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" atmosphere","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"eP036","output_index":1,"sequence_number":15}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" scatter","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"OzIjLRk2","output_index":1,"sequence_number":16}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" shorter","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"DiuFhEcY","output_index":1,"sequence_number":17}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" blue","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"segucKKlPCL","output_index":1,"sequence_number":18}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" wavelengths","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"aq6p","output_index":1,"sequence_number":19}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"Fi9SdfexXtQNw","output_index":1,"sequence_number":20}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" sunlight","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"CqAF68Y","output_index":1,"sequence_number":21}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" more","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"hJerSCENZq1","output_index":1,"sequence_number":22}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" strongly","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"H36kPvQ","output_index":1,"sequence_number":23}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" than","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"GEo8xGLgheI","output_index":1,"sequence_number":24}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" longer","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"DdttJlCiX","output_index":1,"sequence_number":25}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" red","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"iM64SmUIejtS","output_index":1,"sequence_number":26}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" wavelengths","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"rYpa","output_index":1,"sequence_number":27}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"OltgdlfTCYUrr9t","output_index":1,"sequence_number":28}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" so","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"ZMwN8tEqWoBqe","output_index":1,"sequence_number":29}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"22WiLhN41Swx","output_index":1,"sequence_number":30}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" scattered","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"z900k5","output_index":1,"sequence_number":31}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" light","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"LypM4em4Ll","output_index":1,"sequence_number":32}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" reaching","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"a2xRraT","output_index":1,"sequence_number":33}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" your","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"Gl3jt0jioIk","output_index":1,"sequence_number":34}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" eyes","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"NwiS1JgeEyf","output_index":1,"sequence_number":35}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"gaVCb85FZqkuv","output_index":1,"sequence_number":36}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" mostly","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"Jk6alhJHj","output_index":1,"sequence_number":37}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" blue","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"gYHeJ7idH6K","output_index":1,"sequence_number":38}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"obfuscation":"84cWThZ9qkAMw8B","output_index":1,"sequence_number":39}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","logprobs":[],"output_index":1,"sequence_number":40,"text":"The sky looks blue because molecules in Earth’s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, so the scattered light reaching your eyes is mostly blue."}
+
+event: response.content_part.done
+data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The sky looks blue because molecules in Earth’s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, so the scattered light reaching your eyes is mostly blue."},"sequence_number":41}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The sky looks blue because molecules in Earth’s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, so the scattered light reaching your eyes is mostly blue."}],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":42}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_0fc1e46549626e100169c30ba7bb2481918c90d1bebfa72bc3","object":"response","created_at":1774390183,"status":"completed","background":false,"completed_at":1774390184,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Answer in one sentence.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[{"id":"rs_0fc1e46549626e100169c30ba8082c81918cdce9d4cbd024a0","type":"reasoning","summary":[]},{"id":"msg_0fc1e46549626e100169c30ba817cc8191aa1fa36895c9e298","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The sky looks blue because molecules in Earth’s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, so the scattered light reaching your eyes is mostly blue."}],"phase":"final_answer","role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"fa18f078-7b78-4fc2-81f4-e5207782c871","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":null},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":21,"input_tokens_details":{"cached_tokens":0},"output_tokens":48,"output_tokens_details":{"reasoning_tokens":8},"total_tokens":69},"user":null,"metadata":{}},"sequence_number":43}
+

--- a/tests/data/yakbak/openai_resp/reasoning_stream_tools/response_000.txt
+++ b/tests/data/yakbak/openai_resp/reasoning_stream_tools/response_000.txt
@@ -1,0 +1,63 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_0730d762b8425ec20169c30ba7ec9081918c91cc7dceebd10e","object":"response","created_at":1774390183,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant. Use tools when needed.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"77afdb18-57b8-460c-a747-f803da83dce4","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":null},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_weather","parameters":{"properties":{"city":{"description":"The city name","type":"string"},"country":{"description":"The most likely country of this city name","type":"string"},"unit":{"description":"The temperature unit of the country. C for Celsius, and F for Fahrenheit","enum":["C","F"],"type":"string"}},"required":["city","country","unit"],"type":"object"},"strict":false}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_0730d762b8425ec20169c30ba7ec9081918c91cc7dceebd10e","object":"response","created_at":1774390183,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant. Use tools when needed.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"77afdb18-57b8-460c-a747-f803da83dce4","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":null},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_weather","parameters":{"properties":{"city":{"description":"The city name","type":"string"},"country":{"description":"The most likely country of this city name","type":"string"},"unit":{"description":"The temperature unit of the country. C for Celsius, and F for Fahrenheit","enum":["C","F"],"type":"string"}},"required":["city","country","unit"],"type":"object"},"strict":false}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"rs_0730d762b8425ec20169c30ba89b4c819193545054f62a38a5","type":"reasoning","summary":[]},"output_index":0,"sequence_number":2}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"rs_0730d762b8425ec20169c30ba89b4c819193545054f62a38a5","type":"reasoning","summary":[]},"output_index":0,"sequence_number":3}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","type":"function_call","status":"in_progress","arguments":"","call_id":"call_lXXeAhYrkvWB3R6d2q5F8MbU","name":"get_weather"},"output_index":1,"sequence_number":4}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"{\"","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"hs6YtEXXNOBHvh","output_index":1,"sequence_number":5}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"city","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"tTgEJI5rhsdt","output_index":1,"sequence_number":6}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"UYRWkofFcObDd","output_index":1,"sequence_number":7}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"Paris","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"DEmBaWgX54f","output_index":1,"sequence_number":8}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\",\"","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"G1Hi0MUaik9M2","output_index":1,"sequence_number":9}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"country","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"a23cFReXV","output_index":1,"sequence_number":10}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"70UAU2BOMkrH3","output_index":1,"sequence_number":11}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"France","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"72ePA8koME","output_index":1,"sequence_number":12}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\",\"","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"RDwXbIO1icNCC","output_index":1,"sequence_number":13}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"unit","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"qKYaYizsQYDB","output_index":1,"sequence_number":14}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"lHadVxHwciabZ","output_index":1,"sequence_number":15}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"C","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"UCiBrBWnhPCkUMA","output_index":1,"sequence_number":16}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"\"}","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","obfuscation":"NmWpHs0L01Jh87","output_index":1,"sequence_number":17}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","arguments":"{\"city\":\"Paris\",\"country\":\"France\",\"unit\":\"C\"}","item_id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","output_index":1,"sequence_number":18}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","type":"function_call","status":"completed","arguments":"{\"city\":\"Paris\",\"country\":\"France\",\"unit\":\"C\"}","call_id":"call_lXXeAhYrkvWB3R6d2q5F8MbU","name":"get_weather"},"output_index":1,"sequence_number":19}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_0730d762b8425ec20169c30ba7ec9081918c91cc7dceebd10e","object":"response","created_at":1774390183,"status":"completed","background":false,"completed_at":1774390184,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant. Use tools when needed.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[{"id":"rs_0730d762b8425ec20169c30ba89b4c819193545054f62a38a5","type":"reasoning","summary":[]},{"id":"fc_0730d762b8425ec20169c30ba8b9ac8191aafd96bcd59965c2","type":"function_call","status":"completed","arguments":"{\"city\":\"Paris\",\"country\":\"France\",\"unit\":\"C\"}","call_id":"call_lXXeAhYrkvWB3R6d2q5F8MbU","name":"get_weather"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"77afdb18-57b8-460c-a747-f803da83dce4","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":null},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_weather","parameters":{"properties":{"city":{"description":"The city name","type":"string"},"country":{"description":"The most likely country of this city name","type":"string"},"unit":{"description":"The temperature unit of the country. C for Celsius, and F for Fahrenheit","enum":["C","F"],"type":"string"}},"required":["city","country","unit"],"type":"object"},"strict":false}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":106,"input_tokens_details":{"cached_tokens":0},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":8},"total_tokens":142},"user":null,"metadata":{}},"sequence_number":20}
+

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -10,6 +10,7 @@ mod data;
 mod helpers;
 mod seeders;
 mod test_error;
+pub mod yakbak;
 
 pub use asserts::*;
 pub use helpers::*;

--- a/tests/support/yakbak/mod.rs
+++ b/tests/support/yakbak/mod.rs
@@ -1,0 +1,76 @@
+//! Yakbak — lightweight HTTP record/replay for integration testing.
+//!
+//! - **Record mode**: proxies requests to a real backend, saves response bodies as `.txt` files.
+//! - **Replay mode**: serves `.txt` files from a cassette directory in lexicographic order.
+//!
+//! No manifest files needed — content-type is inferred from the response body.
+
+mod server;
+
+pub use server::*;
+
+use super::TestResult;
+use genai::resolver::{AuthData, AuthResolver, Endpoint, ServiceTargetResolver};
+use genai::{Client, ServiceTarget};
+
+/// Build a genai `Client` that talks to a yakbak replay server.
+///
+/// Returns `(client, server)` — keep `server` alive for the duration of the test.
+pub async fn replay_client(provider: &str, scenario: &str) -> TestResult<(Client, YakbakServer)> {
+	let cassette_dir = format!("tests/data/yakbak/{provider}/{scenario}");
+	let server = YakbakServer::start(Mode::Replay {
+		cassette_dir: cassette_dir.into(),
+	})
+	.await
+	.map_err(|e| format!("yakbak start failed: {e}"))?;
+
+	let base_url = server.base_url();
+	let client = Client::builder()
+		.with_auth_resolver(AuthResolver::from_resolver_fn(
+			|_| -> Result<Option<AuthData>, genai::resolver::Error> {
+				Ok(Some(AuthData::from_single("yakbak-fake-key")))
+			},
+		))
+		.with_service_target_resolver(ServiceTargetResolver::from_resolver_fn(
+			move |st: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
+				Ok(ServiceTarget {
+					endpoint: Endpoint::from_owned(base_url.clone()),
+					..st
+				})
+			},
+		))
+		.build();
+
+	Ok((client, server))
+}
+
+/// Build a genai `Client` that talks through a yakbak record proxy to a real backend.
+///
+/// Returns `(client, server)` — call `server.shutdown().await` when done to flush cassettes.
+pub async fn record_client(
+	provider: &str,
+	scenario: &str,
+	backend_url: &str,
+) -> TestResult<(Client, YakbakServer)> {
+	let cassette_dir = format!("tests/data/yakbak/{provider}/{scenario}");
+	let server = YakbakServer::start(Mode::Record {
+		backend_url: backend_url.to_string(),
+		cassette_dir: cassette_dir.into(),
+	})
+	.await
+	.map_err(|e| format!("yakbak start failed: {e}"))?;
+
+	let base_url = server.base_url();
+	let client = Client::builder()
+		.with_service_target_resolver(ServiceTargetResolver::from_resolver_fn(
+			move |st: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
+				Ok(ServiceTarget {
+					endpoint: Endpoint::from_owned(base_url.clone()),
+					..st
+				})
+			},
+		))
+		.build();
+
+	Ok((client, server))
+}

--- a/tests/support/yakbak/server.rs
+++ b/tests/support/yakbak/server.rs
@@ -1,0 +1,306 @@
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+
+pub enum Mode {
+	Record {
+		backend_url: String,
+		cassette_dir: PathBuf,
+	},
+	Replay {
+		cassette_dir: PathBuf,
+	},
+}
+
+pub struct YakbakServer {
+	addr: SocketAddr,
+	shutdown_tx: Option<oneshot::Sender<()>>,
+	join_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl YakbakServer {
+	pub fn addr(&self) -> SocketAddr {
+		self.addr
+	}
+
+	/// Base URL, e.g. `http://127.0.0.1:12345/`
+	pub fn base_url(&self) -> String {
+		format!("http://127.0.0.1:{}/", self.addr.port())
+	}
+
+	pub async fn shutdown(&mut self) {
+		if let Some(tx) = self.shutdown_tx.take() {
+			let _ = tx.send(());
+		}
+		if let Some(handle) = self.join_handle.take() {
+			let _ = handle.await;
+		}
+	}
+}
+
+impl Drop for YakbakServer {
+	fn drop(&mut self) {
+		if let Some(tx) = self.shutdown_tx.take() {
+			let _ = tx.send(());
+		}
+	}
+}
+
+
+
+impl YakbakServer {
+	pub async fn start(mode: Mode) -> Result<Self, String> {
+		let listener = TcpListener::bind("127.0.0.1:0")
+			.await
+			.map_err(|e| format!("yakbak bind: {e}"))?;
+		let addr = listener.local_addr().map_err(|e| format!("yakbak addr: {e}"))?;
+
+		let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+		let join_handle = match mode {
+			Mode::Record {
+				backend_url,
+				cassette_dir,
+			} => {
+				let state = Arc::new(RecordState {
+					backend_url,
+					cassette_dir,
+					counter: AtomicUsize::new(0),
+					client: reqwest::Client::new(),
+				});
+				tokio::spawn(run_server(listener, shutdown_rx, move |req| {
+					let state = state.clone();
+					async move { handle_record(req, &state).await }
+				}))
+			}
+			Mode::Replay { cassette_dir } => {
+				let state = Arc::new(ReplayState {
+					cassette_dir,
+					counter: AtomicUsize::new(0),
+				});
+				tokio::spawn(run_server(listener, shutdown_rx, move |req| {
+					let state = state.clone();
+					async move { handle_replay(req, &state).await }
+				}))
+			}
+		};
+
+		Ok(YakbakServer {
+			addr,
+			shutdown_tx: Some(shutdown_tx),
+			join_handle: Some(join_handle),
+		})
+	}
+}
+
+
+
+/// Returns a 500 error response with the given message.
+fn error_response(msg: String) -> Response<Full<Bytes>> {
+	eprintln!("[yakbak] ERROR: {msg}");
+	Response::builder()
+		.status(500)
+		.header("content-type", "text/plain")
+		.body(Full::new(Bytes::from(msg)))
+		.unwrap()
+}
+
+async fn run_server<F, Fut>(listener: TcpListener, mut shutdown_rx: oneshot::Receiver<()>, handler: F)
+where
+	F: Fn(Request<Incoming>) -> Fut + Send + Sync + Clone + 'static,
+	Fut: std::future::Future<Output = Result<Response<Full<Bytes>>, String>> + Send + 'static,
+{
+	loop {
+		tokio::select! {
+			accept = listener.accept() => {
+				match accept {
+					Ok((stream, _)) => {
+						let handler = handler.clone();
+						tokio::spawn(async move {
+							let io = TokioIo::new(stream);
+							let svc = service_fn(move |req: Request<Incoming>| {
+								let handler = handler.clone();
+								async move {
+									let resp = match handler(req).await {
+										Ok(r) => r,
+										Err(e) => error_response(e),
+									};
+									Ok::<_, Infallible>(resp)
+								}
+							});
+							if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
+								eprintln!("[yakbak] connection error: {e}");
+							}
+						});
+					}
+					Err(e) => {
+						eprintln!("[yakbak] accept error: {e}");
+					}
+				}
+			}
+			_ = &mut shutdown_rx => break,
+		}
+	}
+}
+
+
+
+struct RecordState {
+	backend_url: String,
+	cassette_dir: PathBuf,
+	counter: AtomicUsize,
+	client: reqwest::Client,
+}
+
+async fn handle_record(req: Request<Incoming>, state: &RecordState) -> Result<Response<Full<Bytes>>, String> {
+	// -- Extract request parts
+	let method = req.method().clone();
+	let path_and_query = req
+		.uri()
+		.path_and_query()
+		.map(|pq| pq.as_str().to_string())
+		.unwrap_or_else(|| "/".to_string());
+	let req_headers: Vec<(String, String)> = req
+		.headers()
+		.iter()
+		.filter(|(name, _)| name.as_str() != "host")
+		.map(|(name, value)| (name.to_string(), value.to_str().unwrap_or("").to_string()))
+		.collect();
+	let body_bytes = req
+		.into_body()
+		.collect()
+		.await
+		.map_err(|e| format!("read body: {e}"))?
+		.to_bytes();
+
+	// -- Forward to real backend
+	let forward_url = format!(
+		"{}{}",
+		state.backend_url.trim_end_matches('/'),
+		path_and_query
+	);
+	eprintln!("[yakbak] RECORD {method} {forward_url}");
+
+	let mut builder = state
+		.client
+		.request(
+			reqwest::Method::from_bytes(method.as_str().as_bytes()).map_err(|e| format!("method: {e}"))?,
+			&forward_url,
+		);
+	for (name, value) in &req_headers {
+		builder = builder.header(name.as_str(), value.as_str());
+	}
+	builder = builder.body(body_bytes.to_vec());
+
+	let response = builder.send().await.map_err(|e| format!("forward: {e}"))?;
+	let status = response.status().as_u16();
+	let resp_content_type = response
+		.headers()
+		.get("content-type")
+		.and_then(|v| v.to_str().ok())
+		.unwrap_or("")
+		.to_string();
+	let resp_body = response.bytes().await.map_err(|e| format!("read response: {e}"))?;
+
+	// -- Save to cassette
+	tokio::fs::create_dir_all(&state.cassette_dir)
+		.await
+		.map_err(|e| format!("mkdir: {e}"))?;
+	let idx = state.counter.fetch_add(1, Ordering::SeqCst);
+	let filename = format!("response_{:03}.txt", idx);
+	let filepath = state.cassette_dir.join(&filename);
+	tokio::fs::write(&filepath, &resp_body)
+		.await
+		.map_err(|e| format!("write: {e}"))?;
+	eprintln!(
+		"[yakbak] SAVED {} ({} bytes, status={}, ct={})",
+		filepath.display(),
+		resp_body.len(),
+		status,
+		resp_content_type
+	);
+
+	// -- Return response to caller
+	let mut resp_builder = Response::builder().status(status);
+	if !resp_content_type.is_empty() {
+		resp_builder = resp_builder.header("content-type", &resp_content_type);
+	}
+	resp_builder
+		.body(Full::new(resp_body))
+		.map_err(|e| format!("build response: {e}"))
+}
+
+
+
+struct ReplayState {
+	cassette_dir: PathBuf,
+	counter: AtomicUsize,
+}
+
+async fn handle_replay(_req: Request<Incoming>, state: &ReplayState) -> Result<Response<Full<Bytes>>, String> {
+	// -- List .txt files in sorted order
+	let mut files: Vec<PathBuf> = Vec::new();
+	let mut dir = tokio::fs::read_dir(&state.cassette_dir)
+		.await
+		.map_err(|e| format!("readdir {}: {e}", state.cassette_dir.display()))?;
+	while let Some(entry) = dir.next_entry().await.map_err(|e| format!("entry: {e}"))? {
+		let path = entry.path();
+		if path.extension().and_then(|e| e.to_str()) == Some("txt") {
+			files.push(path);
+		}
+	}
+	files.sort();
+
+	// -- Pick the next file
+	let idx = state.counter.fetch_add(1, Ordering::SeqCst);
+	let file = files.get(idx).ok_or_else(|| {
+		format!(
+			"REPLAY: no more response files (idx={}, dir={})",
+			idx,
+			state.cassette_dir.display()
+		)
+	})?;
+
+	let body = tokio::fs::read(file).await.map_err(|e| format!("read: {e}"))?;
+	let body_str = String::from_utf8_lossy(&body);
+
+	// -- Infer content-type from body content
+	let content_type = infer_content_type(&body_str);
+	eprintln!(
+		"[yakbak] REPLAY {} ({} bytes, ct={})",
+		file.display(),
+		body.len(),
+		content_type
+	);
+
+	Response::builder()
+		.status(200)
+		.header("content-type", content_type)
+		.body(Full::new(Bytes::from(body)))
+		.map_err(|e| format!("build response: {e}"))
+}
+
+/// Infer content-type from body text.
+fn infer_content_type(body: &str) -> &'static str {
+	let trimmed = body.trim_start();
+	if trimmed.starts_with('{') || trimmed.starts_with('[') {
+		"application/json"
+	} else if trimmed.starts_with("event:") || trimmed.starts_with("data:") {
+		"text/event-stream"
+	} else {
+		"text/plain"
+	}
+}
+

--- a/tests/tests_yakbak_gemini.rs
+++ b/tests/tests_yakbak_gemini.rs
@@ -1,0 +1,135 @@
+//! Replay integration tests for the Gemini adapter.
+//!
+//! These tests use pre-recorded cassettes from `tests/data/yakbak/gemini/`
+//! and assert that thinking content, tool calls, and usage flow through correctly.
+
+mod support;
+
+use genai::chat::*;
+use serde_json::json;
+use support::yakbak::replay_client;
+use support::{TestResult, extract_stream_end};
+
+#[tokio::test]
+async fn test_yakbak_gemini_thinking_nostream() -> TestResult<()> {
+	let (client, _server) = replay_client("gemini", "thinking_nostream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Low);
+
+	let chat_res = client
+		.exec_chat("gemini-2.5-flash", chat_req, Some(&options))
+		.await?;
+
+	// Exact text
+	assert_eq!(
+		chat_res.first_text().as_deref(),
+		Some("The sky is blue because sunlight scatters off molecules in Earth's atmosphere, with blue light (which has shorter wavelengths) scattering more efficiently in all directions than other colors."),
+	);
+
+	// Exact reasoning content
+	assert_eq!(
+		chat_res.reasoning_content.as_deref(),
+		Some("**My Concise Explanation of the Sky's Color**\n\nAlright, a single sentence, as requested. The user, being the expert they are, just needs the core concept. Let's see... the question is why the sky is blue. My thought process here is to hit the key points directly: Sunlight, the atmosphere, scattering, and the crucial element of wavelength. The first draft: \"The sky is blue because sunlight is scattered by molecules in Earth's atmosphere, and blue light (which has shorter wavelengths) is scattered more efficiently than other colors.\" Yup, that works. It's all there: sunlight interacting with the atmosphere and the wavelength-dependent nature of Rayleigh scattering, which explains why blue is the dominant color we see. Length is fine; clarity is good. Delivered.\n"),
+	);
+
+	// Exact usage
+	assert_eq!(chat_res.usage.prompt_tokens, Some(12));
+	assert_eq!(chat_res.usage.completion_tokens, Some(169));
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_yakbak_gemini_thinking_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("gemini", "thinking_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("gemini-2.5-flash", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// Exact text
+	assert_eq!(
+		extract.content.as_deref(),
+		Some("The sky is blue because molecules in Earth's atmosphere scatter shorter-wavelength blue light from the sun more efficiently than longer-wavelength red light."),
+	);
+
+	// Reasoning should be substantial (862 chars from recorded)
+	let reasoning = extract.reasoning_content.as_deref().ok_or("Should have reasoning")?;
+	assert_eq!(reasoning.len(), 862, "reasoning length should be exactly 862 chars");
+	assert!(reasoning.starts_with("**Defining Sky Color**"));
+
+	// Exact usage
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(12));
+	assert_eq!(usage.completion_tokens, Some(230));
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_yakbak_gemini_stream_tools() -> TestResult<()> {
+	let (client, _server) = replay_client("gemini", "thinking_stream_tools").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("You are a helpful assistant. Use tools when needed."),
+		ChatMessage::user("What is the temperature in C and weather, in Paris, France"),
+	])
+	.append_tool(Tool::new("get_weather").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"city": { "type": "string", "description": "The city name" },
+			"country": { "type": "string", "description": "The most likely country of this city name" },
+			"unit": { "type": "string", "enum": ["C", "F"], "description": "Temperature unit" }
+		},
+		"required": ["city", "country", "unit"],
+	})));
+
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_tool_calls(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("gemini-2.5-flash", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// Exactly one tool call
+	let tool_calls = extract.stream_end.captured_tool_calls().ok_or("Should have tool calls")?;
+	assert_eq!(tool_calls.len(), 1);
+
+	// Exact tool call
+	let tc = &tool_calls[0];
+	assert_eq!(tc.fn_name, "get_weather");
+	assert_eq!(tc.fn_arguments, json!({"country": "France", "unit": "C", "city": "Paris"}));
+
+	// Exact reasoning content
+	let reasoning = extract.reasoning_content.as_deref().ok_or("Should have reasoning")?;
+	assert!(reasoning.starts_with("**Gathering Weather Information**"));
+	assert!(reasoning.contains("Refining Data Retrieval"));
+	assert!(reasoning.ends_with("\n\n\n"));
+
+	// Exact usage
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(107));
+	assert_eq!(usage.completion_tokens, Some(135));
+
+	Ok(())
+}

--- a/tests/tests_yakbak_openai_resp.rs
+++ b/tests/tests_yakbak_openai_resp.rs
@@ -1,0 +1,95 @@
+//! Replay integration tests for the OpenAI Responses API adapter.
+//!
+//! These tests use pre-recorded cassettes from `tests/data/yakbak/openai_resp/`
+//! and assert that content and tool calls flow through correctly.
+
+mod support;
+
+use genai::chat::*;
+use serde_json::json;
+use support::yakbak::replay_client;
+use support::{TestResult, extract_stream_end};
+
+#[tokio::test]
+async fn test_yakbak_openai_resp_reasoning_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("openai_resp", "reasoning_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("openai_resp::gpt-5.4-mini", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// Exact text content
+	assert_eq!(
+		extract.content.as_deref(),
+		Some("The sky looks blue because molecules in Earth\u{2019}s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, so the scattered light reaching your eyes is mostly blue."),
+		"Text should match recorded response exactly"
+	);
+
+	// Exact usage
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(21));
+	assert_eq!(usage.completion_tokens, Some(48));
+	assert_eq!(usage.total_tokens, Some(69));
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_yakbak_openai_resp_stream_tools() -> TestResult<()> {
+	let (client, _server) = replay_client("openai_resp", "reasoning_stream_tools").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("You are a helpful assistant. Use tools when needed."),
+		ChatMessage::user("What is the temperature in C and weather, in Paris, France"),
+	])
+	.append_tool(Tool::new("get_weather").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"city": { "type": "string", "description": "The city name" },
+			"country": { "type": "string", "description": "The most likely country of this city name" },
+			"unit": { "type": "string", "enum": ["C", "F"], "description": "Temperature unit" }
+		},
+		"required": ["city", "country", "unit"],
+	})));
+
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_tool_calls(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("openai_resp::gpt-5.4-mini", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// Exactly one tool call
+	let tool_calls = extract.stream_end.captured_tool_calls().ok_or("Should have tool calls")?;
+	assert_eq!(tool_calls.len(), 1);
+
+	// Exact tool call details
+	let tc = &tool_calls[0];
+	assert_eq!(tc.fn_name, "get_weather");
+	assert_eq!(tc.fn_arguments, json!({"city": "Paris", "country": "France", "unit": "C"}));
+	assert!(!tc.call_id.is_empty());
+
+	// Exact usage
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(106));
+	assert_eq!(usage.completion_tokens, Some(36));
+	assert_eq!(usage.total_tokens, Some(142));
+
+	Ok(())
+}

--- a/tests/tests_yakbak_record.rs
+++ b/tests/tests_yakbak_record.rs
@@ -1,0 +1,172 @@
+//! Recording scripts for yakbak cassettes.
+//!
+//! These are `#[ignore]` tests — run manually with real API keys:
+//!
+//! ```sh
+//! OPENAI_API_KEY=... GEMINI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored
+//! ```
+//!
+//! Each test records a response cassette to `tests/data/yakbak/{provider}/{scenario}/`.
+
+mod support;
+
+use genai::chat::*;
+use support::yakbak::record_client;
+use support::{TestResult, extract_stream_end};
+use serde_json::json;
+
+
+fn openai_backend() -> String {
+	std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| "https://api.openai.com/v1/".to_string())
+}
+
+fn gemini_backend() -> String {
+	std::env::var("GEMINI_BASE_URL").unwrap_or_else(|_| "https://generativelanguage.googleapis.com/v1beta/".to_string())
+}
+
+
+
+const OPENAI_MODEL: &str = "openai_resp::gpt-5.4-mini";
+
+#[tokio::test]
+#[ignore]
+async fn record_openai_resp_reasoning_stream() -> TestResult<()> {
+	let (client, mut server) = record_client("openai_resp", "reasoning_stream", &openai_backend()).await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true);
+
+	let stream_res = client.exec_chat_stream(OPENAI_MODEL, chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+	eprintln!("[record] Stream content: {:?}", extract.content.as_deref().map(|s| &s[..s.len().min(80)]));
+	eprintln!("[record] Stream reasoning: {:?}", extract.reasoning_content.as_deref().map(|s| &s[..s.len().min(80)]));
+
+	server.shutdown().await;
+	Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn record_openai_resp_reasoning_stream_tools() -> TestResult<()> {
+	let (client, mut server) = record_client("openai_resp", "reasoning_stream_tools", &openai_backend()).await?;
+
+	let chat_req = seed_tool_request();
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true);
+
+	let stream_res = client.exec_chat_stream(OPENAI_MODEL, chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+	eprintln!("[record] Stream reasoning: {:?}", extract.reasoning_content.is_some());
+	let tool_calls = &extract.stream_end.captured_tool_calls();
+	eprintln!("[record] Tool calls: {:?}", tool_calls.as_ref().map(|tc| tc.len()));
+
+	server.shutdown().await;
+	Ok(())
+}
+
+
+
+const GEMINI_MODEL: &str = "gemini-2.5-flash";
+
+#[tokio::test]
+#[ignore]
+async fn record_gemini_thinking_nostream() -> TestResult<()> {
+	let (client, mut server) = record_client("gemini", "thinking_nostream", &gemini_backend()).await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Low);
+
+	let res = client.exec_chat(GEMINI_MODEL, chat_req, Some(&options)).await?;
+	let text = res.first_text().ok_or("Should have text content")?;
+	eprintln!("[record] Got text: {}", &text[..text.len().min(80)]);
+	if let Some(rc) = &res.reasoning_content {
+		eprintln!("[record] Got reasoning_content ({} chars)", rc.len());
+	}
+
+	server.shutdown().await;
+	Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn record_gemini_thinking_stream() -> TestResult<()> {
+	let (client, mut server) = record_client("gemini", "thinking_stream", &gemini_backend()).await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true);
+
+	let stream_res = client.exec_chat_stream(GEMINI_MODEL, chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+	eprintln!("[record] Stream content: {:?}", extract.content.as_deref().map(|s| &s[..s.len().min(80)]));
+	eprintln!("[record] Stream reasoning: {:?}", extract.reasoning_content.as_deref().map(|s| &s[..s.len().min(80)]));
+
+	server.shutdown().await;
+	Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn record_gemini_thinking_stream_tools() -> TestResult<()> {
+	let (client, mut server) = record_client("gemini", "thinking_stream_tools", &gemini_backend()).await?;
+
+	let chat_req = seed_tool_request();
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true);
+
+	let stream_res = client.exec_chat_stream(GEMINI_MODEL, chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+	eprintln!("[record] Stream reasoning: {:?}", extract.reasoning_content.is_some());
+	let tool_calls = &extract.stream_end.captured_tool_calls();
+	eprintln!("[record] Tool calls: {:?}", tool_calls.as_ref().map(|tc| tc.len()));
+
+	server.shutdown().await;
+	Ok(())
+}
+
+
+
+fn seed_tool_request() -> ChatRequest {
+	ChatRequest::new(vec![
+		ChatMessage::system("You are a helpful assistant. Use tools when needed."),
+		ChatMessage::user("What is the temperature in C and weather, in Paris, France"),
+	])
+	.append_tool(Tool::new("get_weather").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"city": {
+				"type": "string",
+				"description": "The city name"
+			},
+			"country": {
+				"type": "string",
+				"description": "The most likely country of this city name"
+			},
+			"unit": {
+				"type": "string",
+				"enum": ["C", "F"],
+				"description": "The temperature unit of the country. C for Celsius, and F for Fahrenheit"
+			}
+		},
+		"required": ["city", "country", "unit"],
+	})))
+}
+


### PR DESCRIPTION
Lightweight test harness that records real API responses as .txt cassettes and replays them deterministically without API keys. Covers OpenAI Responses API (streaming + tool calls) and Gemini (streaming, non-streaming, tool calls).

All assertions are exact string/value equality against recorded responses. Includes GitHub Actions workflow for CI.