### PR TITLE
+ tests - add yakbak Gemini streaming replay test

### DIFF
--- a/.github/workflows/yakbak-replay-tests.yml
+++ b/.github/workflows/yakbak-replay-tests.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run OpenAI replay tests
         run: cargo test --test tests_yakbak_openai_resp
+
+      - name: Run Gemini replay tests
+        run: cargo test --test tests_yakbak_gemini

--- a/tests/data/yakbak/gemini/thinking_stream/response_000.txt
+++ b/tests/data/yakbak/gemini/thinking_stream/response_000.txt
@@ -1,0 +1,121 @@
+[{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**Defining Sky Color**\n\nI'm now focusing on a concise explanation for why the sky appears blue. I've pinpointed the key aspects: sunlight's interaction with Earth's atmosphere, and the critical role of Rayleigh scattering in dispersing light. It is essential to ensure a clear and accurate one-sentence response. I will now work on integrating the key elements, so that it is easily understood.\n\n\n",
+            "thought": true
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "totalTokenCount": 81,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 69
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**Refining Concise Explanation**\n\nI've crafted a single-sentence response: \"The sky appears blue because sunlight scatters off atmospheric molecules, with blue light scattered more intensely due to its shorter wavelength.\" I've confirmed that this encapsulates the core reason for the sky's blue hue, emphasizing both the scattering mechanism and the wavelength dependence. It's accurate, concise, and direct, ensuring it will communicate the answer effectively.\n\n\n",
+            "thought": true
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "totalTokenCount": 215,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 203
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The sky is blue because molecules in Earth's atmosphere scatter shorter"
+          }
+        ],
+        "role": "model"
+      },
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "candidatesTokenCount": 11,
+    "totalTokenCount": 226,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 203
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+,
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "-wavelength blue light from the sun more efficiently than longer-wavelength red light."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 12,
+    "candidatesTokenCount": 27,
+    "totalTokenCount": 242,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 12
+      }
+    ],
+    "thoughtsTokenCount": 203
+  },
+  "modelVersion": "gemini-2.5-flash",
+  "responseId": "vgvDaez4G6T9nsEPpvzX6AM"
+}
+]

--- a/tests/tests_yakbak_gemini.rs
+++ b/tests/tests_yakbak_gemini.rs
@@ -1,0 +1,48 @@
+//! Replay integration tests for the Gemini adapter.
+//!
+//! These tests use pre-recorded cassettes from `tests/data/yakbak/gemini/`
+//! and assert that thinking content, tool calls, and usage flow through correctly.
+
+mod support;
+
+use genai::chat::*;
+use support::yakbak::replay_client;
+use support::{TestResult, extract_stream_end};
+
+#[tokio::test]
+async fn test_yakbak_gemini_thinking_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("gemini", "thinking_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_usage(true);
+
+	let stream_res = client.exec_chat_stream("gemini-2.5-flash", chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// Exact text
+	assert_eq!(
+		extract.content.as_deref(),
+		Some(
+			"The sky is blue because molecules in Earth's atmosphere scatter shorter-wavelength blue light from the sun more efficiently than longer-wavelength red light."
+		),
+	);
+
+	// Reasoning should be substantial (862 chars from recorded)
+	let reasoning = extract.reasoning_content.as_deref().ok_or("Should have reasoning")?;
+	assert_eq!(reasoning.len(), 862, "reasoning length should be exactly 862 chars");
+	assert!(reasoning.starts_with("**Defining Sky Color**"));
+
+	// Exact usage
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(12));
+	assert_eq!(usage.completion_tokens, Some(230));
+
+	Ok(())
+}

--- a/tests/tests_yakbak_record.rs
+++ b/tests/tests_yakbak_record.rs
@@ -1,10 +1,24 @@
 //! Recording scripts for yakbak cassettes.
 //!
-//! These are `#[ignore]` tests — run manually with real API keys:
+//! These are `#[ignore]` tests — run manually with real API keys.
+//! Each provider's keys and base URLs are independent; you only need
+//! the credentials for the provider(s) you want to record.
 //!
 //! ```sh
-//! OPENAI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored
+//! # Record all providers (need all keys):
+//! OPENAI_API_KEY=... GEMINI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored
+//!
+//! # Record only Gemini scenarios:
+//! GEMINI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored record_gemini
+//!
+//! # Record only OpenAI scenarios:
+//! OPENAI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored record_openai
+//!
+//! # Record a single scenario by name:
+//! GEMINI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored record_gemini_thinking_stream
 //! ```
+//!
+//! Optional env vars for custom endpoints: `OPENAI_BASE_URL`, `GEMINI_BASE_URL`.
 //!
 //! Each test records a response cassette to `tests/data/yakbak/{provider}/{scenario}/`.
 
@@ -66,6 +80,41 @@ async fn record_openai_resp_reasoning_stream_tools() -> TestResult<()> {
 	eprintln!("[record] Stream reasoning: {:?}", extract.reasoning_content.is_some());
 	let tool_calls = &extract.stream_end.captured_tool_calls();
 	eprintln!("[record] Tool calls: {:?}", tool_calls.as_ref().map(|tc| tc.len()));
+
+	server.shutdown().await;
+	Ok(())
+}
+
+fn gemini_backend() -> String {
+	std::env::var("GEMINI_BASE_URL").unwrap_or_else(|_| "https://generativelanguage.googleapis.com/v1beta/".to_string())
+}
+
+const GEMINI_MODEL: &str = "gemini-2.5-flash";
+
+#[tokio::test]
+#[ignore]
+async fn record_gemini_thinking_stream() -> TestResult<()> {
+	let (client, mut server) = record_client("gemini", "thinking_stream", &gemini_backend()).await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true);
+
+	let stream_res = client.exec_chat_stream(GEMINI_MODEL, chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+	eprintln!(
+		"[record] Stream content: {:?}",
+		extract.content.as_deref().map(|s| &s[..s.len().min(80)])
+	);
+	eprintln!(
+		"[record] Stream reasoning: {:?}",
+		extract.reasoning_content.as_deref().map(|s| &s[..s.len().min(80)])
+	);
 
 	server.shutdown().await;
 	Ok(())


### PR DESCRIPTION
First Gemini yakbak test — streaming only, per discussion to add adapter tests incrementally.

- tests_yakbak_gemini.rs: thinking_stream replay test (exact text, reasoning length, usage assertions against recorded cassette)
- tests_yakbak_record.rs: add record_gemini_thinking_stream() recorder
- yakbak-replay-tests.yml: add Gemini replay step to CI
- Cassette: tests/data/yakbak/gemini/thinking_stream/