### PR TITLE
Add chat extra_body passthrough

### DIFF
--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -202,11 +202,21 @@ impl OpenAIAdapter {
 			}
 		}
 
+		// -- Provider-specific payload extension
+		// Merged last so callers can intentionally override previously set fields.
+		if let Some(extra_body) = options_set.extra_body() {
+			payload.x_merge(extra_body.clone())?;
+		}
+
 		Ok(WebRequestData { url, headers, payload })
 	}
 
 	/// Note: Needs to be called from super::streamer as well
 	pub(super) fn into_usage(adapter: AdapterKind, usage_value: Value) -> Usage {
+		if usage_value.is_null() {
+			return Usage::default();
+		}
+
 		// NOTE: here we make sure we do not fail since we do not want to break a response because usage parsing fail
 		let usage = serde_json::from_value(usage_value).map_err(|err| {
 			error!("Fail to deserialize usage. Cause: {err}");
@@ -489,10 +499,44 @@ struct OpenAIRequestParts {
 mod tests {
 	use super::*;
 	use crate::adapter::AdapterKind;
-	use crate::chat::{ChatMessage, ContentPart, MessageContent, ToolCall};
+	use crate::chat::{ChatMessage, ChatOptions, ContentPart, MessageContent, ToolCall};
 
 	fn test_model() -> ModelIden {
 		ModelIden::new(AdapterKind::OpenAI, "test-model")
+	}
+
+	#[test]
+	fn test_extra_body_merged_into_chat_completion_payload() {
+		let chat_options = ChatOptions::default()
+			.with_temperature(0.2)
+			.with_extra_body(json!({"temperature": 0.7, "enable_thinking": false}));
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			model: test_model(),
+			auth: AuthData::from_single("test-key"),
+			endpoint: Endpoint::from_static("https://api.openai.com/v1/"),
+		};
+
+		let web_req = OpenAIAdapter::util_to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			options_set,
+			None,
+		)
+		.expect("to_web_request_data should succeed");
+
+		assert_eq!(web_req.payload["enable_thinking"], false);
+		assert_eq!(web_req.payload["temperature"], 0.7);
+	}
+
+	#[test]
+	fn test_null_usage_is_treated_as_absent_usage() {
+		let usage = OpenAIAdapter::into_usage(AdapterKind::OpenAI, Value::Null);
+
+		assert!(usage.prompt_tokens.is_none());
+		assert!(usage.completion_tokens.is_none());
+		assert!(usage.total_tokens.is_none());
 	}
 
 	/// When an assistant message carries reasoning_content, it must appear

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -249,6 +249,12 @@ impl Adapter for OpenAIRespAdapter {
 			}
 		}
 
+		// -- Provider-specific payload extension
+		// Merged last so callers can intentionally override previously set fields.
+		if let Some(extra_body) = chat_options.extra_body() {
+			payload.x_merge(extra_body.clone())?;
+		}
+
 		Ok(WebRequestData { url, headers, payload })
 	}
 
@@ -612,7 +618,31 @@ struct OpenAIRespRequestParts {
 mod tests {
 	use super::*;
 	use crate::adapter::AdapterKind;
-	use crate::chat::ChatMessage;
+	use crate::chat::{ChatMessage, ChatOptions};
+
+	#[test]
+	fn test_extra_body_merged_into_response_payload() {
+		let chat_options = ChatOptions::default()
+			.with_top_p(0.3)
+			.with_extra_body(json!({"top_p": 0.9, "metadata": {"source": "test"}}));
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			model: ModelIden::new(AdapterKind::OpenAIResp, "gpt-5-mini"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: OpenAIRespAdapter::default_endpoint(),
+		};
+
+		let web_req = OpenAIRespAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			options_set,
+		)
+		.expect("to_web_request_data should succeed");
+
+		assert_eq!(web_req.payload["top_p"], 0.9);
+		assert_eq!(web_req.payload["metadata"]["source"], "test");
+	}
 
 	/// Test that assistant message text content uses "output_text" type (not "input_text").
 	///

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -10,6 +10,7 @@ use crate::chat::CacheControl;
 use crate::chat::chat_req_response_format::ChatResponseFormat;
 use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::ops::Deref;
 
 /// Options considered by all `Client::exec_*` chat calls.
@@ -76,6 +77,12 @@ pub struct ChatOptions {
 
 	/// OpenAI prompt cache key.
 	pub prompt_cache_key: Option<String>,
+
+	/// Provider-specific extra request payload merged by the adapter.
+	///
+	/// This is primarily useful for OpenAI-compatible providers that expose
+	/// non-standard request fields.
+	pub extra_body: Option<Value>,
 }
 
 /// Chainable Setters
@@ -191,6 +198,12 @@ impl ChatOptions {
 	/// Sets the OpenAI prompt cache key.
 	pub fn with_prompt_cache_key(mut self, key: impl Into<String>) -> Self {
 		self.prompt_cache_key = Some(key.into());
+		self
+	}
+
+	/// Sets provider-specific extra body fields.
+	pub fn with_extra_body(mut self, value: Value) -> Self {
+		self.extra_body = Some(value);
 		self
 	}
 
@@ -577,6 +590,12 @@ impl ChatOptionsSet<'_, '_> {
 		self.chat
 			.and_then(|chat| chat.prompt_cache_key.as_deref())
 			.or_else(|| self.client.and_then(|client| client.prompt_cache_key.as_deref()))
+	}
+
+	pub fn extra_body(&self) -> Option<&Value> {
+		self.chat
+			.and_then(|chat| chat.extra_body.as_ref())
+			.or_else(|| self.client.and_then(|client| client.extra_body.as_ref()))
 	}
 
 	pub fn cache_control(&self) -> Option<&CacheControl> {


### PR DESCRIPTION
  This adds a generic chat request body extension point for provider-specific OpenAI-compatible fields.

  Changes:
  - Add `ChatOptions::with_extra_body(Value)`.
  - Add `ChatOptionsSet::extra_body()`.
  - Merge `extra_body` into OpenAI Chat Completions payloads.
  - Merge `extra_body` into OpenAI Responses payloads.
  - Treat streaming `usage:null` as absent usage instead of logging a deserialization error.
  - Add unit tests for Chat Completions payload merge, Responses payload merge, and null usage handling.

  Motivation:
  Some OpenAI-compatible providers expose useful non-standard request fields. For example, Aliyun/DashScope thinking models can require fields like `enable_thinking: false` to
  disable server-side thinking. Also, some compatible providers stream chunks with `usage:null`; this is a valid response shape and should not produce noisy deserialization
  errors.