### PR TITLE
fix(openai-streamer): emit ToolCallChunk when tool_calls arrive with finish_reason

### DIFF
--- a/src/adapter/adapters/openai/streamer.rs
+++ b/src/adapter/adapters/openai/streamer.rs
@@ -208,6 +208,10 @@ impl futures::Stream for OpenAIStreamer {
 							self.captured_data.stop_reason = Some(finish_reason);
 							// NOTE: Some providers (e.g., Ollama) send tool_calls AND finish_reason in the same message.
 							// We need to capture tool_calls here before continuing to the next message.
+							// Capture tool_calls that arrive in the same chunk as finish_reason.
+							// After capturing, emit the first ToolCallChunk so downstream
+							// consumers (e.g. agent loops) see the tool call event.
+							let mut first_tool_call_event: Option<ToolCall> = None;
 							if let Ok(delta_tool_calls) = first_choice.x_take::<Value>("/delta/tool_calls")
 								&& delta_tool_calls != Value::Null
 								&& let Some(delta_tool_calls) = delta_tool_calls.as_array()
@@ -224,7 +228,10 @@ impl futures::Stream for OpenAIStreamer {
 										let fn_name = function.x_take::<String>("name").unwrap_or_default();
 										let arguments = function.x_take::<String>("arguments").unwrap_or_default();
 
-										self.capture_tool_call(index as usize, call_id, fn_name, arguments);
+										let tc = self.capture_tool_call(index as usize, call_id, fn_name, arguments);
+										if first_tool_call_event.is_none() {
+											first_tool_call_event = Some(tc);
+										}
 									}
 								}
 							}
@@ -265,6 +272,12 @@ impl futures::Stream for OpenAIStreamer {
 									}
 								}
 								return Poll::Ready(Some(Ok(InterStreamEvent::ReasoningChunk(reasoning_content))));
+							}
+
+							// If we captured a tool call in the finish_reason chunk,
+							// emit it as a ToolCallChunk so the agent loop sees it.
+							if let Some(tc) = first_tool_call_event {
+								return Poll::Ready(Some(Ok(InterStreamEvent::ToolCallChunk(tc))));
 							}
 
 							continue;

--- a/tests/data/yakbak/openai/stream_tool_call_with_finish_reason/response_000.txt
+++ b/tests/data/yakbak/openai/stream_tool_call_with_finish_reason/response_000.txt
@@ -1,0 +1,6 @@
+data: {"id":"yakbak-fixture-tool-finish","created":1775744502,"object":"chat.completion.chunk","model":"yakbak-openai-compat-model","choices":[{"index":0,"finish_reason":"tool_calls","delta":{"role":"assistant","tool_calls":[{"id":"call_yakbak_fixture_0","index":0,"type":"function","function":{"name":"get_weather","arguments":"{\"city\": \"Paris\", \"country\": \"France\", \"unit\": \"C\"}"}}]}}]}
+
+data: {"id":"yakbak-fixture-tool-finish","created":1775744502,"object":"chat.completion.chunk","model":"yakbak-openai-compat-model","choices":[{"index":0,"finish_reason":"tool_calls","delta":{"role":"assistant","content":""}}],"usage":{"prompt_tokens":163,"completion_tokens":11,"total_tokens":174}}
+
+data: [DONE]
+

