### PR TITLE
Add Ollama Cloud adapter

### DIFF
--- a/.github/workflows/yakbak-replay-tests.yml
+++ b/.github/workflows/yakbak-replay-tests.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Run GitHub Copilot replay tests
         run: cargo test --test tests_yakbak_github_copilot
+
+      - name: Run Ollama Cloud replay tests
+        run: cargo test --test tests_yakbak_ollama_cloud

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # genai, Multi-AI Providers Library for Rust
 
-Currently natively supports: **OpenAI**, **Anthropic**, **Gemini**, **xAI**, **Ollama**, **Groq**, **DeepSeek**, **Cohere**, **Together**, **Fireworks**, **Nebius**, **Mimo**, **Zai** (Zhipu AI), **BigModel**, **GitHub Copilot** (GitHub Models API).
+Currently natively supports: **OpenAI**, **Anthropic**, **Gemini**, **xAI**, **Ollama**, **Ollama Cloud**, **Groq**, **DeepSeek**, **Cohere**, **Together**, **Fireworks**, **Nebius**, **Mimo**, **Zai** (Zhipu AI), **BigModel**, **GitHub Copilot** (GitHub Models API).
 
 Also supports a custom URL with `ServiceTargetResolver` (see [examples/c06-target-resolver.rs](examples/c06-target-resolver.rs)).
 
@@ -72,6 +72,7 @@ const MODEL_TOGETHER: &str = "together::openai/gpt-oss-20b";
 const MODEL_GEMINI: &str = "gemini-2.0-flash";
 const MODEL_GROQ: &str = "llama-3.1-8b-instant";
 const MODEL_OLLAMA: &str = "gemma:2b"; // sh: `ollama pull gemma:2b`
+const MODEL_OLLAMA_CLOUD: &str = "ollama_cloud::gemma3:4b";
 const MODEL_XAI: &str = "grok-3-mini";
 const MODEL_DEEPSEEK: &str = "deepseek-chat";
 const MODEL_ZAI: &str = "glm-4-plus";
