### PR TITLE
feat: add Moonshot AI adapter

### DIFF
--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -18,6 +18,7 @@ use crate::adapter::gemini::GeminiAdapter;
 use crate::adapter::groq::GroqAdapter;
 use crate::adapter::mimo::MimoAdapter;
 use crate::adapter::nebius::NebiusAdapter;
+use crate::adapter::moonshot::MoonshotAdapter;
 use crate::adapter::openai::OpenAIAdapter;
 use crate::adapter::vertex::VertexAdapter;
 use crate::adapter::xai::XaiAdapter;
@@ -47,6 +48,8 @@ pub enum AdapterKind {
 	Groq,
 	/// For Mimo (Mostly use OpenAI)
 	Mimo,
+	/// For Moonshot AI (Mostly use OpenAI)
+	Moonshot,
 	/// For Nebius (Mostly use OpenAI)
 	Nebius,
 	/// For xAI (Mostly use OpenAI)
@@ -99,6 +102,7 @@ impl AdapterKind {
 			AdapterKind::Together => "Together",
 			AdapterKind::Groq => "Groq",
 			AdapterKind::Mimo => "Mimo",
+			AdapterKind::Moonshot => "Moonshot",
 			AdapterKind::Nebius => "Nebius",
 			AdapterKind::Xai => "xAi",
 			AdapterKind::DeepSeek => "DeepSeek",
@@ -128,6 +132,7 @@ impl AdapterKind {
 			AdapterKind::Together => "together",
 			AdapterKind::Groq => "groq",
 			AdapterKind::Mimo => "mimo",
+			AdapterKind::Moonshot => "moonshot",
 			AdapterKind::Nebius => "nebius",
 			AdapterKind::Xai => "xai",
 			AdapterKind::DeepSeek => "deepseek",
@@ -156,6 +161,7 @@ impl AdapterKind {
 			"together" => Some(AdapterKind::Together),
 			"groq" => Some(AdapterKind::Groq),
 			"mimo" => Some(AdapterKind::Mimo),
+			"moonshot" => Some(AdapterKind::Moonshot),
 			"nebius" => Some(AdapterKind::Nebius),
 			"xai" => Some(AdapterKind::Xai),
 			"deepseek" => Some(AdapterKind::DeepSeek),
@@ -189,6 +195,7 @@ impl AdapterKind {
 			AdapterKind::Together => TogetherAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Groq => GroqAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Mimo => MimoAdapter::DEFAULT_API_KEY_ENV_NAME,
+			AdapterKind::Moonshot => MoonshotAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Nebius => NebiusAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Xai => XaiAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::DeepSeek => DeepSeekAdapter::DEFAULT_API_KEY_ENV_NAME,
@@ -277,6 +284,8 @@ impl AdapterKind {
 			Ok(Self::Zai)
 		} else if model.starts_with("deepseek-") {
 			Ok(Self::DeepSeek)
+		} else if model.starts_with("moonshot-") {
+			Ok(Self::Moonshot)
 		}
 		// For now, fallback to Ollama
 		else {

--- a/src/adapter/adapters/mod.rs
+++ b/src/adapter/adapters/mod.rs
@@ -10,6 +10,7 @@ pub(super) mod fireworks;
 pub(super) mod gemini;
 pub(super) mod github_copilot;
 pub(super) mod groq;
+pub(super) mod moonshot;
 pub(super) mod mimo;
 pub(super) mod nebius;
 pub(super) mod ollama;

--- a/src/adapter/adapters/moonshot/adapter_impl.rs
+++ b/src/adapter/adapters/moonshot/adapter_impl.rs
@@ -1,0 +1,80 @@
+use crate::ModelIden;
+use crate::adapter::openai::OpenAIAdapter;
+use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
+use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::resolver::{AuthData, Endpoint};
+use crate::webc::WebResponse;
+use crate::{Result, ServiceTarget};
+use reqwest::RequestBuilder;
+
+pub struct MoonshotAdapter;
+
+impl MoonshotAdapter {
+	pub const API_KEY_DEFAULT_ENV_NAME: &str = "MOONSHOT_API_KEY";
+}
+
+// The Moonshot AI API adapter is modeled after the OpenAI adapter, as the Moonshot API is compatible with the OpenAI API.
+impl Adapter for MoonshotAdapter {
+	const DEFAULT_API_KEY_ENV_NAME: Option<&'static str> = Some(Self::API_KEY_DEFAULT_ENV_NAME);
+
+	fn default_endpoint() -> Endpoint {
+		const BASE_URL: &str = "https://api.moonshot.cn/v1/";
+		Endpoint::from_static(BASE_URL)
+	}
+
+	fn default_auth() -> AuthData {
+		match Self::DEFAULT_API_KEY_ENV_NAME {
+			Some(env_name) => AuthData::from_env(env_name),
+			None => AuthData::None,
+		}
+	}
+
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
+	}
+
+	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {
+		OpenAIAdapter::util_get_service_url(model, service_type, endpoint)
+	}
+
+	fn to_web_request_data(
+		target: ServiceTarget,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		chat_options: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		OpenAIAdapter::util_to_web_request_data(target, service_type, chat_req, chat_options, None)
+	}
+
+	fn to_chat_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatResponse> {
+		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+	}
+
+	fn to_chat_stream(
+		model_iden: ModelIden,
+		reqwest_builder: RequestBuilder,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatStreamResponse> {
+		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
+}

--- a/src/adapter/adapters/moonshot/mod.rs
+++ b/src/adapter/adapters/moonshot/mod.rs
@@ -1,0 +1,11 @@
+//! API Documentation:     <https://platform.moonshot.cn/docs/api/chat>
+//! Model Names:           <https://platform.moonshot.cn/docs/intro#模型列表>
+//! Endpoint:              <https://api.moonshot.cn/v1/>
+
+// region:    --- Modules
+
+mod adapter_impl;
+
+pub use adapter_impl::*;
+
+// endregion: --- Modules

--- a/src/adapter/dispatcher_macros.rs
+++ b/src/adapter/dispatcher_macros.rs
@@ -47,6 +47,10 @@ macro_rules! dispatch_adapter {
 				type A = crate::adapter::groq::[<Groq Adapter>];
 				$body
 			}
+			crate::adapter::AdapterKind::Moonshot => {
+				type A = crate::adapter::moonshot::[<Moonshot Adapter>];
+				$body
+			}
 			crate::adapter::AdapterKind::Mimo => {
 				type A = crate::adapter::mimo::[<Mimo Adapter>];
 				$body


### PR DESCRIPTION
## Summary

  Add support for [Moonshot AI](https://www.moonshot.cn/) (Kimi) as a new adapter.

  ## Details

  - **API Base URL:** `https://api.moonshot.cn/v1/`
  - **Auth Env Var:** `MOONSHOT_API_KEY`
  - **Model Prefix Auto-detection:** `moonshot-*` (e.g., `moonshot-v1-8k`, `moonshot-v1-32k`)
  - **Namespace Routing:** `moonshot::model-name`
  - **Protocol:** OpenAI-compatible, reuses `OpenAIAdapter` for chat, streaming, and embeddings

  ## Usage

  ```rust
  // Auto-detected by model prefix
  let res = client.exec_chat("moonshot-v1-8k", chat_req, None).await?;

  // Or force via namespace
  let res = client.exec_chat("moonshot::moonshot-v1-8k", chat_req, None).await?;
  Checklist
  • [x] Added MoonshotAdapter in src/adapter/adapters/moonshot/
  • [x] Registered in adapter_kind.rs with model prefix moonshot-
  • [x] Added to dispatcher macros
  • [x] cargo check passes
  • [x] cargo test --lib passes (86/86)

  ---