### PR TITLE
fix(anthropic): guard against null tool_call arguments in request serialization

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -11,7 +11,7 @@ use crate::webc::{EventSourceStream, WebResponse};
 use crate::{Headers, ModelIden};
 use crate::{Result, ServiceTarget};
 use reqwest::RequestBuilder;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use tracing::info;
 use tracing::warn;
 use value_ext::JsonValueExt;
@@ -638,12 +638,20 @@ impl AnthropicAdapter {
 							}
 							ContentPart::ToolCall(tool_call) => {
 								has_tool_use = true;
+								// Anthropic API requires `input` to be an object, never null.
+								// Streaming parsers may produce null arguments when deltas are
+								// missing or empty; fall back to an empty object in that case.
+								let input = if tool_call.fn_arguments.is_null() {
+									Value::Object(Map::new())
+								} else {
+									tool_call.fn_arguments
+								};
 								// see: https://docs.anthropic.com/en/docs/build-with-claude/tool-use#example-of-successful-tool-result
 								values.push(json!({
 									"type": "tool_use",
 									"id": tool_call.call_id,
 									"name": tool_call.fn_name,
-									"input": tool_call.fn_arguments,
+									"input": input,
 								}));
 							}
 							// Unsupported for assistant role in Anthropic message content


### PR DESCRIPTION
## Summary

- Fix Anthropic adapter to fall back to `{}` when `tool_call.fn_arguments` is `Value::Null` during assistant message serialization
- Prevents 500 errors from Anthropic-compatible providers (e.g., BigModel/GLM) that strictly validate the `input` field

## Problem

When using streaming mode, tool call arguments can end up as `Value::Null` if streaming deltas are missing or empty. The Anthropic API specification requires the `input` field in `tool_use` content blocks to be an object, never null.

This manifests as a 500 error on the second inference turn (when the assistant message with `tool_use` is sent back):

```json
{"error":{"code":"500","message":"'ClaudeContentBlockToolResult' object has no attribute 'id'"}}
```

The actual request body shows `"input": null` instead of `"input": {}`:

```json
{
  "type": "tool_use",
  "id": "call_xxx",
  "name": "calculator",
  "input": null
}
```

## Root cause

In `adapter_impl.rs` line 646, `tool_call.fn_arguments` is serialized directly without null-checking:

```rust
values.push(json!({
    "type": "tool_use",
    "id": tool_call.call_id,
    "name": tool_call.fn_name,
    "input": tool_call.fn_arguments,  // may be Value::Null
}));
```

## Fix

Added a null guard that falls back to an empty object:

```rust
let input = if tool_call.fn_arguments.is_null() {
    Value::Object(Map::new())
} else {
    tool_call.fn_arguments
};
```

## Test plan

- [x] Verified with BigModel GLM-4.7 via Anthropic-compatible endpoint — multi-turn tool calling now completes successfully (12 steps) instead of failing on the 2nd turn
- [x] `cargo check` passes