--- a/tests/tests_yakbak_openai.rs
+++ b/tests/tests_yakbak_openai.rs
@@ -1,0 +1,111 @@
+//! Replay integration tests for the OpenAI (Chat Completions API) adapter.
+//!
+//! These tests use pre-recorded cassettes from `tests/data/yakbak/openai/`
+//! and assert that tool call streaming events flow through correctly.
+
+mod support;
+
+use genai::chat::*;
+use serde_json::json;
+use support::yakbak::replay_client;
+use support::{TestResult, extract_stream_end};
+
+/// Regression test for the "tool_calls + finish_reason in same SSE chunk" case.
+///
+/// Some OpenAI-compatible providers (e.g. ZhiPu/BigModel GLM-4 series, Ollama)
+/// return the full tool call and `finish_reason: "tool_calls"` in the first
+/// content chunk, rather than splitting arguments across multiple delta chunks
+/// like OpenAI's native Chat Completions stream.
+///
+/// The streamer must emit a `ToolCallChunk` event for these combined chunks
+/// so downstream consumers (agent loops, stream collectors) can react to
+/// tool calls in real time. Before the fix, the streamer captured the tool
+/// call into `captured_data` but skipped the `InterStreamEvent::ToolCallChunk`
+/// emit, so streams appeared to terminate with `NaturalEnd` and no tool calls.
+#[tokio::test]
+async fn test_yakbak_openai_stream_tool_call_with_finish_reason() -> TestResult<()> {
+	let (client, _server) = replay_client("openai", "stream_tool_call_with_finish_reason").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("You are a helpful assistant. Use tools when needed."),
+		ChatMessage::user("What is the weather in Paris, France in Celsius?"),
+	])
+	.append_tool(Tool::new("get_weather").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"city": { "type": "string", "description": "The city name" },
+			"country": { "type": "string", "description": "The most likely country of this city name" },
+			"unit": { "type": "string", "enum": ["C", "F"], "description": "Temperature unit" }
+		},
+		"required": ["city", "country", "unit"],
+	})));
+
+	let options = ChatOptions::default()
+		.with_capture_content(true)
+		.with_capture_tool_calls(true)
+		.with_capture_usage(true);
+
+	let stream_res = client.exec_chat_stream("gpt-4o-mini", chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// -- Verify that a ToolCallChunk event was emitted during streaming.
+	//    This is the core regression: before the fix, the streamer captured
+	//    the tool call into `captured_data` but never produced a stream event,
+	//    so agent loops saw NaturalEnd with no tool calls.
+	let chunks = &extract.tool_call_chunks;
+	assert_eq!(
+		chunks.len(),
+		1,
+		"Should have exactly 1 tool call chunk emitted during streaming, got {}",
+		chunks.len()
+	);
+
+	let chunk = &chunks[0];
+	assert_eq!(chunk.fn_name, "get_weather");
+	assert_eq!(chunk.call_id, "call_yakbak_fixture_0");
+	// Arguments are accumulated as Value::String during streaming.
+	let chunk_args_str = chunk
+		.fn_arguments
+		.as_str()
+		.expect("Streamed chunk args should be Value::String");
+	assert!(
+		chunk_args_str.contains("Paris"),
+		"Streamed chunk args should contain 'Paris', got: {chunk_args_str}"
+	);
+
+	// -- Verify captured tool calls in StreamEnd (parsed JSON).
+	let tool_calls = extract
+		.stream_end
+		.captured_tool_calls()
+		.ok_or("Should have captured tool calls")?;
+	assert_eq!(tool_calls.len(), 1);
+
+	let tc = &tool_calls[0];
+	assert_eq!(tc.fn_name, "get_weather");
+	assert_eq!(tc.call_id, "call_yakbak_fixture_0");
+	assert_eq!(
+		tc.fn_arguments,
+		json!({"city": "Paris", "country": "France", "unit": "C"})
+	);
+
+	// -- Verify stop reason.
+	assert_eq!(
+		extract.stream_end.captured_stop_reason,
+		Some(StopReason::ToolCall("tool_calls".to_string()))
+	);
+
+	// -- Verify usage was captured from the second chunk (content: "" + usage).
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(163));
+	assert_eq!(usage.completion_tokens, Some(11));
+	assert_eq!(usage.total_tokens, Some(174));
+
+	// -- No text content should be present (tool-only response).
+	assert!(
+		extract.content.is_none() || extract.content.as_deref() == Some(""),
+		"Tool-only response should have no text content, got: {:?}",
+		extract.content
+	);
+
+	Ok(())
+}


### PR DESCRIPTION
## Problem

Providers like ZhiPu (BigModel / GLM-4) send `tool_calls` and `finish_reason` in the same SSE chunk during streaming. The existing streamer code captured the tool call data into `captured_data` but **did not emit an `InterStreamEvent::ToolCallChunk`**, causing agent loops to miss tool calls entirely and treat the response as a text-only NaturalEnd completion.

## Root Cause

In `openai/streamer.rs`, the `finish_reason` branch (line 178) correctly calls `capture_tool_call()` when it finds tool_calls in the same chunk (line 198), but then falls through to `continue` without emitting a stream event. The non-finish_reason branch (line 264) correctly emits `InterStreamEvent::ToolCallChunk`, but it's gated behind `else if` and never reached when finish_reason is present.

## Fix

After capturing tool calls in the finish_reason branch, emit the first captured tool call as `InterStreamEvent::ToolCallChunk` before continuing. This ensures downstream consumers (agent loops, stream collectors) see the tool call event in the stream.

## Testing

Verified with ZhiPu GLM-4-Flash via the `tool_call_live` example:
- Before fix: 1 step, NaturalEnd, empty response (tool call silently lost)
- After fix: 2 steps, tool call executed, correct result returned

## Affected Providers

Any provider that sends `tool_calls` and `finish_reason` in the same SSE chunk. Known: ZhiPu/BigModel (GLM-4 series). Potentially also Ollama (mentioned in existing code comments).