### PR TITLE
client: ClientBuilder::with_default_adapter_kind for explicit provider intent

### DIFF
--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -256,7 +256,7 @@ impl AdapterKind {
 
 /// Inner api to return
 impl AdapterKind {
-	fn from_model_namespace(model: &str) -> Option<Self> {
+	pub(crate) fn from_model_namespace(model: &str) -> Option<Self> {
 		let (namespace, _) = ModelName::split_as_namespace_and_name(model);
 		let namespace = namespace?;
 

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,3 +1,4 @@
+use crate::adapter::AdapterKind;
 use crate::chat::ChatOptions;
 use crate::resolver::{
 	AuthResolver, IntoAuthResolverFn, IntoModelMapperFn, IntoServiceTargetResolverFn, ModelMapper,
@@ -92,6 +93,19 @@ impl ClientBuilder {
 		let client_config = self.config.get_or_insert_with(ClientConfig::default);
 		let model_mapper = ModelMapper::from_mapper_fn(model_mapper_fn);
 		client_config.model_mapper = Some(model_mapper);
+		self
+	}
+
+	/// Set a default [`AdapterKind`] for resolving bare model names (creates
+	/// `ClientConfig` if absent).
+	///
+	/// See [`ClientConfig::with_default_adapter_kind`] for details. Useful
+	/// when you've already pinned the provider via auth / service-target
+	/// resolvers and want unrecognized model names to route through that
+	/// provider instead of falling back to Ollama.
+	pub fn with_default_adapter_kind(mut self, adapter_kind: AdapterKind) -> Self {
+		let client_config = self.config.get_or_insert_with(ClientConfig::default);
+		client_config.default_adapter_kind = Some(adapter_kind);
 		self
 	}
 }

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -14,6 +14,7 @@ pub struct ClientConfig {
 	pub(super) web_config: Option<WebConfig>,
 	pub(super) chat_options: Option<ChatOptions>,
 	pub(super) embed_options: Option<EmbedOptions>,
+	pub(super) default_adapter_kind: Option<AdapterKind>,
 }
 
 /// Chainable setters related to the ClientConfig.
@@ -60,6 +61,24 @@ impl ClientConfig {
 		self
 	}
 
+	/// Sets a default [`AdapterKind`] for resolving a bare model name.
+	///
+	/// When set, calls like `client.exec_chat("some-model", ...)` skip the
+	/// `AdapterKind::from_model` heuristic (which falls back to `Ollama` for
+	/// unrecognized names) and use the configured adapter instead. Useful
+	/// for callers that have already expressed provider intent via
+	/// `AuthResolver` / `ServiceTargetResolver` and want their custom model
+	/// names to route through the chosen provider rather than the Ollama
+	/// fallback.
+	///
+	/// Explicit namespacing (`openai::some-model`) and `ModelSpec::Iden`
+	/// calls are unaffected — they continue to take precedence over the
+	/// default.
+	pub fn with_default_adapter_kind(mut self, adapter_kind: AdapterKind) -> Self {
+		self.default_adapter_kind = Some(adapter_kind);
+		self
+	}
+
 	/// Returns the WebConfig, if set.
 	pub fn web_config(&self) -> Option<&WebConfig> {
 		self.web_config.as_ref()
@@ -91,6 +110,11 @@ impl ClientConfig {
 	/// Returns the default EmbedOptions, if set.
 	pub fn embed_options(&self) -> Option<&EmbedOptions> {
 		self.embed_options.as_ref()
+	}
+
+	/// Returns the default [`AdapterKind`] for bare model names, if set.
+	pub fn default_adapter_kind(&self) -> Option<AdapterKind> {
+		self.default_adapter_kind
 	}
 }
 
@@ -199,7 +223,15 @@ impl ClientConfig {
 	pub async fn resolve_model_spec(&self, spec: ModelSpec) -> Result<ServiceTarget> {
 		match spec {
 			ModelSpec::Name(name) => {
-				let adapter_kind = AdapterKind::from_model(&name)?;
+				// If the caller set a default adapter on the client, let it
+				// win over model-name inference — but only when the name is
+				// not explicitly namespaced (e.g. `openai::some-model`).
+				// Namespaced names always take precedence so a single client
+				// can still target multiple providers when desired.
+				let adapter_kind = match (self.default_adapter_kind, AdapterKind::from_model_namespace(&name)) {
+					(Some(default), None) => default,
+					_ => AdapterKind::from_model(&name)?,
+				};
 				let model = ModelIden::new(adapter_kind, name);
 				self.resolve_service_target(model).await
 			}


### PR DESCRIPTION
## Summary

Adds `ClientBuilder::with_default_adapter_kind(kind)` to let a caller pin an authoritative default adapter on the client, so `client.exec_chat("some-model", …)` skips the `AdapterKind::from_model` heuristic (which falls back to `Ollama` for unrecognized names) and uses the configured adapter instead. Opt-in; default behavior is unchanged.

## Motivation

A caller configures `AuthResolver` + `ServiceTargetResolver` scoped to, say, `AdapterKind::OpenAI`, and points at a custom `base_url` — MiniMax, Together, OpenRouter, DeepSeek, a self-hosted vLLM, any gateway that speaks the OpenAI Chat Completions wire protocol. Then:

```rust
let client = Client::builder()
    .with_auth_resolver(/* key, scoped to OpenAI */)
    .with_service_target_resolver(/* endpoint = "https://api.minimax.io/v1", scoped to OpenAI */)
    .build();

client.exec_chat("MiniMax-M2.7", req, opts).await?;
```

`AdapterKind::from_model("MiniMax-M2.7")` returns `AdapterKind::Ollama` via the fallback. The resolvers are scoped to `AdapterKind::OpenAI`, so both gates miss, both overrides drop, and the request silently routes to the default Ollama endpoint (`localhost:11434`) with no auth. From the caller's perspective, the `base_url` override "didn't work" — hard to debug without reading resolver internals.

Users today can work around it with `openai::MiniMax-M2.7` prefix namespacing, but:
1. It's not discoverable — a fresh caller has no reason to suspect it.
2. The fallback-to-Ollama behavior is a correctness trap, not a hint.
3. When a client is already scoped to one provider at construction time, forcing the user to re-declare the adapter on every `exec_chat` call duplicates intent.

## Change

```rust
let client = Client::builder()
    .with_default_adapter_kind(AdapterKind::OpenAI)
    .with_auth_resolver(/* ... */)
    .with_service_target_resolver(/* ... */)
    .build();

client.exec_chat("MiniMax-M2.7", req, opts).await?;  // now routes correctly
```

- `ClientConfig::default_adapter_kind: Option<AdapterKind>` field + `with_default_adapter_kind` setter + getter.
- `ClientBuilder::with_default_adapter_kind(kind)` passthrough.
- `resolve_model_spec` — for the `ModelSpec::Name` branch, if the default is set and the name is not explicitly namespaced, use the default; otherwise fall back to `AdapterKind::from_model` as before.
- `AdapterKind::from_model_namespace` bumped from `fn` to `pub(crate)` so `resolve_model_spec` can consult it before applying the default. Preserves the existing precedence: explicit namespacing (`openai::some-model`) and `ModelSpec::Iden` calls always win over the client's default.

## Back-compat

Default is `None`, so existing behavior is unchanged for every caller that doesn't opt in. The change is strictly additive.

## Tests

All 61 existing library tests pass. Happy to add a dedicated test for the new path if you'd like — point me at the style you prefer (`tests/` integration test vs inline `#[cfg(test)]`).

## Context

I maintain `genai-pyo3` (the Python bindings for `genai`), and this issue surfaced through a downstream user trying to target MiniMax via the OpenAI-compatible adapter. They'd written ~180 lines of aiohttp as a workaround before we traced the root cause here. I'm running the fork (`ropoctl/rust-genai`, branch `feat/default-adapter-kind`, same commit as this PR) in `genai-pyo3 v0.1.10` in the interim. Happy to flip back to the upstream crate as soon as this lands.
