### PR TITLE
! openai_resp - 'reasoning.summary' is opt-in for 'capture_reasoning_content'

### DIFF
--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -52,7 +52,7 @@ impl Adapter for OpenAIRespAdapter {
 	/// - `.store = false` - To maintain consistent behavior with other chat completions, store is set to false
 	/// - `.instructions` For now we do not use the top ".instructions" (genai::ChatRequest.system),
 	///   but just add this top system as a regular system message.
-	/// - `.summary` right now, supporting "generate reasoning summary" is not supported
+	/// - `.summary` reasoning summary is opt-in via `ChatOptions.capture_reasoning_content(true)` → `"detailed"`
 	///
 	fn to_web_request_data(
 		target: ServiceTarget,
@@ -142,10 +142,17 @@ impl Adapter for OpenAIRespAdapter {
 		if let Some(reasoning_effort) = reasoning_effort
 			&& let Some(keyword) = reasoning_effort.as_keyword()
 		{
-			// NOTE: For now, we do not set the "summary" property to generate the reasoning summary
+			let mut reasoning_obj = json!({"effort": keyword});
 
-			payload.x_insert("reasoning", json!({"effort": keyword}))?;
-			// TODO: needs to find a way to add summary: auto, concise, detailed
+			// Opt-in: only request detailed reasoning summaries when the caller
+			// explicitly asks for reasoning content capture.
+			if chat_options.capture_reasoning_content() == Some(true) {
+				reasoning_obj
+					.x_insert("summary", "detailed")
+					.map_err(|e| Error::Internal(format!("reasoning summary insert: {e}")))?;
+			}
+
+			payload.x_insert("reasoning", reasoning_obj)?;
 		}
 
 		// -- Tools


### PR DESCRIPTION
When capture_reasoning_content is set to true in ChatOptions, the openai_resp adapter now includes "summary": "detailed" in the reasoning payload. This tells the API to return reasoning text in the response stream.

Without this flag, the API only returns reasoning usage tokens but no actual reasoning content — making it opt-in as discussed.

Later, ReasoningCapture enum can be introduced to support the full range of summary values (auto, concise, detailed).