### PR TITLE
fix: use BTreeMap for deterministic tool-call ordering in openai_resp streamer

### DIFF
--- a/src/adapter/adapters/openai_resp/streamer.rs
+++ b/src/adapter/adapters/openai_resp/streamer.rs
@@ -6,7 +6,7 @@ use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use value_ext::JsonValueExt;
@@ -20,7 +20,7 @@ pub struct OpenAIRespStreamer {
 	done: bool,
 	captured_data: StreamerCapturedData,
 
-	in_progress_tool_calls: HashMap<usize, ToolCall>,
+	in_progress_tool_calls: BTreeMap<usize, ToolCall>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -88,7 +88,7 @@ impl OpenAIRespStreamer {
 			done: false,
 			options: StreamerOptions::new(model_iden, options_set),
 			captured_data: Default::default(),
-			in_progress_tool_calls: HashMap::new(),
+			in_progress_tool_calls: BTreeMap::new(),
 		}
 	}
 }
@@ -187,7 +187,7 @@ impl futures::Stream for OpenAIRespStreamer {
 							}
 
 							let mut tool_calls = Vec::new();
-							for (_, mut tc) in self.in_progress_tool_calls.drain() {
+							for (_, mut tc) in std::mem::take(&mut self.in_progress_tool_calls) {
 								// Parse arguments if they are strings
 								if let Some(args_str) = tc.fn_arguments.as_str()
 									&& let Ok(args_val) = serde_json::from_str(args_str)

--- a/tests/data/yakbak/openai_resp/multi_tool_ordering/response_000.txt
+++ b/tests/data/yakbak/openai_resp/multi_tool_ordering/response_000.txt
@@ -1,0 +1,52 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_multi_tool_order_test_001","object":"response","created_at":1774920000,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant. Use tools when needed.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"reasoning":{"effort":"low","summary":"detailed"},"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_multi_tool_order_test_001","object":"response","created_at":1774920000,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant. Use tools when needed.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"reasoning":{"effort":"low","summary":"detailed"},"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"rs_reasoning_001","type":"reasoning","encrypted_content":"fakeEncryptedContent","summary":[]},"output_index":0,"sequence_number":2}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"rs_reasoning_001","type":"reasoning","encrypted_content":"fakeEncryptedContent","summary":[]},"output_index":0,"sequence_number":3}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"fc_tool_1","type":"function_call","status":"in_progress","arguments":"","call_id":"call_weather_001","name":"get_weather"},"output_index":1,"sequence_number":4}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"{\"city\":\"Paris\",\"country\":\"France\",\"unit\":\"C\"}","item_id":"fc_tool_1","output_index":1,"sequence_number":5}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","arguments":"{\"city\":\"Paris\",\"country\":\"France\",\"unit\":\"C\"}","item_id":"fc_tool_1","output_index":1,"sequence_number":6}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"fc_tool_1","type":"function_call","status":"completed","arguments":"{\"city\":\"Paris\",\"country\":\"France\",\"unit\":\"C\"}","call_id":"call_weather_001","name":"get_weather"},"output_index":1,"sequence_number":7}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"fc_tool_2","type":"function_call","status":"in_progress","arguments":"","call_id":"call_time_002","name":"get_time"},"output_index":2,"sequence_number":8}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"{\"timezone\":\"Europe/Paris\"}","item_id":"fc_tool_2","output_index":2,"sequence_number":9}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","arguments":"{\"timezone\":\"Europe/Paris\"}","item_id":"fc_tool_2","output_index":2,"sequence_number":10}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"fc_tool_2","type":"function_call","status":"completed","arguments":"{\"timezone\":\"Europe/Paris\"}","call_id":"call_time_002","name":"get_time"},"output_index":2,"sequence_number":11}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"fc_tool_3","type":"function_call","status":"in_progress","arguments":"","call_id":"call_currency_003","name":"get_currency"},"output_index":3,"sequence_number":12}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","delta":"{\"from\":\"USD\",\"to\":\"EUR\",\"amount\":100}","item_id":"fc_tool_3","output_index":3,"sequence_number":13}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","arguments":"{\"from\":\"USD\",\"to\":\"EUR\",\"amount\":100}","item_id":"fc_tool_3","output_index":3,"sequence_number":14}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"fc_tool_3","type":"function_call","status":"completed","arguments":"{\"from\":\"USD\",\"to\":\"EUR\",\"amount\":100}","call_id":"call_currency_003","name":"get_currency"},"output_index":3,"sequence_number":15}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_multi_tool_order_test_001","object":"response","created_at":1774920000,"status":"completed","background":false,"completed_at":1774920002,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant. Use tools when needed.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[{"id":"rs_reasoning_001","type":"reasoning","encrypted_content":"fakeEncryptedContent","summary":[]},{"id":"fc_tool_1","type":"function_call","status":"completed","arguments":"{\"city\":\"Paris\",\"country\":\"France\",\"unit\":\"C\"}","call_id":"call_weather_001","name":"get_weather"},{"id":"fc_tool_2","type":"function_call","status":"completed","arguments":"{\"timezone\":\"Europe/Paris\"}","call_id":"call_time_002","name":"get_time"},{"id":"fc_tool_3","type":"function_call","status":"completed","arguments":"{\"from\":\"USD\",\"to\":\"EUR\",\"amount\":100}","call_id":"call_currency_003","name":"get_currency"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"reasoning":{"effort":"low","summary":"detailed"},"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":150,"input_tokens_details":{"cached_tokens":0},"output_tokens":80,"output_tokens_details":{"reasoning_tokens":10},"total_tokens":230},"user":null,"metadata":{}},"sequence_number":16}
+
+