@@ -92,6 +93,7 @@ const MODEL_AND_KEY_ENV_NAME_LIST: &[(&str, &str)] = &[
 	(MODEL_XAI, "XAI_API_KEY"),
 	(MODEL_DEEPSEEK, "DEEPSEEK_API_KEY"),
 	(MODEL_OLLAMA, ""),
+	(MODEL_OLLAMA_CLOUD, "OLLAMA_API_KEY"),
 	(MODEL_ZAI, "ZAI_API_KEY"),
 	(MODEL_COHERE, "COHERE_API_KEY"),
 	(MODEL_GITHUB_COPILOT, "GITHUB_TOKEN"),
@@ -104,6 +106,7 @@ const MODEL_AND_KEY_ENV_NAME_LIST: &[(&str, &str)] = &[
 //  - starts_with "gemini"   -> Gemini
 //  - model in Groq models   -> Groq
 //  - starts_with "glm"      -> ZAI
+//  - starts_with "ollama_cloud::" -> OllamaCloud
 //  - For anything else      -> Ollama
 //
 // This can be customized; see `examples/c03-mapper.rs`

--- a/doc/for-llm/api-reference-for-llm.md
+++ b/doc/for-llm/api-reference-for-llm.md
@@ -30,8 +30,9 @@ genai (crate root / lib.rs)
 - **ModelSpec**: Specifies a model at three resolution levels: `Name`, `Iden`, or `Target`.
 - **ServiceTarget**: Fully resolved call target: `ModelIden` + `Endpoint` + `AuthData`.
 - **Resolvers**: User hooks to customize model mapping, authentication, and service endpoints.
-- **AdapterKind**: Supported providers: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`, `GithubCopilot`.
+- **AdapterKind**: Supported providers: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`, `OllamaCloud`, `GithubCopilot`.
   - `GithubCopilot` is a GitHub Models gateway with multi-publisher namespaced models such as `github_copilot::openai/gpt-4.1-mini`, `github_copilot::anthropic/claude-sonnet-4-6`, and `github_copilot::google/gemini-2.5-pro`.
+  - `OllamaCloud` is the hosted Ollama Cloud service (`ollama.com`). Uses the same native Ollama protocol as the local `Ollama` adapter but authenticates with `Authorization: Bearer $OLLAMA_API_KEY`. Use via `ollama_cloud::model_name` namespace (e.g., `ollama_cloud::gemma3:4b`).
 
 ## Client & Configuration
 
@@ -483,7 +484,7 @@ Single-value-per-name HTTP header map.
 
 Enum identifying the AI provider adapter.
 
-Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`, `GithubCopilot`.
+Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`, `OllamaCloud`, `GithubCopilot`.
 
 - `as_str()`: Display name (e.g., `"OpenAI"`, `"xAi"`).
 - `as_lower_str()`: Lowercase name (e.g., `"openai"`, `"xai"`).
@@ -507,7 +508,7 @@ Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`
   - `glm*` -> `Zai`.
   - Fallback -> `Ollama`.
 - **Namespacing**: `namespace::model_name` (e.g., `together::meta-llama/...`, `nebius::Qwen/...`).
-  - Namespace matches adapter lowercase name (e.g., `openai::`, `gemini::`, `anthropic::`, `fireworks::`, `together::`, `groq::`, `mimo::`, `nebius::`, `xai::`, `deepseek::`, `zai::`, `bigmodel::`, `aliyun::`, `cohere::`, `ollama::`, `openai_resp::`, `github_copilot::`)
+  - Namespace matches adapter lowercase name (e.g., `openai::`, `gemini::`, `anthropic::`, `fireworks::`, `together::`, `groq::`, `mimo::`, `nebius::`, `xai::`, `deepseek::`, `zai::`, `bigmodel::`, `aliyun::`, `cohere::`, `ollama::`, `ollama_cloud::`, `openai_resp::`, `github_copilot::`)
   - Special: `coding::` namespace maps to `Zai` adapter.
 - **Ollama Fallback**: Unrecognized non-namespaced names default to `Ollama` adapter (localhost:11434).
 - **Reasoning Normalization**: Automatic extraction for DeepSeek/Ollama `<think>` blocks when `normalize_reasoning_content` is enabled.

--- a/examples/c00-readme.rs
+++ b/examples/c00-readme.rs
@@ -13,6 +13,7 @@ const MODEL_TOGETHER: &str = "together::openai/gpt-oss-20b";
 const MODEL_GEMINI: &str = "gemini-2.0-flash";
 const MODEL_GROQ: &str = "groq::openai/gpt-oss-20b";
 const MODEL_OLLAMA: &str = "gemma4:e2b"; // sh: `ollama pull gemma:2b`
+const MODEL_OLLAMA_CLOUD: &str = "ollama_cloud::gemma3:4b";
 const MODEL_XAI: &str = "grok-3-mini";
 const MODEL_DEEPSEEK: &str = "deepseek-chat";
 const MODEL_ZAI: &str = "glm-4-plus";
@@ -29,6 +30,7 @@ const MODEL_AND_KEY_ENV_NAME_LIST: &[(&str, &str)] = &[
 	(MODEL_ANTHROPIC, "ANTHROPIC_API_KEY"),
 	(MODEL_GEMINI, "GEMINI_API_KEY"),
 	(MODEL_OLLAMA, ""),
+	(MODEL_OLLAMA_CLOUD, "OLLAMA_API_KEY"),
 	(MODEL_FIREWORKS, "FIREWORKS_API_KEY"),
 	(MODEL_TOGETHER, "TOGETHER_API_KEY"),
 	(MODEL_GROQ, "GROQ_API_KEY"),
@@ -47,6 +49,7 @@ const MODEL_AND_KEY_ENV_NAME_LIST: &[(&str, &str)] = &[
 //  - starts_with "gemini"   -> Gemini
 //  - model in Groq models   -> Groq
 //  - starts_with "glm"      -> ZAI
+//  - starts_with "ollama_cloud::" -> OllamaCloud
 //  - For anything else      -> Ollama
 //
 // This can be customized; see `examples/c03-mapper.rs`

--- a/examples/c05-model-names.rs
+++ b/examples/c05-model-names.rs
@@ -1,5 +1,5 @@
 //! Example showing how to get the list of models per AdapterKind
-//! Note: Currently, only Ollama makes a dynamic query. Other adapters have a static list of models.
+//! Note: Currently, only Ollama and Ollama Cloud make a dynamic query. Other adapters have a static list of models.
 
 use genai::Client;
 use genai::adapter::AdapterKind;

--- a/examples/c99-ollama-cloud.rs
+++ b/examples/c99-ollama-cloud.rs
@@ -1,0 +1,44 @@
+use genai::Client;
+use genai::chat::printer::{PrintChatStreamOptions, print_chat_stream};
+use genai::chat::{ChatMessage, ChatRequest};
+
+// Ollama Cloud is the hosted Ollama service at ollama.com.
+// It uses the same native Ollama protocol as local Ollama, but authenticates with a Bearer token.
+// Requires OLLAMA_API_KEY environment variable.
+//
+// Use `ollama_cloud::` namespace to route to the cloud instead of local Ollama:
+//   "ollama_cloud::gemma3:4b"
+//   "ollama_cloud::gpt-oss:120b"
+//   "ollama_cloud::deepseek-v3.2"
+const MODEL: &str = "ollama_cloud::gemma3:4b";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let question = "Why is the sky blue?";
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence"),
+		ChatMessage::user(question),
+	]);
+
+	let client = Client::default();
+
+	let adapter_kind = client.resolve_service_target(MODEL).await?.model.adapter_kind;
+
+	println!("\n===== MODEL: {MODEL} ({adapter_kind}) =====");
+
+	println!("\n--- Question:\n{question}");
+
+	println!("\n--- Answer:");
+	let chat_res = client.exec_chat(MODEL, chat_req.clone(), None).await?;
+	println!("{}", chat_res.first_text().unwrap_or("NO ANSWER"));
+
+	println!("\n--- Answer: (streaming)");
+	let chat_res = client.exec_chat_stream(MODEL, chat_req.clone(), None).await?;
+	let print_options = PrintChatStreamOptions::from_print_events(false);
+	print_chat_stream(chat_res, Some(&print_options)).await?;
+
+	println!();
+
+	Ok(())
+}

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -59,7 +59,7 @@ pub enum AdapterKind {
 	Cohere,
 	/// OpenAI shared behavior + some custom. (currently, localhost only, can be customize with ServerTargetResolver).
 	Ollama,
-	/// For Ollama Cloud (cloud.ollama.com) - uses native Ollama protocol with Bearer auth
+	/// For Ollama Cloud (ollama.com) - uses native Ollama protocol with Bearer auth
 	OllamaCloud,
 	/// Google Vertex AI (Model Garden). Supports Gemini and Claude models via publishers/google and publishers/anthropic.
 	/// Uses namespace routing: `vertex::gemini-2.5-flash`, `vertex::claude-sonnet-4-6`

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -1,5 +1,6 @@
 use crate::adapter::adapters::github_copilot::GithubCopilotAdapter;
 use crate::adapter::adapters::ollama::OllamaAdapter;
+use crate::adapter::adapters::ollama_cloud::OllamaCloudAdapter;
 use crate::adapter::adapters::openai_resp::OpenAIRespAdapter;
 use crate::adapter::adapters::together::TogetherAdapter;
 use crate::adapter::adapters::zai::ZaiAdapter;
@@ -58,6 +59,8 @@ pub enum AdapterKind {
 	Cohere,
 	/// OpenAI shared behavior + some custom. (currently, localhost only, can be customize with ServerTargetResolver).
 	Ollama,
+	/// For Ollama Cloud (cloud.ollama.com) - uses native Ollama protocol with Bearer auth
+	OllamaCloud,
 	/// Google Vertex AI (Model Garden). Supports Gemini and Claude models via publishers/google and publishers/anthropic.
 	/// Uses namespace routing: `vertex::gemini-2.5-flash`, `vertex::claude-sonnet-4-6`
 	Vertex,
@@ -87,6 +90,7 @@ impl AdapterKind {
 			AdapterKind::Aliyun => "Aliyun",
 			AdapterKind::Cohere => "Cohere",
 			AdapterKind::Ollama => "Ollama",
+			AdapterKind::OllamaCloud => "OllamaCloud",
 			AdapterKind::Vertex => "Vertex",
 			AdapterKind::GithubCopilot => "GithubCopilot",
 		}
@@ -111,6 +115,7 @@ impl AdapterKind {
 			AdapterKind::Aliyun => "aliyun",
 			AdapterKind::Cohere => "cohere",
 			AdapterKind::Ollama => "ollama",
+			AdapterKind::OllamaCloud => "ollama_cloud",
 			AdapterKind::Vertex => "vertex",
 			AdapterKind::GithubCopilot => "github_copilot",
 		}
@@ -134,6 +139,7 @@ impl AdapterKind {
 			"aliyun" => Some(AdapterKind::Aliyun),
 			"cohere" => Some(AdapterKind::Cohere),
 			"ollama" => Some(AdapterKind::Ollama),
+			"ollama_cloud" => Some(AdapterKind::OllamaCloud),
 			"vertex" => Some(AdapterKind::Vertex),
 			"github_copilot" => Some(AdapterKind::GithubCopilot),
 			_ => None,
@@ -162,6 +168,7 @@ impl AdapterKind {
 			AdapterKind::Aliyun => AliyunAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Cohere => CohereAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Ollama => OllamaAdapter::DEFAULT_API_KEY_ENV_NAME,
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Vertex => VertexAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::GithubCopilot => GithubCopilotAdapter::DEFAULT_API_KEY_ENV_NAME,
 		}

--- a/src/adapter/adapters/mod.rs
+++ b/src/adapter/adapters/mod.rs
@@ -12,6 +12,7 @@ pub(super) mod groq;
 pub(super) mod mimo;
 pub(super) mod nebius;
 pub(super) mod ollama;
+pub(super) mod ollama_cloud;
 pub(super) mod openai;
 pub(super) mod openai_resp;
 pub(super) mod together;

--- a/src/adapter/adapters/ollama_cloud/adapter_impl.rs
+++ b/src/adapter/adapters/ollama_cloud/adapter_impl.rs
@@ -1,0 +1,108 @@
+use crate::Headers;
+use crate::adapter::adapters::ollama::OllamaAdapter;
+use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
+use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::embed::{EmbedOptionsSet, EmbedRequest, EmbedResponse};
+use crate::resolver::{AuthData, Endpoint};
+use crate::webc::WebResponse;
+use crate::{Error, ModelIden, Result, ServiceTarget};
+use reqwest::RequestBuilder;
+use value_ext::JsonValueExt;
+
+pub struct OllamaCloudAdapter;
+
+impl OllamaCloudAdapter {
+	pub const API_KEY_DEFAULT_ENV_NAME: &str = "OLLAMA_API_KEY";
+}
+
+impl Adapter for OllamaCloudAdapter {
+	const DEFAULT_API_KEY_ENV_NAME: Option<&'static str> = Some(Self::API_KEY_DEFAULT_ENV_NAME);
+
+	fn default_endpoint() -> Endpoint {
+		const BASE_URL: &str = "https://ollama.com/";
+		Endpoint::from_static(BASE_URL)
+	}
+
+	fn default_auth() -> AuthData {
+		AuthData::from_env(Self::API_KEY_DEFAULT_ENV_NAME)
+	}
+
+	async fn all_model_names(adapter_kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		let base_url = endpoint.base_url();
+		let url = format!("{base_url}api/tags");
+
+		let api_key = get_api_key(auth, &ModelIden::new(adapter_kind, ""))?;
+		let headers = Headers::from(vec![("Authorization", format!("Bearer {api_key}"))]);
+
+		let web_c = crate::webc::WebClient::default();
+		let mut res = web_c.do_get(&url, &headers).await.map_err(|webc_error| Error::WebAdapterCall {
+			adapter_kind,
+			webc_error,
+		})?;
+
+		let mut models: Vec<String> = Vec::new();
+		if let serde_json::Value::Array(models_value) = res.body.x_take("models")? {
+			for mut model in models_value {
+				let model_name: String = model.x_take("name")?;
+				models.push(model_name);
+			}
+		}
+		Ok(models)
+	}
+
+	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {
+		OllamaAdapter::get_service_url(model, service_type, endpoint)
+	}
+
+	fn to_web_request_data(
+		target: ServiceTarget,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		chat_options: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		let api_key = get_api_key(target.auth.clone(), &target.model)?;
+		let mut web_req = OllamaAdapter::to_web_request_data(target, service_type, chat_req, chat_options)?;
+		web_req
+			.headers
+			.merge(Headers::from(("Authorization", format!("Bearer {api_key}"))));
+		Ok(web_req)
+	}
+
+	fn to_chat_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatResponse> {
+		OllamaAdapter::to_chat_response(model_iden, web_response, options_set)
+	}
+
+	fn to_chat_stream(
+		model_iden: ModelIden,
+		reqwest_builder: RequestBuilder,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatStreamResponse> {
+		OllamaAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	fn to_embed_request_data(
+		service_target: ServiceTarget,
+		embed_req: EmbedRequest,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		let api_key = get_api_key(service_target.auth.clone(), &service_target.model)?;
+		let mut web_req = OllamaAdapter::to_embed_request_data(service_target, embed_req, options_set)?;
+		web_req
+			.headers
+			.merge(Headers::from(("Authorization", format!("Bearer {api_key}"))));
+		Ok(web_req)
+	}
+
+	fn to_embed_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: EmbedOptionsSet<'_, '_>,
+	) -> Result<EmbedResponse> {
+		OllamaAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
+}

--- a/src/adapter/adapters/ollama_cloud/adapter_impl.rs
+++ b/src/adapter/adapters/ollama_cloud/adapter_impl.rs
@@ -47,6 +47,8 @@ impl Adapter for OllamaCloudAdapter {
 				let model_name: String = model.x_take("name")?;
 				models.push(model_name);
 			}
+		} else {
+			// TODO: Need to add tracing
 		}
 		Ok(models)
 	}

--- a/src/adapter/adapters/ollama_cloud/mod.rs
+++ b/src/adapter/adapters/ollama_cloud/mod.rs
@@ -1,0 +1,3 @@
+mod adapter_impl;
+
+pub use adapter_impl::*;

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -1,6 +1,7 @@
 use super::groq::GroqAdapter;
 use crate::adapter::adapters::github_copilot::GithubCopilotAdapter;
 use crate::adapter::adapters::mimo::MimoAdapter;
+use crate::adapter::adapters::ollama_cloud::OllamaCloudAdapter;
 use crate::adapter::adapters::together::TogetherAdapter;
 use crate::adapter::adapters::zai::ZaiAdapter;
 use crate::adapter::aliyun::AliyunAdapter;
@@ -51,6 +52,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::default_endpoint(),
 			AdapterKind::Cohere => CohereAdapter::default_endpoint(),
 			AdapterKind::Ollama => OllamaAdapter::default_endpoint(),
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::default_endpoint(),
 			AdapterKind::Vertex => VertexAdapter::default_endpoint(),
 			AdapterKind::GithubCopilot => GithubCopilotAdapter::default_endpoint(),
 		}
@@ -74,6 +76,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::default_auth(),
 			AdapterKind::Cohere => CohereAdapter::default_auth(),
 			AdapterKind::Ollama => OllamaAdapter::default_auth(),
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::default_auth(),
 			AdapterKind::Vertex => VertexAdapter::default_auth(),
 			AdapterKind::GithubCopilot => GithubCopilotAdapter::default_auth(),
 		}
@@ -97,6 +100,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Cohere => CohereAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Ollama => OllamaAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Vertex => VertexAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::GithubCopilot => GithubCopilotAdapter::all_model_names(kind, endpoint, auth).await,
 		}
@@ -120,6 +124,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Cohere => CohereAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Ollama => OllamaAdapter::get_service_url(model, service_type, endpoint),
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Vertex => VertexAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::GithubCopilot => GithubCopilotAdapter::get_service_url(model, service_type, endpoint),
 		}
@@ -155,6 +160,9 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_web_request_data(target, service_type, chat_req, options_set),
+			AdapterKind::OllamaCloud => {
+				OllamaCloudAdapter::to_web_request_data(target, service_type, chat_req, options_set)
+			}
 			AdapterKind::Vertex => VertexAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::GithubCopilot => {
 				GithubCopilotAdapter::to_web_request_data(target, service_type, chat_req, options_set)
@@ -184,6 +192,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_chat_response(model_iden, web_response, options_set),
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Vertex => VertexAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::GithubCopilot => GithubCopilotAdapter::to_chat_response(model_iden, web_response, options_set),
 		}
@@ -211,6 +220,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Vertex => VertexAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::GithubCopilot => {
 				GithubCopilotAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
@@ -244,6 +254,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Vertex => VertexAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::GithubCopilot => GithubCopilotAdapter::to_embed_request_data(target, embed_req, options_set),
 		}
@@ -274,6 +285,7 @@ impl AdapterDispatcher {
 			AdapterKind::Aliyun => AliyunAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Cohere => CohereAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Ollama => OllamaAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::OllamaCloud => OllamaCloudAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Vertex => VertexAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::GithubCopilot => {
 				GithubCopilotAdapter::to_embed_response(model_iden, web_response, options_set)

--- a/tests/data/yakbak/ollama_cloud/simple_stream/response_000.txt
+++ b/tests/data/yakbak/ollama_cloud/simple_stream/response_000.txt
@@ -1,0 +1,3 @@
+{"model":"gemma3:4b","created_at":"2026-04-10T13:19:59.948798825Z","message":{"role":"assistant","content":"The sky appears blue due to a phenomenon called Rayleigh scattering, where shorter wavelengths of sunlight (blue and violet) are scattered more by the Earth’s atmosphere than longer wavelengths like red and orange."},"done":false}
+{"model":"gemma3:4b","created_at":"2026-04-10T13:19:59.955113763Z","message":{"role":"assistant","content":""},"done":false}
+{"model":"gemma3:4b","created_at":"2026-04-10T13:20:00.156773998Z","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","total_duration":499049129,"prompt_eval_count":21,"eval_count":40}

--- a/tests/tests_p_ollama_cloud.rs
+++ b/tests/tests_p_ollama_cloud.rs
@@ -1,0 +1,52 @@
+mod support;
+
+use crate::support::{TestResult, common_tests};
+use genai::adapter::AdapterKind;
+use genai::resolver::AuthData;
+
+const MODEL: &str = "ollama_cloud::gpt-oss:120b";
+
+#[tokio::test]
+async fn test_chat_simple_ok() -> TestResult<()> {
+	if std::env::var("OLLAMA_API_KEY").is_err() {
+		println!("Skipping test_chat_simple_ok: OLLAMA_API_KEY not set");
+		return Ok(());
+	}
+	common_tests::common_test_chat_simple_ok(MODEL, None).await
+}
+
+#[tokio::test]
+async fn test_chat_stream_simple_ok() -> TestResult<()> {
+	if std::env::var("OLLAMA_API_KEY").is_err() {
+		println!("Skipping test_chat_stream_simple_ok: OLLAMA_API_KEY not set");
+		return Ok(());
+	}
+	common_tests::common_test_chat_stream_simple_ok(MODEL, None).await
+}
+
+#[tokio::test]
+async fn test_chat_stream_capture_content_ok() -> TestResult<()> {
+	if std::env::var("OLLAMA_API_KEY").is_err() {
+		println!("Skipping test_chat_stream_capture_content_ok: OLLAMA_API_KEY not set");
+		return Ok(());
+	}
+	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
+}
+
+#[tokio::test]
+async fn test_resolver_auth_ok() -> TestResult<()> {
+	if std::env::var("OLLAMA_API_KEY").is_err() {
+		println!("Skipping test_resolver_auth_ok: OLLAMA_API_KEY not set");
+		return Ok(());
+	}
+	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("OLLAMA_API_KEY")).await
+}
+
+#[tokio::test]
+async fn test_list_models() -> TestResult<()> {
+	if std::env::var("OLLAMA_API_KEY").is_err() {
+		println!("Skipping test_list_models: OLLAMA_API_KEY not set");
+		return Ok(());
+	}
+	common_tests::common_test_list_models(AdapterKind::OllamaCloud, "gpt-oss:120b").await
+}

--- a/tests/tests_yakbak_ollama_cloud.rs
+++ b/tests/tests_yakbak_ollama_cloud.rs
@@ -1,0 +1,42 @@
+//! Replay integration tests for the Ollama Cloud adapter.
+//!
+//! These tests use pre-recorded cassettes from `tests/data/yakbak/ollama_cloud/`
+//! and assert that Ollama-native streaming content and stop reasons replay
+//! correctly for the hosted Ollama Cloud backend.
+
+mod support;
+
+use genai::chat::*;
+use support::yakbak::replay_client;
+use support::{TestResult, extract_stream_end};
+
+#[tokio::test]
+async fn test_yakbak_ollama_cloud_simple_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("ollama_cloud", "simple_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default().with_capture_content(true).with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("ollama_cloud::gemma3:4b", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	assert_eq!(
+		extract.content.as_deref(),
+		Some(
+			"The sky appears blue due to a phenomenon called Rayleigh scattering, where shorter wavelengths of sunlight (blue and violet) are scattered more by the Earth’s atmosphere than longer wavelengths like red and orange."
+		),
+		"Text should match recorded response exactly"
+	);
+
+	assert_eq!(
+		extract.stream_end.captured_stop_reason,
+		Some(StopReason::Completed("stop".to_string()))
+	);
+
+	Ok(())
+}

--- a/tests/tests_yakbak_record.rs
+++ b/tests/tests_yakbak_record.rs
@@ -6,7 +6,7 @@
 //!
 //! ```sh
 //! # Record all providers (need all keys):
-//! OPENAI_API_KEY=... GEMINI_API_KEY=... GITHUB_TOKEN=... cargo test --test tests_yakbak_record -- --ignored
+//! OPENAI_API_KEY=... GEMINI_API_KEY=... GITHUB_TOKEN=... OLLAMA_API_KEY=... cargo test --test tests_yakbak_record -- --ignored
 //!
 //! # Record only Gemini scenarios:
 //! GEMINI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored record_gemini
@@ -17,11 +17,14 @@
 //! # Record only GitHub Copilot scenarios:
 //! GITHUB_TOKEN=... cargo test --test tests_yakbak_record -- --ignored record_github_copilot
 //!
+//! # Record only Ollama Cloud scenarios:
+//! OLLAMA_API_KEY=... cargo test --test tests_yakbak_record -- --ignored record_ollama_cloud
+//!
 //! # Record a single scenario by name:
 //! GEMINI_API_KEY=... cargo test --test tests_yakbak_record -- --ignored record_gemini_thinking_stream
 //! ```
 //!
-//! Optional env vars for custom endpoints: `OPENAI_BASE_URL`, `GEMINI_BASE_URL`, `GITHUB_COPILOT_BASE_URL`.
+//! Optional env vars for custom endpoints: `OPENAI_BASE_URL`, `GEMINI_BASE_URL`, `GITHUB_COPILOT_BASE_URL`, `OLLAMA_CLOUD_BASE_URL`.
 //!
 //! Each test records a response cassette to `tests/data/yakbak/{provider}/{scenario}/`.
 
@@ -192,4 +195,32 @@ fn seed_tool_request() -> ChatRequest {
 		},
 		"required": ["city", "country", "unit"],
 	})))
+}
+
+fn ollama_cloud_backend() -> String {
+	std::env::var("OLLAMA_CLOUD_BASE_URL").unwrap_or_else(|_| "https://ollama.com/".to_string())
+}
+
+const OLLAMA_CLOUD_MODEL: &str = "ollama_cloud::gemma3:4b";
+
+#[tokio::test]
+#[ignore]
+async fn record_ollama_cloud_simple_stream() -> TestResult<()> {
+	let (client, mut server) = record_client("ollama_cloud", "simple_stream", &ollama_cloud_backend()).await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default().with_capture_content(true);
+
+	let stream_res = client.exec_chat_stream(OLLAMA_CLOUD_MODEL, chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+	eprintln!(
+		"[record] Stream content: {:?}",
+		extract.content.as_deref().map(|s| &s[..s.len().min(80)])
+	);
+
+	server.shutdown().await;
+	Ok(())
 }


### PR DESCRIPTION
Adds an `OllamaCloud` adapter for Ollama's cloud API (https://ollama.com).

Delegates to the existing `OllamaAdapter` and injects Bearer token auth. No changes to the local Ollama adapter.

Includes integration tests, yakbak replay tests, example, docs updates, and CI workflow.

Closes #202