### PR TITLE
Add Google Vertex adapter with support for Gemini and Anthropic

### DIFF
--- a/examples/c99-google-gcp.rs
+++ b/examples/c99-google-gcp.rs
@@ -29,11 +29,12 @@ const CLAUDE_MODEL: &str = "vertex::claude-sonnet-4-6";
 /// Required env vars:
 ///   - GCP_SERVICE_ACCOUNT: JSON content of the service account key
 ///   - VERTEX_PROJECT_ID: Your GCP project ID
-///   - VERTEX_LOCATION: GCP region (defaults to "us-central1" if not set)
+///   - VERTEX_LOCATION: GCP region (uses "global" location if not set)
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 	tracing_subscriber::fmt()
 		.with_env_filter(EnvFilter::new("genai=debug"))
+		// .with_max_level(tracing::Level::DEBUG) // To enable all sub-library tracing
 		.init();
 
 	let gcp_env_name: Arc<str> = "GCP_SERVICE_ACCOUNT".into();
@@ -58,8 +59,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 		})
 	};
 
+	// -- Create the AuthResolver
 	let auth_resolver = AuthResolver::from_resolver_async_fn(resolve_fn);
 
+	// -- Create Chat Client
 	let client = Client::builder().with_auth_resolver(auth_resolver).build();
 
 	// -- Example 1: Gemini on Vertex AI

--- a/examples/c99-google-gcp.rs
+++ b/examples/c99-google-gcp.rs
@@ -1,6 +1,5 @@
 use gcp_auth::{CustomServiceAccount, TokenProvider};
 use genai::Client;
-use genai::Headers;
 use genai::ModelIden;
 use genai::chat::printer::print_chat_stream;
 use genai::chat::{ChatMessage, ChatRequest};
@@ -9,20 +8,38 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tracing_subscriber::EnvFilter;
 
-const MODEL: &str = "gemini-2.0-flash";
+// With the Vertex adapter, use the `vertex::` namespace prefix.
+// The adapter handles URL construction and publisher routing automatically.
+const GEMINI_MODEL: &str = "vertex::gemini-2.5-flash";
+const CLAUDE_MODEL: &str = "vertex::claude-sonnet-4-6";
 
+/// This example shows how to use the Vertex AI adapter with an AuthResolver
+/// that obtains OAuth2 tokens from a GCP service account.
+///
+/// The `vertex::` adapter handles URL construction (region, project, publisher)
+/// and wire format dispatch (Gemini vs Anthropic) automatically.
+/// You only need to supply a Bearer token via the AuthResolver.
+///
+/// For an alternative approach without the Vertex adapter, you can use
+/// `AuthData::RequestOverride` with the Gemini adapter to manually construct
+/// the full Vertex URL and auth headers. See the git history of this file
+/// for that pattern, which also works as a general escape hatch for any
+/// custom endpoint/auth scenario.
+///
+/// Required env vars:
+///   - GCP_SERVICE_ACCOUNT: JSON content of the service account key
+///   - VERTEX_PROJECT_ID: Your GCP project ID
+///   - VERTEX_LOCATION: GCP region (defaults to "us-central1" if not set)
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 	tracing_subscriber::fmt()
 		.with_env_filter(EnvFilter::new("genai=debug"))
-		// .with_max_level(tracing::Level::DEBUG) // To enable all sub-library tracing
 		.init();
 
-	// Just an example of a data that will get captured (needs to be locable)
 	let gcp_env_name: Arc<str> = "GCP_SERVICE_ACCOUNT".into();
 
-	// -- Create the Async Auth resolve_fn closure
-	let resolve_fn = move |model: ModelIden| -> Pin<
+	// -- Create the Async Auth resolver that fetches OAuth2 tokens from the service account
+	let resolve_fn = move |_model: ModelIden| -> Pin<
 		Box<dyn Future<Output = Result<Option<AuthData>, genai::resolver::Error>> + Send + 'static>,
 	> {
 		let gcp_env_name = gcp_env_name.clone();
@@ -37,37 +54,27 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 				.token(scopes)
 				.await
 				.map_err(|e| genai::resolver::Error::Custom(e.to_string()))?;
-			let location = std::env::var("GCP_LOCATION").unwrap_or("us-central1".to_string());
-			let project_id = account.project_id().ok_or_else(|| {
-				genai::resolver::Error::Custom("GCP Auth: Service account has no project_id".to_string())
-			})?;
-			let url = format!(
-				"https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}/publishers/google/models/{}:generateContent",
-				location, project_id, location, model.model_name
-			);
-
-			let auth_value = format!("Bearer {}", token.as_str());
-			let auth_header = Headers::from(("Authorization", auth_value));
-			Ok(Some(AuthData::RequestOverride {
-				headers: auth_header,
-				url,
-			}))
+			Ok(Some(AuthData::from_single(token.as_str())))
 		})
 	};
 
-	// -- Create the AuthResolver
 	let auth_resolver = AuthResolver::from_resolver_async_fn(resolve_fn);
 
-	// -- Create Chat Client
 	let client = Client::builder().with_auth_resolver(auth_resolver).build();
 
-	// -- Create Chat Request
+	// -- Example 1: Gemini on Vertex AI
+	println!("--- Gemini on Vertex AI ---");
 	let chat_request = ChatRequest::default().with_system("Answer in one sentence");
 	let chat_request = chat_request.append_message(ChatMessage::user("Why is the sky blue?"));
-
-	// -- Executed
-	let stream = client.exec_chat_stream(MODEL, chat_request, None).await?;
-
+	let stream = client.exec_chat_stream(GEMINI_MODEL, chat_request, None).await?;
 	print_chat_stream(stream, None).await?;
+
+	// -- Example 2: Claude on Vertex AI (Model Garden)
+	println!("\n--- Claude on Vertex AI (Model Garden) ---");
+	let chat_request = ChatRequest::default().with_system("Answer in one sentence");
+	let chat_request = chat_request.append_message(ChatMessage::user("Why is the sky blue?"));
+	let stream = client.exec_chat_stream(CLAUDE_MODEL, chat_request, None).await?;
+	print_chat_stream(stream, None).await?;
+
 	Ok(())
 }

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -13,6 +13,7 @@ use crate::adapter::groq::GroqAdapter;
 use crate::adapter::mimo::MimoAdapter;
 use crate::adapter::nebius::NebiusAdapter;
 use crate::adapter::openai::OpenAIAdapter;