--- a/tests/tests_yakbak_openai_resp.rs
+++ b/tests/tests_yakbak_openai_resp.rs
@@ -146,3 +146,96 @@ async fn test_yakbak_openai_resp_utf8_chunking_bug() -> TestResult<()> {
 
 	Ok(())
 }
+
+/// Regression test: tool calls from a streamed response must be returned in the
+/// same order as their `output_index` from the SSE stream.
+///
+/// Before the fix, `HashMap::drain()` yielded entries in arbitrary hash-bucket
+/// order, so the final `Vec<ToolCall>` could be shuffled across runs even though
+/// the input stream was identical.  Replacing `HashMap` with `BTreeMap` (keyed by
+/// `output_index`) guarantees sorted iteration order.
+///
+/// This cassette contains 3 parallel tool calls at output indices 1, 2, 3:
+///   1 → get_weather(city=Paris, country=France, unit=C)
+///   2 → get_time(timezone=Europe/Paris)
+///   3 → get_currency(from=USD, to=EUR, amount=100)
+#[tokio::test]
+async fn test_yakbak_openai_resp_multi_tool_ordering() -> TestResult<()> {
+	let (client, _server) = replay_client("openai_resp", "multi_tool_ordering").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("You are a helpful assistant. Use tools when needed."),
+		ChatMessage::user("What's the weather, time, and USD→EUR rate for Paris?"),
+	])
+	.append_tool(Tool::new("get_weather").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"city":    { "type": "string" },
+			"country": { "type": "string" },
+			"unit":    { "type": "string", "enum": ["C", "F"] }
+		},
+		"required": ["city", "country", "unit"]
+	})))
+	.append_tool(Tool::new("get_time").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"timezone": { "type": "string" }
+		},
+		"required": ["timezone"]
+	})))
+	.append_tool(Tool::new("get_currency").with_schema(json!({
+		"type": "object",
+		"properties": {
+			"from":   { "type": "string" },
+			"to":     { "type": "string" },
+			"amount": { "type": "number" }
+		},
+		"required": ["from", "to", "amount"]
+	})));
+
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_tool_calls(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("openai_resp::gpt-5.4-mini", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// -- Exactly 3 tool calls
+	let tool_calls = extract.stream_end.captured_tool_calls().ok_or("Should have tool calls")?;
+	assert_eq!(tool_calls.len(), 3, "Expected exactly 3 tool calls");
+
+	// -- Tool call 0: get_weather (output_index 1)
+	assert_eq!(tool_calls[0].fn_name, "get_weather");
+	assert_eq!(tool_calls[0].call_id, "call_weather_001");
+	assert_eq!(
+		tool_calls[0].fn_arguments,
+		json!({"city": "Paris", "country": "France", "unit": "C"})
+	);
+
+	// -- Tool call 1: get_time (output_index 2)
+	assert_eq!(tool_calls[1].fn_name, "get_time");
+	assert_eq!(tool_calls[1].call_id, "call_time_002");
+	assert_eq!(
+		tool_calls[1].fn_arguments,
+		json!({"timezone": "Europe/Paris"})
+	);
+
+	// -- Tool call 2: get_currency (output_index 3)
+	assert_eq!(tool_calls[2].fn_name, "get_currency");
+	assert_eq!(tool_calls[2].call_id, "call_currency_003");
+	assert_eq!(
+		tool_calls[2].fn_arguments,
+		json!({"from": "USD", "to": "EUR", "amount": 100})
+	);
+
+	// -- Usage
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(150));
+	assert_eq!(usage.completion_tokens, Some(80));
+	assert_eq!(usage.total_tokens, Some(230));
+
+	Ok(())
+}


### PR DESCRIPTION
HashMap.drain() yields entries in arbitrary hash-bucket order, causing nondeterministic tool-call ordering across program runs even with identical input streams. Replace with BTreeMap keyed by output_index to guarantee sorted iteration order.

Adds regression test with 3 parallel tool calls asserting exact positional ordering, call IDs, and argument payloads.