### PR TITLE
Add support for JSON schema in Anthropic adapter

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -33,7 +33,12 @@ fn has_model(model_prefixes: &[&str], model_name: &str) -> bool {
 	model_prefixes.iter().any(|prefix| model_name.contains(prefix))
 }
 
-fn insert_anthropic_reasoning(payload: &mut Value, model_name: &str, effort: &ReasoningEffort) -> Result<()> {
+fn insert_anthropic_reasoning(
+	payload: &mut Value,
+	output_config: &mut Map<String, Value>,
+	model_name: &str,
+	effort: &ReasoningEffort,
+) -> Result<()> {
 	let mut budget: Option<u32> = None;
 	let support_effort = has_model(SUPPORT_EFFORT_MODELS, model_name);
 	let support_reasoning_max = has_model(SUPPORT_REASONING_MAX_MODELS, model_name);
@@ -49,7 +54,7 @@ fn insert_anthropic_reasoning(payload: &mut Value, model_name: &str, effort: &Re
 			ReasoningEffort::Max | ReasoningEffort::XHigh if support_reasoning_max => "max",
 			ReasoningEffort::XHigh => "high",
 			ReasoningEffort::Max => "high",
-			// we apture for later
+			// we capture for later
 			ReasoningEffort::Budget(val) => {
 				budget = Some(*val); // not very elegant
 				""
@@ -57,14 +62,9 @@ fn insert_anthropic_reasoning(payload: &mut Value, model_name: &str, effort: &Re
 			ReasoningEffort::None => "",
 		};
 
-		// if we have an effort, we set it
+		// if we have an effort, write into the shared output_config map
 		if !effort.is_empty() {
-			payload.x_insert(
-				"output_config",
-				json!({
-					"effort": effort
-				}),
-			)?;
+			output_config.insert("effort".to_string(), json!(effort));
 		}
 	}
 
@@ -218,9 +218,7 @@ impl Adapter for AnthropicAdapter {
 
 		// -- headers
 		let headers = Headers::from(vec![
-			// headers
 			("x-api-key".to_string(), api_key),
-			("anthropic-beta".to_string(), "effort-2025-11-24,structured-outputs-2025-11-13".to_string()),
 			("anthropic-version".to_string(), ANTHROPIC_VERSION.to_string()),
 		]);
 
@@ -280,8 +278,12 @@ impl Adapter for AnthropicAdapter {
 		}
 
 		// -- Set the reasoning effort
+		// Both reasoning effort and structured-output format write into `output_config`.
+		// Build a shared map so both contributions end up in the same object.
+		let mut output_config: Map<String, Value> = Map::new();
+
 		if let Some(computed_reasoning_effort) = computed_reasoning_effort {
-			insert_anthropic_reasoning(&mut payload, model_name, &computed_reasoning_effort)?;
+			insert_anthropic_reasoning(&mut payload, &mut output_config, model_name, &computed_reasoning_effort)?;
 		}
 
 		if let Some(cache_control) = options_set.cache_control() {
@@ -293,20 +295,19 @@ impl Adapter for AnthropicAdapter {
 		// -- Add supported ChatOptions
 		if let Some(ChatResponseFormat::JsonSpec(st_json)) = options_set.response_format() {
 			// https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-outputs
+			// Note: Anthropic's json_schema format does not use a schema name; JsonSpec.name is intentionally omitted.
+			output_config.insert(
+				"format".to_string(),
+				json!({
+					"type": "json_schema",
+					"schema": st_json.schema_with_additional_properties_false(),
+				}),
+			);
+		}
 
-			// https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations
-			let mut schema = st_json.schema.clone();
-			schema.x_walk(|parent_map, name| {
-				if name == "type" && matches!(parent_map.get("type"), Some(Value::String(s)) if s == "object") {
-                    parent_map.insert("additionalProperties".into(), Value::Bool(false));
-				}
-				true
-			});
-
-			payload.x_insert("output_format", json!({
-				"type": "json_schema",
-				"schema": schema,
-			}))?;
+		// Insert output_config once, merging effort + format into a single object.
+		if !output_config.is_empty() {
+			payload.x_insert("output_config", Value::Object(output_config))?;
 		}
 
 		if let Some(temperature) = options_set.temperature() {
@@ -919,6 +920,60 @@ pub(in crate::adapter) struct AnthropicRequestParts {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::adapter::{Adapter, ServiceType};
+	use crate::chat::{ChatOptions, ChatRequest, JsonSpec};
+	use crate::resolver::AuthData;
+	use crate::ServiceTarget;
+
+	/// Regression guard: when both `reasoning_effort` and `JsonSpec` response format are set
+	/// on a model that uses the `output_config` effort API (e.g. `claude-sonnet-4-6`), both
+	/// `effort` and `format` must appear inside the same `output_config` JSON object.
+	#[test]
+	fn test_output_config_merges_effort_and_format() {
+		let chat_options = ChatOptions {
+			reasoning_effort: Some(ReasoningEffort::High),
+			response_format: Some(ChatResponseFormat::JsonSpec(JsonSpec::new(
+				"anthropic_ignores_name", // NOTE: Anthropic doesn't recognize a "name" field
+				json!({"type": "object", "properties": {}}),
+			))),
+			..Default::default()
+		};
+
+		let model_iden = ModelIden::new(AdapterKind::Anthropic, "claude-sonnet-4-6");
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(),
+			auth: AuthData::from_single("test-key"),
+			model: model_iden,
+		};
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+
+		let result = AnthropicAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			options_set,
+		);
+
+		let web_req = result.expect("to_web_request_data should succeed");
+		let output_config = web_req
+			.payload
+			.get("output_config")
+			.expect("output_config must be present");
+
+		assert_eq!(
+			output_config.get("effort").and_then(|v| v.as_str()),
+			Some("high"),
+			"effort must be present in output_config"
+		);
+		assert_eq!(
+			output_config
+				.get("format")
+				.and_then(|f| f.get("type"))
+				.and_then(|v| v.as_str()),
+			Some("json_schema"),
+			"format.type must be present in output_config"
+		);
+	}
 
 	#[test]
 	fn test_cache_control_to_json_ephemeral() {

--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -2,9 +2,9 @@ use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::anthropic::AnthropicStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
-	Binary, BinarySource, CacheControl, CacheCreationDetails, ChatOptionsSet, ChatRequest, ChatResponse, ChatRole,
-	ChatStream, ChatStreamResponse, ContentPart, MessageContent, PromptTokensDetails, ReasoningEffort, StopReason,
-	Tool, ToolCall, ToolConfig, ToolName, Usage,
+	Binary, BinarySource, CacheControl, CacheCreationDetails, ChatOptionsSet, ChatRequest, ChatResponse,
+	ChatResponseFormat, ChatRole, ChatStream, ChatStreamResponse, ContentPart, MessageContent, PromptTokensDetails,
+	ReasoningEffort, StopReason, Tool, ToolCall, ToolConfig, ToolName, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{EventSourceStream, WebResponse};
@@ -220,7 +220,7 @@ impl Adapter for AnthropicAdapter {
 		let headers = Headers::from(vec![
 			// headers
 			("x-api-key".to_string(), api_key),
-			("anthropic-beta".to_string(), "effort-2025-11-24".to_string()),
+			("anthropic-beta".to_string(), "effort-2025-11-24,structured-outputs-2025-11-13".to_string()),
 			("anthropic-version".to_string(), ANTHROPIC_VERSION.to_string()),
 		]);
 
@@ -291,6 +291,24 @@ impl Adapter for AnthropicAdapter {
 		}
 
 		// -- Add supported ChatOptions
+		if let Some(ChatResponseFormat::JsonSpec(st_json)) = options_set.response_format() {
+			// https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-outputs
+
+			// https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations
+			let mut schema = st_json.schema.clone();
+			schema.x_walk(|parent_map, name| {
+				if name == "type" && matches!(parent_map.get("type"), Some(Value::String(s)) if s == "object") {
+                    parent_map.insert("additionalProperties".into(), Value::Bool(false));
+				}
+				true
+			});
+
+			payload.x_insert("output_format", json!({
+				"type": "json_schema",
+				"schema": schema,
+			}))?;
+		}
+
 		if let Some(temperature) = options_set.temperature() {
 			payload.x_insert("temperature", temperature)?;
 		}

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -51,7 +51,7 @@ impl OpenAIAdapter {
 		};
 		let mut full_url = base_url.join(suffix).map_err(|err| {
 			Error::Internal(format!(
-				"Cannot joing suffix '{suffix}' for url: {base_url}. Cause:\n{err}"
+				"Cannot join suffix '{suffix}' for url: {base_url}. Cause:\n{err}"
 			))
 		})?;
 		full_url.set_query(original_query_params);
@@ -126,25 +126,13 @@ impl OpenAIAdapter {
 				ChatResponseFormat::JsonMode => Some(json!({"type": "json_object"})),
 				ChatResponseFormat::JsonSpec(st_json) => {
 					// "type": "json_schema", "json_schema": {...}
-
-					let mut schema = st_json.schema.clone();
-					schema.x_walk(|parent_map, name| {
-						if name == "type" {
-							let typ = parent_map.get("type").and_then(|v| v.as_str()).unwrap_or("");
-							if typ == "object" {
-								parent_map.insert("additionalProperties".to_string(), false.into());
-							}
-						}
-						true
-					});
-
 					Some(json!({
 						"type": "json_schema",
 						"json_schema": {
 							"name": st_json.name.clone(),
 							"strict": true,
 							// TODO: add description
-							"schema": schema,
+							"schema": st_json.schema_with_additional_properties_false(),
 						}
 					}))
 				}

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -171,25 +171,13 @@ impl Adapter for OpenAIRespAdapter {
 			match response_format {
 				ChatResponseFormat::JsonMode => Some(json!({"type": "json_object"})),
 				ChatResponseFormat::JsonSpec(st_json) => {
-					// "type": "json_schema", "json_schema": {...}
-					let mut schema = st_json.schema.clone();
-					schema.x_walk(|parent_map, name| {
-						if name == "type" {
-							let typ = parent_map.get("type").and_then(|v| v.as_str()).unwrap_or("");
-							if typ == "object" {
-								parent_map.insert("additionalProperties".to_string(), false.into());
-							}
-						}
-						true
-					});
-
 					// Flatten for OpenAI Responses
 					Some(json!({
 						"type": "json_schema",
 						"name": st_json.name.clone(),
 						"strict": true,
 						// TODO: add description
-						"schema": schema,
+						"schema": st_json.schema_with_additional_properties_false(),
 					}))
 				}
 			}

--- a/src/chat/chat_req_response_format.rs
+++ b/src/chat/chat_req_response_format.rs
@@ -1,6 +1,7 @@
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use value_ext::JsonValueExt;
 
 /// Preferred response format for `ChatRequest` (structured output).
 /// Only applied when the provider supports it.
@@ -50,5 +51,25 @@ impl JsonSpec {
 	pub fn with_description(mut self, description: impl Into<String>) -> Self {
 		self.description = Some(description.into());
 		self
+	}
+}
+
+/// Helpers
+impl JsonSpec {
+	/// Returns a clone of the schema with `"additionalProperties": false` injected into every
+	/// object node. Required by several providers (Anthropic, OpenAI) whose structured-output
+	/// APIs reject schemas that omit this constraint.
+	pub fn schema_with_additional_properties_false(&self) -> Value {
+		let mut schema = self.schema.clone();
+		schema.x_walk(|parent_map, name| {
+			if name == "type" {
+				let typ = parent_map.get("type").and_then(|v| v.as_str()).unwrap_or("");
+				if typ == "object" {
+					parent_map.insert("additionalProperties".to_string(), false.into());
+				}
+			}
+			true
+		});
+		schema
 	}
 }


### PR DESCRIPTION
This PR adds support for using a JSON schema as the response format in the Anthropic adapter (https://platform.claude.com/docs/en/build-with-claude/structured-outputs)

Changes:
- Moved logic for adding `additionalProperties: false` to all JSON objects into `JsonSpec` since it's now used in three places
- Refactored logic for building `output_config` in Anthropic request body to allow setting both `effort` and `format` fields
- Added unit test for building `output_config` in Anthropic request body
- Removed `anthropic-beta` header in Anthropic adapter, as `effort-2025-11-24` header is no longer needed (https://platform.claude.com/docs/en/about-claude/models/migration-guide)
- Fixed a couple of typos in comments