### PR TITLE
client: ClientBuilder::with_adapter_kind — bind a Client to one adapter

### DIFF
--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -256,7 +256,7 @@ impl AdapterKind {
 
 /// Inner api to return
 impl AdapterKind {
-	fn from_model_namespace(model: &str) -> Option<Self> {
+	pub(crate) fn from_model_namespace(model: &str) -> Option<Self> {
 		let (namespace, _) = ModelName::split_as_namespace_and_name(model);
 		let namespace = namespace?;
 

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,3 +1,4 @@
+use crate::adapter::AdapterKind;
 use crate::chat::ChatOptions;
 use crate::resolver::{
 	AuthResolver, IntoAuthResolverFn, IntoModelMapperFn, IntoServiceTargetResolverFn, ModelMapper,
@@ -92,6 +93,19 @@ impl ClientBuilder {
 		let client_config = self.config.get_or_insert_with(ClientConfig::default);
 		let model_mapper = ModelMapper::from_mapper_fn(model_mapper_fn);
 		client_config.model_mapper = Some(model_mapper);
+		self
+	}
+
+	/// Bind the Client to a single [`AdapterKind`] (creates `ClientConfig` if absent).
+	///
+	/// See [`ClientConfig::with_adapter_kind`] for semantics. Short version:
+	/// a Client whose `AuthResolver` / `ServiceTargetResolver` are gated on an
+	/// adapter is already physically single-provider; this makes that
+	/// constraint explicit and drives routing directly instead of inferring
+	/// the adapter from the model name on every call.
+	pub fn with_adapter_kind(mut self, adapter_kind: AdapterKind) -> Self {
+		let client_config = self.config.get_or_insert_with(ClientConfig::default);
+		client_config.adapter_kind = Some(adapter_kind);
 		self
 	}
 }

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -27,6 +27,19 @@ impl Client {
 		Ok(models)
 	}
 
+	/// Returns the bound [`AdapterKind`] for this Client, if any.
+	///
+	/// Set via [`ClientBuilder::with_adapter_kind`] at construction
+	/// time — `None` for Clients that did not opt into the bound
+	/// shape and still use per-call model-name inference. Useful for
+	/// callers that want to introspect a Client without tracking the
+	/// provider in parallel state.
+	///
+	/// [`ClientBuilder::with_adapter_kind`]: crate::ClientBuilder::with_adapter_kind
+	pub fn adapter_kind(&self) -> Option<AdapterKind> {
+		self.config().adapter_kind()
+	}
+
 	/// Builds a ModelIden by inferring AdapterKind from the model name.
 	pub fn default_model(&self, model_name: &str) -> Result<ModelIden> {
 		// -- First get the default ModelInfo

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -14,6 +14,7 @@ pub struct ClientConfig {
 	pub(super) web_config: Option<WebConfig>,
 	pub(super) chat_options: Option<ChatOptions>,
 	pub(super) embed_options: Option<EmbedOptions>,
+	pub(super) adapter_kind: Option<AdapterKind>,
 }
 
 /// Chainable setters related to the ClientConfig.
@@ -60,6 +61,33 @@ impl ClientConfig {
 		self
 	}
 
+	/// Binds this Client to a single [`AdapterKind`].
+	///
+	/// A Client that has configured an [`AuthResolver`] or [`ServiceTargetResolver`]
+	/// scoped to a specific adapter is *already* physically single-provider: both
+	/// resolvers gate on `adapter_kind`, so any call that routes through a
+	/// different adapter silently drops auth and the configured endpoint. Setting
+	/// `adapter_kind` on the Client makes that constraint explicit and drives
+	/// routing directly, bypassing the [`AdapterKind::from_model`] name-sniffing
+	/// heuristic (which falls back to Ollama for unrecognized names).
+	///
+	/// When set:
+	/// - [`ModelSpec::Name`] routes through this adapter. A `::` namespace prefix
+	///   or other embedded adapter reference is a usage error (see
+	///   [`Error::AdapterKindMismatch`]).
+	/// - [`ModelSpec::Iden`] must carry the same adapter; otherwise returns
+	///   [`Error::AdapterKindMismatch`] instead of silently producing a
+	///   misconfigured request.
+	/// - [`ModelSpec::Target`] is passed through unchanged (callers handing in a
+	///   fully-resolved target have already opted out of Client-level routing).
+	///
+	/// Leave unset for the classic multi-provider shape (route per-call by model
+	/// name).
+	pub fn with_adapter_kind(mut self, adapter_kind: AdapterKind) -> Self {
+		self.adapter_kind = Some(adapter_kind);
+		self
+	}
+
 	/// Returns the WebConfig, if set.
 	pub fn web_config(&self) -> Option<&WebConfig> {
 		self.web_config.as_ref()
@@ -91,6 +119,11 @@ impl ClientConfig {
 	/// Returns the default EmbedOptions, if set.
 	pub fn embed_options(&self) -> Option<&EmbedOptions> {
 		self.embed_options.as_ref()
+	}
+
+	/// Returns the bound [`AdapterKind`], if set via [`Self::with_adapter_kind`].
+	pub fn adapter_kind(&self) -> Option<AdapterKind> {
+		self.adapter_kind
 	}
 }
 
@@ -188,23 +221,195 @@ impl ClientConfig {
 
 	/// Resolves a [`ModelSpec`] to a [`ServiceTarget`].
 	///
-	/// The resolution behavior depends on the variant:
+	/// The resolution behavior depends on the variant and on whether the
+	/// Client has been bound to an adapter via [`Self::with_adapter_kind`]:
 	///
-	/// - [`ModelSpec::Name`]: Infers adapter from name, then applies full resolution
-	///   (model mapper, auth resolver, service target resolver).
+	/// - [`ModelSpec::Name`]: if a bound adapter is set, routes the bare
+	///   name through it (a `::` namespace prefix in the name is rejected as
+	///   [`Error::AdapterKindMismatch`] when it would resolve to a different
+	///   adapter). Otherwise infers adapter from the name.
 	///
-	/// - [`ModelSpec::Iden`]: Skips adapter inference, applies full resolution.
+	/// - [`ModelSpec::Iden`]: if a bound adapter is set and differs from the
+	///   Iden's adapter, returns [`Error::AdapterKindMismatch`]. Otherwise
+	///   proceeds with the Iden as given.
 	///
-	/// - [`ModelSpec::Target`]: Returns the target directly, running only the service target resolver.
+	/// - [`ModelSpec::Target`]: returns the target directly, running only
+	///   the service target resolver. A fully-resolved target has already
+	///   opted out of Client-level routing.
 	pub async fn resolve_model_spec(&self, spec: ModelSpec) -> Result<ServiceTarget> {
 		match spec {
 			ModelSpec::Name(name) => {
-				let adapter_kind = AdapterKind::from_model(&name)?;
+				let resolved = AdapterKind::from_model(&name)?;
+				let adapter_kind = match self.adapter_kind {
+					Some(bound) => {
+						// If the name carries an explicit `::` namespace that
+						// resolves to a different adapter, that's a
+						// misconfiguration: the bound Client's resolvers
+						// won't fire for it. Reject loudly.
+						if resolved != bound && AdapterKind::from_model_namespace(&name).is_some() {
+							return Err(Error::AdapterKindMismatch {
+								bound,
+								requested: resolved,
+								model: name.to_string(),
+							});
+						}
+						bound
+					}
+					None => resolved,
+				};
 				let model = ModelIden::new(adapter_kind, name);
 				self.resolve_service_target(model).await
 			}
-			ModelSpec::Iden(model) => self.resolve_service_target(model).await,
+			ModelSpec::Iden(model) => {
+				if let Some(bound) = self.adapter_kind
+					&& model.adapter_kind != bound
+				{
+					return Err(Error::AdapterKindMismatch {
+						bound,
+						requested: model.adapter_kind,
+						model: model.model_name.to_string(),
+					});
+				}
+				self.resolve_service_target(model).await
+			}
 			ModelSpec::Target(target) => self.run_service_target_resolver(target).await,
 		}
 	}
 }
+
+// region:    --- Tests
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::resolver::{AuthData, AuthResolver, Endpoint, ServiceTargetResolver};
+
+	/// Build a ClientConfig bound to the given adapter, with an
+	/// auth/service-target resolver pair gated on that same adapter —
+	/// mirroring the real-world configuration shape this feature is meant
+	/// to model. The service_target_resolver records the adapter it
+	/// received so tests can assert routing landed where expected.
+	fn bound_config(adapter_kind: AdapterKind, observed_endpoint: &'static str) -> ClientConfig {
+		ClientConfig::default()
+			.with_adapter_kind(adapter_kind)
+			.with_auth_resolver(AuthResolver::from_resolver_fn(
+				move |model_iden: ModelIden| -> std::result::Result<Option<AuthData>, crate::resolver::Error> {
+					if model_iden.adapter_kind == adapter_kind {
+						Ok(Some(AuthData::from_single("test-key")))
+					} else {
+						// Simulate the real-world gating: mismatched adapter
+						// gets no auth — which is exactly the silent failure
+						// that motivated this feature.
+						Ok(None)
+					}
+				},
+			))
+			.with_service_target_resolver(ServiceTargetResolver::from_resolver_fn(
+				move |mut service_target: crate::ServiceTarget| -> std::result::Result<crate::ServiceTarget, crate::resolver::Error> {
+					if service_target.model.adapter_kind == adapter_kind {
+						service_target.endpoint = Endpoint::from_static(observed_endpoint);
+					}
+					Ok(service_target)
+				},
+			))
+	}
+
+	#[tokio::test]
+	async fn bound_client_routes_bare_name_through_bound_adapter() {
+		// `mini-max-m2.7` hits no prefix matcher — without a bound
+		// adapter it would fall through to Ollama. With `with_adapter_kind`,
+		// it must route through OpenAI instead.
+		let config = bound_config(AdapterKind::OpenAI, "https://custom.example/v1");
+		let target = config
+			.resolve_model_spec(ModelSpec::Name("mini-max-m2.7".into()))
+			.await
+			.expect("bound name should resolve");
+		assert_eq!(target.model.adapter_kind, AdapterKind::OpenAI);
+		assert_eq!(target.endpoint.base_url(), "https://custom.example/v1");
+	}
+
+	#[tokio::test]
+	async fn bound_client_rejects_mismatched_namespace() {
+		// Bound to OpenAI, but caller passes an explicit `anthropic::...`
+		// namespace. The resolvers would silently drop (no auth, default
+		// endpoint). Return AdapterKindMismatch instead.
+		let config = bound_config(AdapterKind::OpenAI, "https://custom.example/v1");
+		let err = config
+			.resolve_model_spec(ModelSpec::Name("anthropic::claude-3-5-sonnet".into()))
+			.await
+			.expect_err("mismatched namespace should error");
+		match err {
+			Error::AdapterKindMismatch { bound, requested, .. } => {
+				assert_eq!(bound, AdapterKind::OpenAI);
+				assert_eq!(requested, AdapterKind::Anthropic);
+			}
+			other => panic!("expected AdapterKindMismatch, got {other:?}"),
+		}
+	}
+
+	#[tokio::test]
+	async fn bound_client_accepts_matching_namespace() {
+		// Redundant but harmless: `openai::gpt-4` against a Client bound
+		// to OpenAI. The namespace matches, so the call proceeds normally.
+		let config = bound_config(AdapterKind::OpenAI, "https://custom.example/v1");
+		let target = config
+			.resolve_model_spec(ModelSpec::Name("openai::gpt-4".into()))
+			.await
+			.expect("matching namespace should resolve");
+		assert_eq!(target.model.adapter_kind, AdapterKind::OpenAI);
+	}
+
+	#[tokio::test]
+	async fn bound_client_rejects_mismatched_iden() {
+		// ModelSpec::Iden carries its own AdapterKind. If it disagrees
+		// with the bound one, same silent-drop failure mode — reject.
+		let config = bound_config(AdapterKind::OpenAI, "https://custom.example/v1");
+		let iden = ModelIden::new(AdapterKind::Gemini, "gemini-1.5-pro");
+		let err = config
+			.resolve_model_spec(ModelSpec::Iden(iden))
+			.await
+			.expect_err("mismatched iden should error");
+		assert!(matches!(
+			err,
+			Error::AdapterKindMismatch {
+				bound: AdapterKind::OpenAI,
+				requested: AdapterKind::Gemini,
+				..
+			}
+		));
+	}
+
+	#[tokio::test]
+	async fn unbound_client_preserves_inference() {
+		// No `with_adapter_kind` set → classic behavior. `gpt-4` should
+		// infer to OpenAI via the prefix matcher, and the service-target
+		// resolver (gated on OpenAI) should fire.
+		let config = bound_config(AdapterKind::OpenAI, "https://custom.example/v1");
+		// Strip the binding to simulate an unbound Client that still has
+		// resolvers attached (closest real-world unbound config).
+		let config = ClientConfig {
+			adapter_kind: None,
+			..config
+		};
+		let target = config
+			.resolve_model_spec(ModelSpec::Name("gpt-4".into()))
+			.await
+			.expect("unbound name should resolve via inference");
+		assert_eq!(target.model.adapter_kind, AdapterKind::OpenAI);
+	}
+
+	#[test]
+	fn bound_client_exposes_adapter_kind_via_getter() {
+		// `Client::adapter_kind()` is the introspection getter a
+		// caller uses to read the bound provider back off a built
+		// Client (without having to carry the AdapterKind alongside
+		// it). Set path returns Some, unset path returns None.
+		let bound = crate::Client::builder().with_adapter_kind(AdapterKind::OpenAI).build();
+		assert_eq!(bound.adapter_kind(), Some(AdapterKind::OpenAI));
+
+		let unbound = crate::Client::default();
+		assert_eq!(unbound.adapter_kind(), None);
+	}
+}
+
+// endregion: --- Tests

--- a/src/error.rs
+++ b/src/error.rs
@@ -136,6 +136,20 @@ Cause:\n{cause}
 	#[display("Adapter '{adapter_kind}' does not support feature '{feature}'")]
 	AdapterNotSupported { adapter_kind: AdapterKind, feature: String },
 
+	#[display(
+		"Client is bound to adapter '{bound}' but model '{model}' resolved to adapter '{requested}'. \
+A Client configured with `with_adapter_kind` targets a single provider — its \
+AuthResolver and ServiceTargetResolver are gated on that adapter, so routing \
+through a different one would silently drop auth and the configured endpoint. \
+Drop the `::` namespace prefix or `ModelSpec::Iden`, or build a Client without \
+`with_adapter_kind` for per-call routing."
+	)]
+	AdapterKindMismatch {
+		bound: AdapterKind,
+		requested: AdapterKind,
+		model: String,
+	},
+
 	#[display("Internal error: {_0}")]
 	Internal(String),
 


### PR DESCRIPTION
Supersedes #208. After @jeremychone's pushback on the `default_` / `fallback_` naming there, I re-examined what's actually happening and the answer is that "default" undersold it. This PR picks up the same motivation but reframes and sharpens the behavior.

## Observation

A `Client` whose `AuthResolver` and/or `ServiceTargetResolver` are scoped to a specific `AdapterKind` is already *physically* single-provider — both resolvers gate on `adapter_kind == X`:

```rust
.with_auth_resolver(AuthResolver::from_resolver_fn(move |iden: ModelIden| {
    if iden.adapter_kind == AdapterKind::OpenAI { Ok(Some(auth.clone())) } else { Ok(None) }
}))
.with_service_target_resolver(ServiceTargetResolver::from_resolver_fn(move |mut t| {
    if t.model.adapter_kind == AdapterKind::OpenAI { t.endpoint = custom_endpoint.clone(); }
    Ok(t)
}))
```

Any call whose resolved `adapter_kind` differs from what the resolvers expect silently drops both the auth and the custom endpoint. The request then hits an adapter default with no auth. From the caller's perspective this looks like "my base_url override didn't work" — hard to debug without reading resolver internals.

Today the routing decision is `AdapterKind::from_model(&name)` — a chain of hardcoded `starts_with` heuristics (`gpt-*`, `claude-*`, `gemini-*`, `grok-*`, `deepseek-chat`, `command-*`, `embed-*`, `glm-*`, `mimo-*`, `*fireworks*`, `o1/o3/o4`, `chatgpt`, `codex`, `text-embedding`) with Ollama as the catch-all. That heuristic works for the quick-start case (`exec_chat(\"gpt-4\", ...)` just works) but is:

- **Brittle to new model families** — a new OpenAI prefix silently routes to Ollama until a library update.
- **Wrong for proxies and gateways** — MiniMax, OpenRouter, DeepSeek gateways, self-hosted vLLM, Azure deployment names, any proxy serving the OpenAI wire protocol under a non-`gpt-*` name — all fall through to Ollama.
- **The wrong layer to decide** when the caller has already declared the provider via resolvers.

## Change

Let the caller declare the constraint directly:

```rust
let client = Client::builder()
    .with_adapter_kind(AdapterKind::OpenAI)
    .with_auth_resolver(/* ... */)
    .with_service_target_resolver(/* endpoint = \"https://proxy.example/v1\" */)
    .build();

client.exec_chat(\"MiniMax-M2.7\", req, opts).await?;  // routes via OpenAI — matches the resolvers
```

Routing behavior when `adapter_kind` is set:

| `ModelSpec` variant | Bound-adapter behavior |
|---|---|
| `Name(name)` | Routes through bound adapter. Bare names route directly; an explicit `::` namespace that resolves to a *different* adapter returns `Error::AdapterKindMismatch` (previously: silent drop). |
| `Iden(model)` | Bound adapter must match the Iden's `adapter_kind`; otherwise returns `Error::AdapterKindMismatch`. |
| `Target(target)` | Unchanged. A fully-resolved target has already opted out of Client-level routing. |

When `adapter_kind` is unset, behavior is **identical to before** — classic multi-provider-via-model-string, Ollama fallback included. Strictly additive.

## Error shape

```rust
Error::AdapterKindMismatch {
    bound: AdapterKind,
    requested: AdapterKind,
    model: String,
}
```

Display includes a pointer to either drop the `::` namespace or build a Client without `with_adapter_kind` for per-call routing.

## Tests

5 new unit tests in `src/client/config.rs`:

- `bound_client_routes_bare_name_through_bound_adapter` — `mini-max-m2.7` (hits no prefix matcher) routes through the bound OpenAI adapter and the custom-endpoint resolver fires.
- `bound_client_rejects_mismatched_namespace` — `anthropic::claude-*` against an OpenAI-bound Client → `AdapterKindMismatch { bound: OpenAI, requested: Anthropic, .. }`.
- `bound_client_accepts_matching_namespace` — redundant `openai::gpt-4` on an OpenAI-bound Client proceeds normally.
- `bound_client_rejects_mismatched_iden` — `ModelSpec::Iden(Gemini, ...)` on an OpenAI-bound Client → mismatch.
- `unbound_client_preserves_inference` — no `with_adapter_kind` set → `gpt-4` infers to OpenAI exactly as today.

All 61 existing library tests still pass (66 total with the new ones). No changes to integration tests.

## Exposed

- `ClientConfig::adapter_kind: Option<AdapterKind>` field
- `ClientConfig::with_adapter_kind(AdapterKind)` chainable setter
- `ClientConfig::adapter_kind()` getter
- `ClientBuilder::with_adapter_kind(AdapterKind)` passthrough
- `Error::AdapterKindMismatch { bound, requested, model }`
- `AdapterKind::from_model_namespace` bumped from `fn` to `pub(crate)` so the Name-path can detect a namespaced name and fill `requested` in the error.

## Back-compat

Default is `None`. Every caller that doesn't call `with_adapter_kind` sees zero behavior change.

## Context

I maintain `genai-pyo3` (the Python bindings). This issue first surfaced through a downstream user targeting MiniMax via the OpenAI-compatible adapter — they'd written ~180 lines of aiohttp as a workaround before we traced it to the silent Ollama fallback. I'm running this change on the `ropoctl/rust-genai` fork (`feat/bind-client-to-adapter-kind`) in `genai-pyo3 v0.1.13` in the interim. Happy to flip back to the upstream crate as soon as this lands.