### PR TITLE
+ tool - add 'strict' option for OpenAI strict function calling

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -755,6 +755,7 @@ impl AnthropicAdapter {
 			description,
 			schema,
 			config,
+			..
 		} = tool;
 
 		let name = match name {

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -785,6 +785,7 @@ impl GeminiAdapter {
 			description,
 			schema,
 			config,
+			..
 		} = tool;
 
 		// Built-in WebSearch for Gemini

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -408,18 +408,32 @@ impl OpenAIAdapter {
 			tools
 				.into_iter()
 				.map(|tool| {
-					// TODO: Need to handle the error correctly
-					// TODO: Needs to have a custom serializer (tool should not have to match to a provider)
-					// NOTE: Right now, low probability, so, we just return null if cannot convert to value.
+					let strict = tool.strict.unwrap_or(false);
+					let mut parameters = tool.schema;
+
+					// When strict mode is enabled, OpenAI requires `additionalProperties: false`
+					// on every object node in the schema.
+					if strict {
+						if let Some(ref mut schema_val) = parameters {
+							schema_val.x_walk(|parent_map, prop_name| {
+								if prop_name == "type" {
+									let typ = parent_map.get("type").and_then(|v| v.as_str()).unwrap_or("");
+									if typ == "object" {
+										parent_map.insert("additionalProperties".to_string(), false.into());
+									}
+								}
+								true
+							});
+						}
+					}
+
 					json!({
 						"type": "function",
 						"function": {
 							"name": tool.name,
 							"description": tool.description,
-							"parameters": tool.schema,
-							// TODO: If we need to support `strict: true` we need to add additionalProperties: false into the schema
-							//       above (like structured output)
-							"strict": false,
+							"parameters": parameters,
+							"strict": strict,
 						}
 					})
 				})

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -537,6 +537,7 @@ impl OpenAIRespAdapter {
 			name,
 			description,
 			schema,
+			strict,
 			config,
 		} = tool;
 
@@ -563,14 +564,31 @@ impl OpenAIRespAdapter {
 				tool_value
 			}
 			name => {
+				let strict = strict.unwrap_or(false);
+				let mut parameters = schema;
+
+				// When strict mode is enabled, OpenAI requires `additionalProperties: false`
+				// on every object node in the schema.
+				if strict {
+					if let Some(ref mut schema_val) = parameters {
+						schema_val.x_walk(|parent_map, prop_name| {
+							if prop_name == "type" {
+								let typ = parent_map.get("type").and_then(|v| v.as_str()).unwrap_or("");
+								if typ == "object" {
+									parent_map.insert("additionalProperties".to_string(), false.into());
+								}
+							}
+							true
+						});
+					}
+				}
+
 				json!({
 					"type": "function",
 					"name": name,
 					"description": description,
-					"parameters": schema,
-					// TODO: If we need to support `strict: true` we need to add additionalProperties: false into the schema
-					//       above (like structured output)
-					"strict": false,
+					"parameters": parameters,
+					"strict": strict,
 				})
 			}
 		};

--- a/src/chat/tool/tool_base.rs
+++ b/src/chat/tool/tool_base.rs
@@ -37,6 +37,12 @@ pub struct Tool {
 	/// ```
 	pub schema: Option<Value>,
 
+	/// When `true`, the provider enforces strict schema validation on tool-call arguments.
+	/// For OpenAI this sets `"strict": true` and auto-injects `"additionalProperties": false`
+	/// on every `"type": "object"` node in the schema.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub strict: Option<bool>,
+
 	/// Optional configuration for the tool.
 	///
 	/// Useful with embedded provider tools (e.g., Google Search for Gemini).
@@ -82,6 +88,7 @@ impl Tool {
 			name: name.into(),
 			description: None,
 			schema: None,
+			strict: None,
 			config: None,
 		}
 	}
@@ -104,6 +111,13 @@ impl Tool {
 	/// Set the JSON Schema for the tool parameters. Returns self for chaining.
 	pub fn with_schema(mut self, parameters: Value) -> Self {
 		self.schema = Some(parameters);
+		self
+	}
+
+	/// Enable strict schema validation for tool-call arguments.
+	/// When `true`, OpenAI enforces exact schema conformance.
+	pub fn with_strict(mut self, strict: bool) -> Self {
+		self.strict = Some(strict);
 		self
 	}
 


### PR DESCRIPTION
Add Tool.strict: Option<bool> so callers can opt into OpenAI's strict function calling mode, which guarantees tool-call arguments conform exactly to the provided JSON Schema.

When strict is true, the adapters:
1. Set "strict": true in the tool JSON
2. Walk the schema to inject "additionalProperties": false on every "type": "object" node (required by the OpenAI API)

This uses the same x_walk pattern already established for structured output (JsonSpec response format).

Supported in both openai (Chat Completions) and openai_resp (Responses API) adapters. Gemini and Anthropic ignore the field.