+use crate::adapter::vertex::VertexAdapter;
 use crate::adapter::xai::XaiAdapter;
 use crate::adapter::{Adapter as _, zai};
 use crate::{ModelName, Result};
@@ -56,6 +57,9 @@ pub enum AdapterKind {
 	Cohere,
 	/// OpenAI shared behavior + some custom. (currently, localhost only, can be customize with ServerTargetResolver).
 	Ollama,
+	/// Google Vertex AI (Model Garden). Supports Gemini and Claude models via publishers/google and publishers/anthropic.
+	/// Uses namespace routing: `vertex::gemini-2.5-flash`, `vertex::claude-sonnet-4-6`
+	Vertex,
 }
 
 /// Serialization/Parse implementations
@@ -79,6 +83,7 @@ impl AdapterKind {
 			AdapterKind::Aliyun => "Aliyun",
 			AdapterKind::Cohere => "Cohere",
 			AdapterKind::Ollama => "Ollama",
+			AdapterKind::Vertex => "Vertex",
 		}
 	}
 
@@ -101,6 +106,7 @@ impl AdapterKind {
 			AdapterKind::Aliyun => "aliyun",
 			AdapterKind::Cohere => "cohere",
 			AdapterKind::Ollama => "ollama",
+			AdapterKind::Vertex => "vertex",
 		}
 	}
 
@@ -122,6 +128,7 @@ impl AdapterKind {
 			"aliyun" => Some(AdapterKind::Aliyun),
 			"cohere" => Some(AdapterKind::Cohere),
 			"ollama" => Some(AdapterKind::Ollama),
+			"vertex" => Some(AdapterKind::Vertex),
 			_ => None,
 		}
 	}
@@ -148,6 +155,7 @@ impl AdapterKind {
 			AdapterKind::Aliyun => AliyunAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Cohere => CohereAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Ollama => OllamaAdapter::DEFAULT_API_KEY_ENV_NAME,
+			AdapterKind::Vertex => VertexAdapter::DEFAULT_API_KEY_ENV_NAME,
 		}
 	}
 }
