### PR TITLE
! gemini - 'thinkingConfig/includeThoughts' is an opt-in for 'capture_reasoning_content'

### DIFF
--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -424,7 +424,12 @@ impl GeminiAdapter {
 			else {
 				insert_gemini_thinking_budget_value(&mut payload, &computed_reasoning_effort)?;
 			}
-			// -- Always include thoughts when reasoning effort is set since you are already paying for them
+		}
+
+		// -- Opt-in for includeThoughts: only request thought content when
+		// the caller explicitly asks for reasoning content capture.
+		// Thought *signatures* are always returned by the API regardless of this flag.
+		if options_set.capture_reasoning_content() == Some(true) {
 			payload.x_insert("/generationConfig/thinkingConfig/includeThoughts", true)?;
 		}
 


### PR DESCRIPTION
Previously, includeThoughts was set unconditionally whenever reasoning effort was configured. This meant every thinking-model request paid for thought extraction even when the caller didn't need it.

Now includeThoughts is only sent when the caller explicitly sets capture_reasoning_content(true) in ChatOptions — making it opt-in.

Thought *signatures* (thinkingConfig/thoughtSignatures) remain always-on since they are free metadata needed for multi-turn tool-call roundtrips.