### PR TITLE
Anthropic: emit incremental ToolCallChunk events during streaming

### DIFF
--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -80,11 +80,25 @@ impl futures::Stream for AnthropicStreamer {
 								Ok("text") => self.in_progress_block = InProgressBlock::Text,
 								Ok("thinking") => self.in_progress_block = InProgressBlock::Thinking,
 								Ok("tool_use") => {
+									let id: String = data.x_take("/content_block/id")?;
+									let name: String = data.x_take("/content_block/name")?;
+
+									// Emit an initial ToolCallChunk with name and empty args,
+									// matching OpenAI's incremental streaming behaviour.
+									let tc = ToolCall {
+										call_id: id.clone(),
+										fn_name: name.clone(),
+										fn_arguments: Value::String(String::new()),
+										thought_signatures: None,
+									};
+
 									self.in_progress_block = InProgressBlock::ToolUse {
-										id: data.x_take("/content_block/id")?,
-										name: data.x_take("/content_block/name")?,
+										id,
+										name,
 										input: String::new(),
 									};
+
+									return Poll::Ready(Some(Ok(InterStreamEvent::ToolCallChunk(tc))));
 								}
 								Ok(txt) => {
 									tracing::warn!("unhandled content type: {txt}");
@@ -117,9 +131,20 @@ impl futures::Stream for AnthropicStreamer {
 
 									return Poll::Ready(Some(Ok(InterStreamEvent::Chunk(content))));
 								}
-								InProgressBlock::ToolUse { input, .. } => {
-									input.push_str(data.x_get_str("/delta/partial_json")?);
-									continue;
+								InProgressBlock::ToolUse { id, name, input } => {
+									let partial = data.x_get_str("/delta/partial_json")?;
+									input.push_str(partial);
+
+									// Emit incremental ToolCallChunk with accumulated args
+									// (as Value::String, same convention as OpenAI adapter).
+									let tc = ToolCall {
+										call_id: id.clone(),
+										fn_name: name.clone(),
+										fn_arguments: Value::String(input.clone()),
+										thought_signatures: None,
+									};
+
+									return Poll::Ready(Some(Ok(InterStreamEvent::ToolCallChunk(tc))));
 								}
 								InProgressBlock::Thinking => {
 									if let Ok(thinking) = data.x_take::<String>("/delta/thinking") {
@@ -149,28 +174,28 @@ impl futures::Stream for AnthropicStreamer {
 						"content_block_stop" => {
 							match std::mem::replace(&mut self.in_progress_block, InProgressBlock::Text) {
 								InProgressBlock::ToolUse { id, name, input } => {
-									let fn_arguments = if input.is_empty() {
-										Value::Object(Map::new())
-									} else {
-										serde_json::from_str(&input)?
-									};
-
-									let tc = ToolCall {
-										call_id: id,
-										fn_name: name,
-										fn_arguments,
-										thought_signatures: None,
-									};
-
-									// Add to the captured_tool_calls if chat options say so
+									// ToolCallChunks were already emitted incrementally
+									// during content_block_start and content_block_delta.
+									// Here we only finalize capture with parsed arguments.
 									if self.options.capture_tool_calls {
+										let fn_arguments = if input.is_empty() {
+											Value::Object(Map::new())
+										} else {
+											serde_json::from_str(&input)?
+										};
+
+										let tc = ToolCall {
+											call_id: id,
+											fn_name: name,
+											fn_arguments,
+											thought_signatures: None,
+										};
+
 										match self.captured_data.tool_calls {
-											Some(ref mut t) => t.push(tc.clone()),
-											None => self.captured_data.tool_calls = Some(vec![tc.clone()]),
+											Some(ref mut t) => t.push(tc),
+											None => self.captured_data.tool_calls = Some(vec![tc]),
 										}
 									}
-
-									return Poll::Ready(Some(Ok(InterStreamEvent::ToolCallChunk(tc))));
 								}
 								_ => {
 									// no-op for remaining block types

--- a/tests/data/yakbak/anthropic/tool_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/tool_stream/response_000.txt
@@ -1,0 +1,39 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01XFDUFYzQKEhQN3M5vW7tTH","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":85,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01A2B3C4D5","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ci"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ty\": \"Pa"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ris\", "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"country"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\": \"France\","}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" \"unit\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" \"C\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":42}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -577,6 +577,7 @@ pub async fn common_test_chat_stream_cache_explicit_1h_ttl_ok(model: &str) -> Te
 		stream_end,
 		content,
 		reasoning_content: _,
+		..
 	} = extract_stream_end(chat_res.stream).await?;
 	let content = content.ok_or("extract_stream_end SHOULD have extracted some content")?;
 
@@ -622,6 +623,7 @@ pub async fn common_test_chat_stream_simple_ok(model: &str, checks: Option<Check
 		stream_end,
 		content,
 		reasoning_content,
+		..
 	} = extract_stream_end(chat_res.stream).await?;
 	let content = content.ok_or("extract_stream_end SHOULD have extracted some content")?;
 
@@ -673,6 +675,7 @@ pub async fn common_test_chat_stream_capture_content_ok(model: &str) -> TestResu
 		stream_end,
 		content,
 		reasoning_content,
+		..
 	} = extract_stream_end(chat_res.stream).await?;
 
 	// -- Check meta_usage
@@ -720,6 +723,7 @@ pub async fn common_test_chat_stream_capture_all_ok(model: &str, checks: Option<
 		stream_end,
 		content,
 		reasoning_content,
+		..
 	} = extract_stream_end(chat_res.stream).await?;
 
 	// -- Check meta_usage
@@ -772,6 +776,7 @@ pub async fn common_test_chat_stream_tool_capture_ok(model: &str) -> TestResult<
 		stream_end,
 		content,
 		reasoning_content,
+		..
 	} = extract_stream_end(chat_res.stream).await?;
 
 	// -- Check

--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -1,6 +1,6 @@
 use super::TestResult;
 use bitflags::parser::to_writer;
-use genai::chat::{ChatStream, ChatStreamEvent, StreamEnd};
+use genai::chat::{ChatStream, ChatStreamEvent, StreamEnd, ToolCall};
 use tokio_stream::StreamExt;
 
 /// A macro to retrieve the value of an `Option` field from a struct, returning an error if the field is `None`.
@@ -78,6 +78,9 @@ pub struct StreamExtract {
 	pub content: Option<String>,
 
 	pub reasoning_content: Option<String>,
+
+	/// All ToolCallChunk events received during streaming, in order.
+	pub tool_call_chunks: Vec<ToolCall>,
 }
 
 pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<StreamExtract> {
@@ -85,6 +88,7 @@ pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<Strea
 
 	let mut content: Vec<String> = Vec::new();
 	let mut reasoning_content: Vec<String> = Vec::new();
+	let mut tool_call_chunks: Vec<ToolCall> = Vec::new();
 
 	while let Some(Ok(stream_event)) = chat_stream.next().await {
 		match stream_event {
@@ -92,7 +96,7 @@ pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<Strea
 			ChatStreamEvent::Chunk(s_chunk) => content.push(s_chunk.content),
 			ChatStreamEvent::ReasoningChunk(s_chunk) => reasoning_content.push(s_chunk.content),
 			ChatStreamEvent::ThoughtSignatureChunk(_) => (), // ignore thought signature chunks for now
-			ChatStreamEvent::ToolCallChunk(_) => (),         // ignore tool call chunks for now
+			ChatStreamEvent::ToolCallChunk(tc) => tool_call_chunks.push(tc.tool_call),
 			ChatStreamEvent::End(s_end) => {
 				stream_end = Some(s_end);
 				break;
@@ -108,6 +112,7 @@ pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<Strea
 		stream_end,
 		content,
 		reasoning_content,
+		tool_call_chunks,
 	})
 }
 

--- a/tests/tests_yakbak_anthropic.rs
+++ b/tests/tests_yakbak_anthropic.rs
@@ -1,0 +1,96 @@
+//! Replay integration tests for the Anthropic adapter.
+//!
+//! These tests use pre-recorded cassettes from `tests/data/yakbak/anthropic/`
+//! and assert that tool call streaming events flow through correctly.
+
+mod support;
+
+use genai::chat::*;
+use serde_json::{Value, json};
+use support::yakbak::replay_client;
+use support::{TestResult, extract_stream_end};
+
+/// Verify that the Anthropic adapter emits incremental ToolCallChunk events
+/// during streaming: one at content_block_start (name + empty args), then one
+/// per content_block_delta (accumulated args as Value::String).
+#[tokio::test]
+async fn test_yakbak_anthropic_tool_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("anthropic", "tool_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("You are a helpful assistant. Use tools when needed."),
+		ChatMessage::user("What is the temperature in C and weather, in Paris, France"),
+	])
+	.append_tool(Tool::new("get_weather").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"city": { "type": "string", "description": "The city name" },
+			"country": { "type": "string", "description": "The most likely country of this city name" },
+			"unit": { "type": "string", "enum": ["C", "F"], "description": "Temperature unit" }
+		},
+		"required": ["city", "country", "unit"],
+	})));
+
+	let options = ChatOptions::default()
+		.with_capture_content(true)
+		.with_capture_tool_calls(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("anthropic::claude-haiku-4-5", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// -- Verify incremental ToolCallChunk events
+	let chunks = &extract.tool_call_chunks;
+	assert!(
+		chunks.len() >= 2,
+		"Should have at least 2 tool call chunks (start + deltas), got {}",
+		chunks.len()
+	);
+
+	// First chunk: tool name with empty args (from content_block_start)
+	let first = &chunks[0];
+	assert_eq!(first.fn_name, "get_weather", "First chunk should have tool name");
+	assert_eq!(first.call_id, "toolu_01A2B3C4D5");
+	assert_eq!(
+		first.fn_arguments,
+		Value::String(String::new()),
+		"First chunk should have empty string args"
+	);
+
+	// Subsequent chunks: accumulated args as Value::String
+	let last = chunks.last().unwrap();
+	assert_eq!(last.fn_name, "get_weather");
+	let last_args_str = last.fn_arguments.as_str().expect("Args should be Value::String");
+	assert!(
+		last_args_str.contains("Paris"),
+		"Final accumulated args should contain 'Paris', got: {last_args_str}"
+	);
+
+	// -- Verify captured tool calls in StreamEnd (parsed JSON)
+	let tool_calls = extract
+		.stream_end
+		.captured_tool_calls()
+		.ok_or("Should have captured tool calls")?;
+	assert_eq!(tool_calls.len(), 1);
+
+	let tc = &tool_calls[0];
+	assert_eq!(tc.fn_name, "get_weather");
+	assert_eq!(
+		tc.fn_arguments,
+		json!({"city": "Paris", "country": "France", "unit": "C"})
+	);
+	assert_eq!(tc.call_id, "toolu_01A2B3C4D5");
+
+	// -- Verify usage
+	let usage = extract
+		.stream_end
+		.captured_usage
+		.as_ref()
+		.ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(85));
+	assert_eq!(usage.completion_tokens, Some(42));
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary

The Anthropic streaming adapter currently buffers tool calls internally — it accumulates `content_block_start` (tool name) and all `content_block_delta` events (partial JSON args), then emits a **single** `ToolCallChunk` at `content_block_stop` with fully parsed `fn_arguments: Value::Object(...)`.

This differs from the OpenAI adapter, which emits a `ToolCallChunk` on every SSE delta with `fn_arguments: Value::String(accumulated)`. The inconsistency forces downstream consumers to implement workarounds (e.g. buffering queues) to handle the case where a single `ToolCallChunk` contains both the tool name and complete arguments simultaneously.

### Changes

- **`content_block_start`** with `tool_use` type: now emits a `ToolCallChunk` with `fn_name` + empty `Value::String("")` args (signals tool call start)
- **`content_block_delta`** with `partial_json`: now emits a `ToolCallChunk` with accumulated args as `Value::String` (incremental streaming)
- **`content_block_stop`**: only finalizes `captured_tool_calls` for the `StreamEnd` event (no `ToolCallChunk` emitted, since they were already streamed incrementally)

### Motivation

This aligns Anthropic's streaming behaviour with OpenAI's convention, allowing consumers to handle tool call streaming uniformly across providers without provider-specific workarounds.

The captured tool calls at stream end (`StreamEnd.captured_tool_calls`) remain unchanged — they still contain fully parsed `Value::Object` arguments.

## Test plan

- [ ] Existing `common_test_chat_stream_simple_ok` tests should continue passing
- [ ] Anthropic streaming with tool calls should emit incremental chunks
- [ ] `captured_tool_calls` in `StreamEnd` should still contain parsed JSON objects
- [ ] OpenAI streaming behaviour should be unaffected