### PR TITLE
remote ollama example + `all_model_names` update

### DIFF
--- a/examples/c05-model-names.rs
+++ b/examples/c05-model-names.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	for &kind in KINDS {
 		println!("\n--- Models for {kind}");
-		let models = client.all_model_names(kind).await?;
+		let models = client.all_model_names(kind, None).await?;
 		println!("{models:?}");
 	}
 

--- a/examples/c99-remote-ollama.rs
+++ b/examples/c99-remote-ollama.rs
@@ -1,0 +1,75 @@
+//! This example demonstrates how to use a custom ServiceTargetResolver to
+//! point the genai Client to a remote (non-localhost) Ollama instance.
+
+use genai::adapter::AdapterKind;
+use genai::chat::{ChatMessage, ChatOptions, ChatRequest};
+use genai::resolver::{Endpoint, ServiceTargetResolver};
+use genai::{Client, ModelIden, ServiceTarget};
+use tracing_subscriber::EnvFilter;
+
+// Use a model you have pulled on your remote Ollama server
+const MODEL: &str = "gpt-oss:120b";
+const REMOTE_URL: &str = "http://XXX.XX.XX.XX:11434/"; // Change this to the address of your remote
+// instance.
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	tracing_subscriber::fmt().with_env_filter(EnvFilter::new("genai=debug")).init();
+
+	let questions = &[
+		// Follow-up questions
+		"Why is the sky blue?",
+		"Why is it red sometimes?",
+	];
+
+	// -- Build a target_resolver for Remote Ollama
+	let target_resolver = ServiceTargetResolver::from_resolver_fn(
+		|service_target: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
+			// Destructure to keep the original auth (Ollama usually has no auth)
+			let ServiceTarget { auth, model, .. } = service_target;
+
+			// 1. Define your custom remote endpoint
+			// Make sure to include the /api/ suffix which Ollama uses
+			let endpoint = Endpoint::from_static(REMOTE_URL);
+
+			// 2. Force the client to use the Ollama Adapter
+			let model = ModelIden::new(AdapterKind::Ollama, model.model_name);
+
+			Ok(ServiceTarget { endpoint, auth, model })
+		},
+	);
+
+	// -- Build the new client with this target_resolver
+	let client = Client::builder().with_service_target_resolver(target_resolver).build();
+	let service_target = ServiceTarget {
+		endpoint: Endpoint::from_static(REMOTE_URL),
+		auth: genai::resolver::AuthData::None,
+		model: ModelIden::new(AdapterKind::Ollama, MODEL),
+	};
+	let all_models = client.all_model_names(AdapterKind::Ollama, Some(service_target)).await?;
+	println!("Found models: {all_models:?}");
+
+	// -- Normalize the eventual reasoning content
+	let chat_options = ChatOptions::default().with_normalize_reasoning_content(true);
+
+	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
+
+	for &question in questions {
+		chat_req = chat_req.append_message(ChatMessage::user(question));
+
+		println!("\n--- Question:\n{question}");
+		let chat_res = client.exec_chat(MODEL, chat_req.clone(), Some(&chat_options)).await?;
+
+		if let Some(reasoning_content) = chat_res.reasoning_content.as_deref() {
+			println!("\n--- Reasoning:\n{reasoning_content}")
+		}
+
+		println!("\n--- Answer: ");
+		let assistant_answer = chat_res.first_text().ok_or("Should have response")?;
+		println!("{assistant_answer}");
+
+		chat_req = chat_req.append_message(ChatMessage::assistant(assistant_answer));
+	}
+
+	Ok(())
+}

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -21,8 +21,16 @@ impl Client {
 	///
 	/// - Adapters should filter non-chat models until more skills are supported.
 	///   Future: `model_names(adapter_kind, Option<&[Skill]>)`.
-	pub async fn all_model_names(&self, adapter_kind: AdapterKind) -> Result<Vec<String>> {
-		let (auth, endpoint) = self.config().resolve_adapter_config(adapter_kind).await?;
+	pub async fn all_model_names(
+		&self,
+		adapter_kind: AdapterKind,
+		service_target: Option<ServiceTarget>,
+	) -> Result<Vec<String>> {
+		let (auth, endpoint) = if let Some(ServiceTarget { endpoint, auth, .. }) = service_target {
+			(auth, endpoint)
+		} else {
+			self.config().resolve_adapter_config(adapter_kind).await?
+		};
 		let models = AdapterDispatcher::all_model_names(adapter_kind, endpoint, auth).await?;
 		Ok(models)
 	}

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -1026,7 +1026,7 @@ pub async fn common_test_list_models(adapter_kind: AdapterKind, contains: &str) 
 	let client = Client::default();
 
 	// -- Exec
-	let models = client.all_model_names(adapter_kind).await?;
+	let models = client.all_model_names(adapter_kind, None).await?;
 
 	// -- Check
 	assert_contains(&models, contains);


### PR DESCRIPTION
Hello!

This PR fixes an issue with the `all_model_names` method on the `Client` struct when using a remote (non-localhost) Ollama instance. Currently, the method uses the default endpoint and therefore only lists local models.

**What's included:**
* **The Fix:** I updated `all_model_names` to take an additional argument, `service_target: Option<ServiceTarget>`, which can hold the custom endpoint.
* **New Example:** I included an example to see it in action, closely related to the `c06-target-resolver.rs` example. (That example works for remote Ollama, but `all_model_names` does not, hence this PR).

I realize adding the argument changes the method signature, so I'm very open to feedback if there is a more elegant way you'd prefer to handle this.

I skipped opening an issue since I thought I could put together the fix myself, but I'm happy to discuss if this needs tweaking.
Thanks for your time!