@@ -173,6 +181,7 @@ impl AdapterKind {
 	/// - e.g., for together.ai `together::meta-llama/Llama-3-8b-chat-hf`
 	/// - e.g., for nebius with `nebius::Qwen/Qwen3-235B-A22B`
 	/// - e.g., for ZAI coding plan with `coding::glm-4.6`
+	/// - e.g., for vertex with `vertex::gemini-2.5-flash` or `vertex::claude-sonnet-4-6`
 	///
 	/// And all adapters can be force namspaced as well.
 	///

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -118,11 +118,10 @@ fn insert_anthropic_reasoning(payload: &mut Value, model_name: &str, effort: &Re
 // For max model tokens see: https://docs.anthropic.com/en/docs/about-claude/models/overview
 //
 // fall back
-const MAX_TOKENS_64K: u32 = 64000; // claude-opus-4-5 claude-sonnet... (4 and above), claude-haiku..., claude-3-7-sonnet,
-// custom
-const MAX_TOKENS_32K: u32 = 32000; // claude-opus-4
-const MAX_TOKENS_8K: u32 = 8192; // claude-3-5-sonnet, claude-3-5-haiku
-const MAX_TOKENS_4K: u32 = 4096; // claude-3-opus, claude-3-haiku
+pub(in crate::adapter) const MAX_TOKENS_64K: u32 = 64000; // claude-opus-4-5 claude-sonnet... (4 and above), claude-haiku..., claude-3-7-sonnet,
+pub(in crate::adapter) const MAX_TOKENS_32K: u32 = 32000; // claude-opus-4
+pub(in crate::adapter) const MAX_TOKENS_8K: u32 = 8192; // claude-3-5-sonnet, claude-3-5-haiku
+pub(in crate::adapter) const MAX_TOKENS_4K: u32 = 4096; // claude-3-opus, claude-3-haiku
 
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 
@@ -299,30 +298,7 @@ impl Adapter for AnthropicAdapter {
 			payload.x_insert("stop_sequences", options_set.stop_sequences())?;
 		}
 
-		// const MAX_TOKENS_64K: u32 = 64000; // claude-opus-4-5 claude-sonnet-4, claude-3-7-sonnet,
-		// const MAX_TOKENS_32K: u32 = 32000; // claude-opus-4
-		// const MAX_TOKENS_8K: u32 = 8192; // claude-3-5-sonnet, claude-3-5-haiku
-		// const MAX_TOKENS_4K: u32 = 4096; // claude-3-opus, claude-3-haiku
-		let max_tokens = options_set.max_tokens().unwrap_or_else(|| {
-			// most likely models used, so put first. Also a little wider with `claude-sonnet` (since name from version 4)
-			if model_name.contains("claude-sonnet")
-				|| model_name.contains("claude-haiku")
-				|| model_name.contains("claude-3-7-sonnet")
-				|| model_name.contains("claude-opus-4-5")
-			{
-				MAX_TOKENS_64K
-			} else if model_name.contains("claude-opus-4") {
-				MAX_TOKENS_32K
-			} else if model_name.contains("claude-3-5") {
-				MAX_TOKENS_8K
-			} else if model_name.contains("3-opus") || model_name.contains("3-haiku") {
-				MAX_TOKENS_4K
-			}
-			// for now, fall back on the 64K by default (might want to be more conservative)
-			else {
-				MAX_TOKENS_64K
-			}
-		});
+		let max_tokens = Self::resolve_max_tokens(model_name, &options_set);
 		payload.x_insert("max_tokens", max_tokens)?; // required for Anthropic
 
 		if let Some(top_p) = options_set.top_p() {
@@ -453,7 +429,29 @@ impl Adapter for AnthropicAdapter {
 // region:    --- Support
 
 impl AnthropicAdapter {
-	pub(super) fn into_usage(mut usage_value: Value) -> Usage {
+	/// Resolves the max_tokens value for an Anthropic model, using the user-provided
+	/// value if set, or a model-appropriate default.
+	pub(in crate::adapter) fn resolve_max_tokens(model_name: &str, options_set: &ChatOptionsSet) -> u32 {
+		options_set.max_tokens().unwrap_or_else(|| {
+			if model_name.contains("claude-sonnet")
+				|| model_name.contains("claude-haiku")
+				|| model_name.contains("claude-3-7-sonnet")
+				|| model_name.contains("claude-opus-4-5")
+			{
+				MAX_TOKENS_64K
+			} else if model_name.contains("claude-opus-4") {
+				MAX_TOKENS_32K
+			} else if model_name.contains("claude-3-5") {
+				MAX_TOKENS_8K
+			} else if model_name.contains("3-opus") || model_name.contains("3-haiku") {
+				MAX_TOKENS_4K
+			} else {
+				MAX_TOKENS_64K
+			}
+		})
+	}
+
+	pub(in crate::adapter) fn into_usage(mut usage_value: Value) -> Usage {
 		// IMPORTANT: For Anthropic, the `input_tokens` does not include `cache_creation_input_tokens` or `cache_read_input_tokens`.
 		// Therefore, it must be normalized in the OpenAI style, where it includes both cached and written tokens (for symmetry).
 		let input_tokens: i32 = usage_value.x_take("input_tokens").ok().unwrap_or(0);
@@ -498,7 +496,7 @@ impl AnthropicAdapter {
 
 	/// Takes the GenAI ChatMessages and constructs the System string and JSON Messages for Anthropic.
 	/// - Will push the `ChatRequest.system` and system message to `AnthropicRequestParts.system`
-	fn into_anthropic_request_parts(chat_req: ChatRequest) -> Result<AnthropicRequestParts> {
+	pub(in crate::adapter) fn into_anthropic_request_parts(chat_req: ChatRequest) -> Result<AnthropicRequestParts> {
 		let mut messages: Vec<Value> = Vec::new();
 		// (content, cache_control)
 		let mut systems: Vec<(String, Option<CacheControl>)> = Vec::new();
@@ -878,10 +876,10 @@ fn apply_cache_control_to_parts(cache_control: Option<&CacheControl>, parts: Vec
 	parts
 }
 
-struct AnthropicRequestParts {
-	system: Option<Value>,
-	messages: Vec<Value>,
-	tools: Option<Vec<Value>>,
+pub(in crate::adapter) struct AnthropicRequestParts {
+	pub system: Option<Value>,
+	pub messages: Vec<Value>,
+	pub tools: Option<Vec<Value>>,
 }
 
 // endregion: --- Support

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -119,6 +119,7 @@ fn insert_anthropic_reasoning(payload: &mut Value, model_name: &str, effort: &Re
 //
 // fall back
 pub(in crate::adapter) const MAX_TOKENS_64K: u32 = 64000; // claude-opus-4-5 claude-sonnet... (4 and above), claude-haiku..., claude-3-7-sonnet,
+// custom
 pub(in crate::adapter) const MAX_TOKENS_32K: u32 = 32000; // claude-opus-4
 pub(in crate::adapter) const MAX_TOKENS_8K: u32 = 8192; // claude-3-5-sonnet, claude-3-5-haiku
 pub(in crate::adapter) const MAX_TOKENS_4K: u32 = 4096; // claude-3-opus, claude-3-haiku
@@ -433,6 +434,7 @@ impl AnthropicAdapter {
 	/// value if set, or a model-appropriate default.
 	pub(in crate::adapter) fn resolve_max_tokens(model_name: &str, options_set: &ChatOptionsSet) -> u32 {
 		options_set.max_tokens().unwrap_or_else(|| {
+			// most likely models used, so put first. Also a little wider with `claude-sonnet` (since name from version 4)
 			if model_name.contains("claude-sonnet")
 				|| model_name.contains("claude-haiku")
 				|| model_name.contains("claude-3-7-sonnet")
@@ -445,7 +447,9 @@ impl AnthropicAdapter {
 				MAX_TOKENS_8K
 			} else if model_name.contains("3-opus") || model_name.contains("3-haiku") {
 				MAX_TOKENS_4K
-			} else {
+			}
+			// for now, fall back on the 64K by default (might want to be more conservative)
+			else {
 				MAX_TOKENS_64K
 			}
 		})

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -16,10 +16,10 @@ use value_ext::JsonValueExt;
 pub struct GeminiAdapter;
 
 // Per gemini doc (https://x.com/jeremychone/status/1916501987371438372)
-const REASONING_ZERO: u32 = 0;
-const REASONING_LOW: u32 = 1000;
-const REASONING_MEDIUM: u32 = 8000;
-const REASONING_HIGH: u32 = 24000;
+pub(in crate::adapter) const REASONING_ZERO: u32 = 0;
+pub(in crate::adapter) const REASONING_LOW: u32 = 1000;
+pub(in crate::adapter) const REASONING_MEDIUM: u32 = 8000;
+pub(in crate::adapter) const REASONING_HIGH: u32 = 24000;
 
 /// Important
 /// - For now Low and Minimal aare the same for geminia
@@ -119,121 +119,13 @@ impl Adapter for GeminiAdapter {
 		let ServiceTarget { endpoint, auth, model } = target;
 		let (_, model_name) = model.model_name.namespace_and_name();
 
-		// -- api_key
 		let api_key = get_api_key(auth, &model)?;
-
-		// -- headers (empty for gemini)
 		let headers = Headers::from(("x-goog-api-key".to_string(), api_key.to_string()));
 
-		// -- Reasoning Budget
-		let (provider_model_name, computed_reasoning_effort) = match (model_name, options_set.reasoning_effort()) {
-			// No explicity reasoning_effort, try to infer from model name suffix (supports -zero)
-			(model, None) => {
-				// let model_name: &str = &model.model_name;
-				if let Some((prefix, last)) = model_name.rsplit_once('-') {
-					let reasoning = match last {
-						// 'zero' is a gemini special
-						"zero" => Some(ReasoningEffort::Budget(REASONING_ZERO)),
-						"none" => Some(ReasoningEffort::None),
-						"low" | "minimal" => Some(ReasoningEffort::Low),
-						"medium" => Some(ReasoningEffort::Medium),
-						"high" => Some(ReasoningEffort::High),
-						"xhigh" => Some(ReasoningEffort::XHigh),
-						"max" => Some(ReasoningEffort::Max),
-						_ => None,
-					};
-					// create the model name if there was a `-..` reasoning suffix
-					let model = if reasoning.is_some() { prefix } else { model };
+		let (payload, provider_model_name) =
+			Self::build_gemini_request_payload(&model, model_name, chat_req, options_set)?;
 
-					(model, reasoning)
-				} else {
-					(model, None)
-				}
-			}
-			// TOOD: make it more elegant
-			(model, Some(effort)) => (model, Some(effort.clone())),
-		};
-
-		// -- parts
-		let GeminiChatRequestParts {
-			system,
-			contents,
-			tools,
-		} = Self::into_gemini_request_parts(&model, chat_req)?;
-
-		// -- Playload
-		let mut payload = json!({
-			"contents": contents,
-		});
-
-		// -- Set the reasoning effort
-		if let Some(computed_reasoning_effort) = computed_reasoning_effort {
-			// -- For gemini-3 use the thinkingLevel if Low or High (does not support medium for now)
-			if provider_model_name.contains("gemini-3") {
-				match computed_reasoning_effort {
-					ReasoningEffort::Low | ReasoningEffort::Minimal => {
-						payload.x_insert("/generationConfig/thinkingConfig/thinkingLevel", "LOW")?;
-					}
-					ReasoningEffort::High | ReasoningEffort::Max => {
-						payload.x_insert("/generationConfig/thinkingConfig/thinkingLevel", "HIGH")?;
-					}
-					// Fallback on thinkingBudget
-					other => {
-						insert_gemini_thinking_budget_value(&mut payload, &other)?;
-					}
-				}
-			}
-			// -- Otherwise, Do thinking budget
-			else {
-				insert_gemini_thinking_budget_value(&mut payload, &computed_reasoning_effort)?;
-			}
-			// -- Always include thoughts when reasoning effort is set since you are already paying for them
-			payload.x_insert("/generationConfig/thinkingConfig/includeThoughts", true)?;
-		}
-
-		// Note: It's unclear from the spec if the content of systemInstruction should have a role.
-		//       Right now, it is omitted (since the spec states it can only be "user" or "model")
-		//       It seems to work. https://ai.google.dev/api/rest/v1beta/models/generateContent
-		if let Some(system) = system {
-			payload.x_insert(
-				"systemInstruction",
-				json!({
-					"parts": [ { "text": system }]
-				}),
-			)?;
-		}
-
-		// -- Tools
-		if let Some(tools) = tools {
-			payload.x_insert("tools", tools)?;
-		}
-
-		// -- Response Format
-		if let Some(ChatResponseFormat::JsonSpec(st_json)) = options_set.response_format() {
-			payload.x_insert("/generationConfig/responseMimeType", "application/json")?;
-			let mut schema = st_json.schema.clone();
-			super::openapi_schema::to_openapi_schema(&mut schema);
-			payload.x_insert("/generationConfig/responseJsonSchema", schema)?;
-		}
-
-		// -- Add supported ChatOptions
-		if let Some(temperature) = options_set.temperature() {
-			payload.x_insert("/generationConfig/temperature", temperature)?;
-		}
-
-		if !options_set.stop_sequences().is_empty() {
-			payload.x_insert("/generationConfig/stopSequences", options_set.stop_sequences())?;
-		}
-
-		if let Some(max_tokens) = options_set.max_tokens() {
-			payload.x_insert("/generationConfig/maxOutputTokens", max_tokens)?;
-		}
-		if let Some(top_p) = options_set.top_p() {
-			payload.x_insert("/generationConfig/topP", top_p)?;
-		}
-
-		// -- url
-		let provider_model = model.from_name(provider_model_name);
+		let provider_model = model.from_name(&provider_model_name);
 		let url = Self::get_service_url(&provider_model, service_type, endpoint)?;
 
 		Ok(WebRequestData { url, headers, payload })
@@ -358,7 +250,7 @@ impl Adapter for GeminiAdapter {
 
 /// Support functions for GeminiAdapter
 impl GeminiAdapter {
-	pub(super) fn body_to_gemini_chat_response(model_iden: &ModelIden, mut body: Value) -> Result<GeminiChatResponse> {
+	pub(in crate::adapter) fn body_to_gemini_chat_response(model_iden: &ModelIden, mut body: Value) -> Result<GeminiChatResponse> {
 		// If the body has an `error` property, then it is assumed to be an error.
 		if body.get("error").is_some() {
 			return Err(Error::ChatResponse {
@@ -460,8 +352,115 @@ impl GeminiAdapter {
 		})
 	}
 
+	/// Builds the Gemini JSON payload from a ChatRequest, including reasoning budget
+	/// resolution, system instruction, tools, response format, and chat options.
+	/// Returns (payload, provider_model_name) where provider_model_name may differ
+	/// from model_name if a reasoning suffix was stripped.
+	pub(in crate::adapter) fn build_gemini_request_payload(
+		model: &ModelIden,
+		model_name: &str,
+		chat_req: ChatRequest,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<(Value, String)> {
+		// -- Reasoning Budget
+		let (provider_model_name, computed_reasoning_effort) = match (model_name, options_set.reasoning_effort()) {
+			// No explicit reasoning_effort, try to infer from model name suffix (supports -zero)
+			(model, None) => {
+				if let Some((prefix, last)) = model_name.rsplit_once('-') {
+					let reasoning = match last {
+						// 'zero' is a gemini special
+						"zero" => Some(ReasoningEffort::Budget(REASONING_ZERO)),
+						"none" => Some(ReasoningEffort::None),
+						"low" | "minimal" => Some(ReasoningEffort::Low),
+						"medium" => Some(ReasoningEffort::Medium),
+						"high" => Some(ReasoningEffort::High),
+						"xhigh" => Some(ReasoningEffort::XHigh),
+						"max" => Some(ReasoningEffort::Max),
+						_ => None,
+					};
+					let model = if reasoning.is_some() { prefix } else { model };
+					(model, reasoning)
+				} else {
+					(model, None)
+				}
+			}
+			// TOOD: make it more elegant
+			(model, Some(effort)) => (model, Some(effort.clone())),
+		};
+
+		// -- parts
+		let GeminiChatRequestParts {
+			system,
+			contents,
+			tools,
+		} = Self::into_gemini_request_parts(model, chat_req)?;
+
+		let mut payload = json!({ "contents": contents });
+
+		// -- Set the reasoning effort
+		if let Some(computed_reasoning_effort) = computed_reasoning_effort {
+			// -- For gemini-3 use the thinkingLevel if Low or High (does not support medium for now)
+			if provider_model_name.contains("gemini-3") {
+				match computed_reasoning_effort {
+					ReasoningEffort::Low | ReasoningEffort::Minimal => {
+						payload.x_insert("/generationConfig/thinkingConfig/thinkingLevel", "LOW")?;
+					}
+					ReasoningEffort::High | ReasoningEffort::Max => {
+						payload.x_insert("/generationConfig/thinkingConfig/thinkingLevel", "HIGH")?;
+					}
+					// Fallback on thinkingBudget
+					other => {
+						insert_gemini_thinking_budget_value(&mut payload, &other)?;
+					}
+				}
+			}
+			// -- Otherwise, Do thinking budget
+			else {
+				insert_gemini_thinking_budget_value(&mut payload, &computed_reasoning_effort)?;
+			}
+			// -- Always include thoughts when reasoning effort is set since you are already paying for them
+			payload.x_insert("/generationConfig/thinkingConfig/includeThoughts", true)?;
+		}
+
+		// Note: It's unclear from the spec if the content of systemInstruction should have a role.
+		//       Right now, it is omitted (since the spec states it can only be "user" or "model")
+		//       It seems to work. https://ai.google.dev/api/rest/v1beta/models/generateContent
+		if let Some(system) = system {
+			payload.x_insert(
+				"systemInstruction",
+				json!({ "parts": [{ "text": system }] }),
+			)?;
+		}
+
+		if let Some(tools) = tools {
+			payload.x_insert("tools", tools)?;
+		}
+
+		if let Some(ChatResponseFormat::JsonSpec(st_json)) = options_set.response_format() {
+			payload.x_insert("/generationConfig/responseMimeType", "application/json")?;
+			let mut schema = st_json.schema.clone();
+			super::openapi_schema::to_openapi_schema(&mut schema);
+			payload.x_insert("/generationConfig/responseJsonSchema", schema)?;
+		}
+
+		if let Some(temperature) = options_set.temperature() {
+			payload.x_insert("/generationConfig/temperature", temperature)?;
+		}
+		if !options_set.stop_sequences().is_empty() {
+			payload.x_insert("/generationConfig/stopSequences", options_set.stop_sequences())?;
+		}
+		if let Some(max_tokens) = options_set.max_tokens() {
+			payload.x_insert("/generationConfig/maxOutputTokens", max_tokens)?;
+		}
+		if let Some(top_p) = options_set.top_p() {
+			payload.x_insert("/generationConfig/topP", top_p)?;
+		}
+
+		Ok((payload, provider_model_name.to_string()))
+	}
+
 	/// See gemini doc: https://ai.google.dev/api/generate-content#UsageMetadata
-	pub(super) fn into_usage(mut usage_value: Value) -> Usage {
+	pub(in crate::adapter) fn into_usage(mut usage_value: Value) -> Usage {
 		let total_tokens: Option<i32> = usage_value.x_take("totalTokenCount").ok();
 
 		// -- Compute prompt tokens
@@ -537,7 +536,7 @@ impl GeminiAdapter {
 	/// - `ChatRole::System` is concatenated (with an empty line) into a single `system` for the system instruction.
 	///   - This adapter uses version v1beta, which supports `systemInstruction`
 	/// - The eventual `chat_req.system` is pushed first into the "systemInstruction"
-	fn into_gemini_request_parts(
+	pub(in crate::adapter) fn into_gemini_request_parts(
 		model_iden: &ModelIden, // use for error reporting
 		chat_req: ChatRequest,
 	) -> Result<GeminiChatRequestParts> {
@@ -853,13 +852,13 @@ pub enum GeminiTool {
 }
 
 /// FIXME: need to be Vec<GeminiChatContent>
-pub(super) struct GeminiChatResponse {
+pub(in crate::adapter) struct GeminiChatResponse {
 	pub content: Vec<GeminiChatContent>,
 	pub usage: Usage,
 	pub stop_reason: Option<String>,
 }
 
-pub(super) enum GeminiChatContent {
+pub(in crate::adapter) enum GeminiChatContent {
 	Text(String),
 	Binary(Binary),
 	ToolCall(ToolCall),
@@ -867,13 +866,13 @@ pub(super) enum GeminiChatContent {
 	ThoughtSignature(String),
 }
 
-struct GeminiChatRequestParts {
-	system: Option<String>,
+pub(in crate::adapter) struct GeminiChatRequestParts {
+	pub system: Option<String>,
 	/// The chat history (user and assistant, except for the last user message which is a message)
-	contents: Vec<Value>,
+	pub contents: Vec<Value>,
 
 	/// The tools to use
-	tools: Option<Vec<Value>>,
+	pub tools: Option<Vec<Value>>,
 }
 
 // region:    --- Helpers

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -119,12 +119,14 @@ impl Adapter for GeminiAdapter {
 		let ServiceTarget { endpoint, auth, model } = target;
 		let (_, model_name) = model.model_name.namespace_and_name();
 
+		// -- api_key
 		let api_key = get_api_key(auth, &model)?;
 		let headers = Headers::from(("x-goog-api-key".to_string(), api_key.to_string()));
 
 		let (payload, provider_model_name) =
 			Self::build_gemini_request_payload(&model, model_name, chat_req, options_set)?;
 
+		// -- url
 		let provider_model = model.from_name(&provider_model_name);
 		let url = Self::get_service_url(&provider_model, service_type, endpoint)?;
 
@@ -378,8 +380,9 @@ impl GeminiAdapter {
 						"max" => Some(ReasoningEffort::Max),
 						_ => None,
 					};
-					let model = if reasoning.is_some() { prefix } else { model };
-					(model, reasoning)
+				// strip the reasoning suffix from the model name if one was matched
+				let model = if reasoning.is_some() { prefix } else { model };
+				(model, reasoning)
 				} else {
 					(model, None)
 				}
@@ -432,10 +435,12 @@ impl GeminiAdapter {
 			)?;
 		}
 
+		// -- Tools
 		if let Some(tools) = tools {
 			payload.x_insert("tools", tools)?;
 		}
 
+		// -- Response Format
 		if let Some(ChatResponseFormat::JsonSpec(st_json)) = options_set.response_format() {
 			payload.x_insert("/generationConfig/responseMimeType", "application/json")?;
 			let mut schema = st_json.schema.clone();
@@ -443,6 +448,7 @@ impl GeminiAdapter {
 			payload.x_insert("/generationConfig/responseJsonSchema", schema)?;
 		}
 
+		// -- Add supported ChatOptions
 		if let Some(temperature) = options_set.temperature() {
 			payload.x_insert("/generationConfig/temperature", temperature)?;
 		}

--- a/src/adapter/adapters/mod.rs
+++ b/src/adapter/adapters/mod.rs
@@ -14,5 +14,6 @@ pub(super) mod ollama;
 pub(super) mod openai;
 pub(super) mod openai_resp;
 pub(super) mod together;
+pub(super) mod vertex;
 pub(super) mod xai;
 pub(super) mod zai;

--- a/src/adapter/adapters/vertex/adapter_impl.rs
+++ b/src/adapter/adapters/vertex/adapter_impl.rs
@@ -1,0 +1,273 @@
+use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::anthropic::{AnthropicAdapter, AnthropicRequestParts};
+use crate::adapter::gemini::GeminiAdapter;
+use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
+use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::resolver::{AuthData, Endpoint};
+use crate::webc::WebResponse;
+use crate::{Error, Headers, ModelIden, Result, ServiceTarget};
+use reqwest::RequestBuilder;
+use serde_json::json;
+use tracing::warn;
+use value_ext::JsonValueExt;
+
+pub struct VertexAdapter;
+
+const VERTEX_ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
+
+impl VertexAdapter {
+	pub const API_KEY_DEFAULT_ENV_NAME: &str = "VERTEX_API_KEY";
+}
+
+// region:    --- VertexPublisher
+
+/// Internal enum to dispatch wire format based on the model's publisher.
+enum VertexPublisher {
+	Google,
+	Anthropic,
+}
+
+impl VertexPublisher {
+	fn from_model_name(model_name: &str) -> Result<Self> {
+		if model_name.starts_with("gemini") {
+			Ok(Self::Google)
+		} else if model_name.starts_with("claude") {
+			Ok(Self::Anthropic)
+		} else {
+			Err(Error::AdapterNotSupported {
+				adapter_kind: AdapterKind::Vertex,
+				feature: format!("model '{model_name}' (unknown Vertex AI publisher)"),
+			})
+		}
+	}
+
+	fn publisher_path(&self) -> &'static str {
+		match self {
+			Self::Google => "publishers/google",
+			Self::Anthropic => "publishers/anthropic",
+		}
+	}
+}
+
+// endregion: --- VertexPublisher
+
+impl Adapter for VertexAdapter {
+	const DEFAULT_API_KEY_ENV_NAME: Option<&'static str> = Some(Self::API_KEY_DEFAULT_ENV_NAME);
+
+	fn default_endpoint() -> Endpoint {
+		let project_id = std::env::var("VERTEX_PROJECT_ID").unwrap_or_else(|_| {
+			warn!("VERTEX_PROJECT_ID env var is not set; Vertex AI requests will use a malformed URL");
+			String::new()
+		});
+		let base_url = match std::env::var("VERTEX_LOCATION") {
+			Ok(location) => format!(
+				"https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/"
+			),
+			Err(_) => format!("https://aiplatform.googleapis.com/v1/projects/{project_id}/locations/global/"),
+		};
+		Endpoint::from_owned(base_url)
+	}
+	fn default_auth() -> AuthData {
+		match Self::DEFAULT_API_KEY_ENV_NAME {
+			Some(env_name) => AuthData::from_env(env_name),
+			None => AuthData::None,
+		}
+	}
+
+	async fn all_model_names(_kind: AdapterKind, _endpoint: Endpoint, _auth: AuthData) -> Result<Vec<String>> {
+		Ok(vec![
+			"gemini-2.5-pro".to_string(),
+			"gemini-2.5-flash".to_string(),
+			"gemini-2.5-flash-lite".to_string(),
+			"claude-sonnet-4-6".to_string(),
+			"claude-opus-4-6".to_string(),
+			"claude-haiku-4-5".to_string(),
+		])
+	}
+
+	/// Note: An unrecognized model prefix falls back to `VertexPublisher::Google` with a warning.
+	/// In practice, `to_web_request_data` validates the publisher first and will return
+	/// an error before this fallback is ever reached.
+	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {
+		let base_url = endpoint.base_url();
+		let (_, model_name) = model.model_name.namespace_and_name();
+		let publisher = VertexPublisher::from_model_name(model_name).unwrap_or_else(|_| {
+			warn!("Unknown Vertex AI publisher for model '{model_name}'; falling back to Google publisher");
+			VertexPublisher::Google
+		});
+		let publisher_path = publisher.publisher_path();
+
+		let url = match publisher {
+			VertexPublisher::Google => match service_type {
+				ServiceType::Chat => format!("{base_url}{publisher_path}/models/{model_name}:generateContent"),
+				ServiceType::ChatStream => {
+					format!("{base_url}{publisher_path}/models/{model_name}:streamGenerateContent")
+				}
+				ServiceType::Embed => format!("{base_url}{publisher_path}/models/{model_name}:predict"),
+			},
+			VertexPublisher::Anthropic => match service_type {
+				ServiceType::Chat | ServiceType::ChatStream => {
+					format!("{base_url}{publisher_path}/models/{model_name}:rawPredict")
+				}
+				ServiceType::Embed => format!("{base_url}{publisher_path}/models/{model_name}:predict"),
+			},
+		};
+
+		Ok(url)
+	}
+
+	fn to_web_request_data(
+		target: ServiceTarget,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		let ServiceTarget { endpoint, auth, model } = target;
+		let (_, model_name) = model.model_name.namespace_and_name();
+		let publisher = VertexPublisher::from_model_name(model_name)?;
+		let model_name = model_name.to_string();
+
+		let api_key = get_api_key(auth, &model)?;
+		let headers = Headers::from(("Authorization".to_string(), format!("Bearer {api_key}")));
+
+		match publisher {
+			VertexPublisher::Google => {
+				Self::to_gemini_web_request_data(model, &model_name, endpoint, headers, service_type, chat_req, options_set)
+			}
+			VertexPublisher::Anthropic => {
+				Self::to_anthropic_web_request_data(model, &model_name, endpoint, headers, service_type, chat_req, options_set)
+			}
+		}
+	}
+
+	fn to_chat_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatResponse> {
+		let (_, model_name) = model_iden.model_name.namespace_and_name();
+		let publisher = VertexPublisher::from_model_name(model_name)?;
+
+		match publisher {
+			VertexPublisher::Google => GeminiAdapter::to_chat_response(model_iden, web_response, options_set),
+			VertexPublisher::Anthropic => AnthropicAdapter::to_chat_response(model_iden, web_response, options_set),
+		}
+	}
+
+	fn to_chat_stream(
+		model_iden: ModelIden,
+		reqwest_builder: RequestBuilder,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatStreamResponse> {
+		let (_, model_name) = model_iden.model_name.namespace_and_name();
+		let publisher = VertexPublisher::from_model_name(model_name)?;
+
+		match publisher {
+			VertexPublisher::Google => GeminiAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+			VertexPublisher::Anthropic => AnthropicAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+		}
+	}
+
+	fn to_embed_request_data(
+		_service_target: ServiceTarget,
+		_embed_req: crate::embed::EmbedRequest,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		Err(Error::AdapterNotSupported {
+			adapter_kind: AdapterKind::Vertex,
+			feature: "embeddings".to_string(),
+		})
+	}
+
+	fn to_embed_response(
+		_model_iden: ModelIden,
+		_web_response: WebResponse,
+		_options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		Err(Error::AdapterNotSupported {
+			adapter_kind: AdapterKind::Vertex,
+			feature: "embeddings".to_string(),
+		})
+	}
+}
+
+// region:    --- Gemini Publisher Support
+
+impl VertexAdapter {
+	fn to_gemini_web_request_data(
+		model: ModelIden,
+		model_name: &str,
+		endpoint: Endpoint,
+		headers: Headers,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		let (payload, provider_model_name) =
+			GeminiAdapter::build_gemini_request_payload(&model, model_name, chat_req, options_set)?;
+
+		let provider_model = model.from_name(&provider_model_name);
+		let url = Self::get_service_url(&provider_model, service_type, endpoint)?;
+
+		Ok(WebRequestData { url, headers, payload })
+	}
+}
+
+// endregion: --- Gemini Publisher Support
+
+// region:    --- Anthropic Publisher Support
+
+impl VertexAdapter {
+	fn to_anthropic_web_request_data(
+		model: ModelIden,
+		model_name: &str,
+		endpoint: Endpoint,
+		headers: Headers,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		let AnthropicRequestParts {
+			system,
+			messages,
+			tools,
+		} = AnthropicAdapter::into_anthropic_request_parts(chat_req)?;
+
+		// Vertex Anthropic: model is in URL, not body; anthropic_version goes in body
+		let stream = matches!(service_type, ServiceType::ChatStream);
+		let mut payload = json!({
+			"anthropic_version": VERTEX_ANTHROPIC_VERSION,
+			"messages": messages,
+			"stream": stream,
+		});
+
+		if let Some(system) = system {
+			payload.x_insert("system", system)?;
+		}
+
+		if let Some(tools) = tools {
+			payload.x_insert("/tools", tools)?;
+		}
+
+		if let Some(temperature) = options_set.temperature() {
+			payload.x_insert("temperature", temperature)?;
+		}
+
+		if !options_set.stop_sequences().is_empty() {
+			payload.x_insert("stop_sequences", options_set.stop_sequences())?;
+		}
+
+		let max_tokens = AnthropicAdapter::resolve_max_tokens(model_name, &options_set);
+		payload.x_insert("max_tokens", max_tokens)?;
+
+		if let Some(top_p) = options_set.top_p() {
+			payload.x_insert("top_p", top_p)?;
+		}
+
+		let url = Self::get_service_url(&model, service_type, endpoint)?;
+
+		Ok(WebRequestData { url, headers, payload })
+	}
+}
+
+// endregion: --- Anthropic Publisher Support

--- a/src/adapter/adapters/vertex/adapter_impl.rs
+++ b/src/adapter/adapters/vertex/adapter_impl.rs
@@ -59,10 +59,12 @@ impl Adapter for VertexAdapter {
 			warn!("VERTEX_PROJECT_ID env var is not set; Vertex AI requests will use a malformed URL");
 			String::new()
 		});
+		// Model availability varies by region. See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations for details.
 		let base_url = match std::env::var("VERTEX_LOCATION") {
 			Ok(location) => format!(
 				"https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/"
 			),
+			// When no location is set, fall back to "global"
 			Err(_) => format!("https://aiplatform.googleapis.com/v1/projects/{project_id}/locations/global/"),
 		};
 		Endpoint::from_owned(base_url)
@@ -127,6 +129,7 @@ impl Adapter for VertexAdapter {
 		let publisher = VertexPublisher::from_model_name(model_name)?;
 		let model_name = model_name.to_string();
 
+		// For Vertex AI the "api key" is an OAuth2 Bearer token supplied by the AuthResolver
 		let api_key = get_api_key(auth, &model)?;
 		let headers = Headers::from(("Authorization".to_string(), format!("Bearer {api_key}")));
 
@@ -258,7 +261,7 @@ impl VertexAdapter {
 		}
 
 		let max_tokens = AnthropicAdapter::resolve_max_tokens(model_name, &options_set);
-		payload.x_insert("max_tokens", max_tokens)?;
+		payload.x_insert("max_tokens", max_tokens)?; // required for Anthropic
 
 		if let Some(top_p) = options_set.top_p() {
 			payload.x_insert("top_p", top_p)?;

--- a/src/adapter/adapters/vertex/mod.rs
+++ b/src/adapter/adapters/vertex/mod.rs
@@ -1,0 +1,16 @@
+//! Google Vertex AI (Model Garden) adapter.
+//! Supports multiple publishers: Google (Gemini) and Anthropic (Claude).
+//!
+//! API Documentation:
+//!   - Gemini on Vertex: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference
+//!   - Claude on Vertex: https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
+//!
+//! Usage: namespace model names with `vertex::`, e.g. `vertex::gemini-2.5-flash` or `vertex::claude-sonnet-4-6`
+
+// region:    --- Modules
+
+mod adapter_impl;
+
+pub use adapter_impl::*;
+
+// endregion: --- Modules

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -13,6 +13,7 @@ use crate::adapter::nebius::NebiusAdapter;
 use crate::adapter::ollama::OllamaAdapter;
 use crate::adapter::openai::OpenAIAdapter;
 use crate::adapter::openai_resp::OpenAIRespAdapter;
+use crate::adapter::vertex::VertexAdapter;
 use crate::adapter::xai::XaiAdapter;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
@@ -49,6 +50,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::default_endpoint(),
 			AdapterKind::Cohere => CohereAdapter::default_endpoint(),
 			AdapterKind::Ollama => OllamaAdapter::default_endpoint(),
+			AdapterKind::Vertex => VertexAdapter::default_endpoint(),
 		}
 	}
 
@@ -70,6 +72,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::default_auth(),
 			AdapterKind::Cohere => CohereAdapter::default_auth(),
 			AdapterKind::Ollama => OllamaAdapter::default_auth(),
+			AdapterKind::Vertex => VertexAdapter::default_auth(),
 		}
 	}
 
@@ -91,6 +94,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Cohere => CohereAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Ollama => OllamaAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Vertex => VertexAdapter::all_model_names(kind, endpoint, auth).await,
 		}
 	}
 
@@ -112,6 +116,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Cohere => CohereAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Ollama => OllamaAdapter::get_service_url(model, service_type, endpoint),
+			AdapterKind::Vertex => VertexAdapter::get_service_url(model, service_type, endpoint),
 		}
 	}
 
@@ -145,6 +150,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_web_request_data(target, service_type, chat_req, options_set),
+			AdapterKind::Vertex => VertexAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 		}
 	}
 
@@ -170,6 +176,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_chat_response(model_iden, web_response, options_set),
+			AdapterKind::Vertex => VertexAdapter::to_chat_response(model_iden, web_response, options_set),
 		}
 	}
 
@@ -195,6 +202,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+			AdapterKind::Vertex => VertexAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 		}
 	}
 
@@ -224,6 +232,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Vertex => VertexAdapter::to_embed_request_data(target, embed_req, options_set),
 		}
 	}
 
@@ -252,6 +261,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Vertex => VertexAdapter::to_embed_response(model_iden, web_response, options_set),
 		}
 	}
 }

--- a/tests/tests_p_vertex.rs
+++ b/tests/tests_p_vertex.rs
@@ -1,0 +1,172 @@
+mod support;
+
+use crate::support::{Check, TestResult, common_tests};
+use genai::adapter::AdapterKind;
+use genai::resolver::AuthData;
+use serial_test::serial;
+
+// Vertex AI requires namespace-prefixed model names.
+// Env vars needed: VERTEX_PROJECT_ID, VERTEX_LOCATION, VERTEX_API_KEY (Bearer token)
+
+// -- Gemini on Vertex (publishers/google)
+const MODEL_GEMINI: &str = "vertex::gemini-2.5-flash";
+
+// -- Claude on Vertex / Model Garden (publishers/anthropic)
+const MODEL_CLAUDE: &str = "vertex::claude-sonnet-4-6";
+
+// region:    --- Chat (Gemini)
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_gemini_simple_ok() -> TestResult<()> {
+	common_tests::common_test_chat_simple_ok(MODEL_GEMINI, None).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_gemini_multi_system_ok() -> TestResult<()> {
+	common_tests::common_test_chat_multi_system_ok(MODEL_GEMINI).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_gemini_json_structured_ok() -> TestResult<()> {
+	common_tests::common_test_chat_json_structured_ok(MODEL_GEMINI, Some(Check::USAGE)).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_gemini_temperature_ok() -> TestResult<()> {
+	common_tests::common_test_chat_temperature_ok(MODEL_GEMINI).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_gemini_stop_sequences_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stop_sequences_ok(MODEL_GEMINI).await
+}
+
+// endregion: --- Chat (Gemini)
+
+// region:    --- Chat (Claude)
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_claude_simple_ok() -> TestResult<()> {
+	common_tests::common_test_chat_simple_ok(MODEL_CLAUDE, None).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_claude_multi_system_ok() -> TestResult<()> {
+	common_tests::common_test_chat_multi_system_ok(MODEL_CLAUDE).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_claude_temperature_ok() -> TestResult<()> {
+	common_tests::common_test_chat_temperature_ok(MODEL_CLAUDE).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_claude_stop_sequences_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stop_sequences_ok(MODEL_CLAUDE).await
+}
+
+// endregion: --- Chat (Claude)
+
+// region:    --- Chat Stream (Gemini)
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_stream_gemini_simple_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_simple_ok(MODEL_GEMINI, None).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_stream_gemini_capture_content_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_capture_content_ok(MODEL_GEMINI).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_stream_gemini_capture_all_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_capture_all_ok(MODEL_GEMINI, None).await
+}
+
+// endregion: --- Chat Stream (Gemini)
+
+// region:    --- Chat Stream (Claude)
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_stream_claude_simple_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_simple_ok(MODEL_CLAUDE, None).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_stream_claude_capture_content_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_capture_content_ok(MODEL_CLAUDE).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_chat_stream_claude_capture_all_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_capture_all_ok(MODEL_CLAUDE, None).await
+}
+
+// endregion: --- Chat Stream (Claude)
+
+// region:    --- Tool Tests (Gemini)
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_tool_gemini_simple_ok() -> TestResult<()> {
+	common_tests::common_test_tool_simple_ok(MODEL_GEMINI).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_tool_gemini_full_flow_ok() -> TestResult<()> {
+	common_tests::common_test_tool_full_flow_ok(MODEL_GEMINI).await
+}
+
+// endregion: --- Tool Tests (Gemini)
+
+// region:    --- Tool Tests (Claude)
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_tool_claude_simple_ok() -> TestResult<()> {
+	common_tests::common_test_tool_simple_ok(MODEL_CLAUDE).await
+}
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_tool_claude_full_flow_ok() -> TestResult<()> {
+	common_tests::common_test_tool_full_flow_ok(MODEL_CLAUDE).await
+}
+
+// endregion: --- Tool Tests (Claude)
+
+// region:    --- Resolver Tests
+
+#[tokio::test]
+#[serial(vertex)]
+async fn test_resolver_auth_ok() -> TestResult<()> {
+	common_tests::common_test_resolver_auth_ok(MODEL_GEMINI, AuthData::from_env("VERTEX_API_KEY")).await
+}
+
+// endregion: --- Resolver Tests
+
+// region:    --- List
+
+#[tokio::test]
+async fn test_list_models() -> TestResult<()> {
+	common_tests::common_test_list_models(AdapterKind::Vertex, "gemini-2.5-flash").await
+}
+
+// endregion: --- List


### PR DESCRIPTION
Added support for Google Vertex using either Gemini or Anthropic models.

Some implementation details:
- Exposed some functionality and constants from Gemini and Anthropic adapters so they could be used in Vertex
- Added env vars
    - VERTEX_API_KEY -- API token for authentication when not using an auth resolver
    - VERTEX_LOCATION -- Vertex AI location; uses "global" when not set
- Tests pass (assuming configured VERTEX_LOCATION supports both Gemini and Claude, and when no VERTEX_LOCATION is specified)
