### PR TITLE
feat(adapter): add AIHubMix adapter support

### DIFF
--- a/.github/workflows/yakbak-replay-tests.yml
+++ b/.github/workflows/yakbak-replay-tests.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Run Gemini replay tests
         run: cargo test --test tests_yakbak_gemini
+
+      - name: Run AIHubMix replay tests
+        run: cargo test --test tests_yakbak_aihubmix

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ _*
 # -- AIPack related
 ako-config.jsonc
 
+# -- API keys
+aihubmix.key
+
 # -- Rust
 target/
 # !Cargo.lock # commented by default

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # genai, Multi-AI Providers Library for Rust
 
-Currently natively supports: **OpenAI**, **Anthropic**, **Gemini**, **xAI**, **Ollama**, **Groq**, **DeepSeek**, **Cohere**, **Together**, **Fireworks**, **Nebius**, **Mimo**, **Zai** (Zhipu AI), **BigModel**.
+Currently natively supports: **OpenAI**, **Anthropic**, **Gemini**, **xAI**, **Ollama**, **Groq**, **DeepSeek**, **Cohere**, **Together**, **Fireworks**, **Nebius**, **Mimo**, **Zai** (Zhipu AI), **BigModel**, **AIHubMix**.
 
 Also supports a custom URL with `ServiceTargetResolver` (see [examples/c06-target-resolver.rs](examples/c06-target-resolver.rs)).
 
@@ -188,7 +188,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## ChatOptions
 
 - **(1)** - **OpenAI-compatible** notes
-	- Models: OpenAI, DeepSeek, Groq, Ollama, xAI, Mimo, Together, Fireworks, Nebius, Zai, Together, Fireworks, Nebius, Zai
+	- Models: OpenAI, DeepSeek, Groq, Ollama, xAI, Mimo, Together, Fireworks, Nebius, Zai, AIHubMix
 
 | Property      | OpenAI Compatibles (*1) | Anthropic                   | Gemini `generationConfig.` | Cohere        |
 |---------------|-------------------------|-----------------------------|----------------------------|---------------|

--- a/doc/for-llm/api-reference-for-llm.md
+++ b/doc/for-llm/api-reference-for-llm.md
@@ -30,7 +30,7 @@ genai (crate root / lib.rs)
 - **ModelSpec**: Specifies a model at three resolution levels: `Name`, `Iden`, or `Target`.
 - **ServiceTarget**: Fully resolved call target: `ModelIden` + `Endpoint` + `AuthData`.
 - **Resolvers**: User hooks to customize model mapping, authentication, and service endpoints.
-- **AdapterKind**: Supported providers: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`.
+- **AdapterKind**: Supported providers: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Aihubmix`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`.
 
 ## Client & Configuration
 
@@ -482,7 +482,7 @@ Single-value-per-name HTTP header map.
 
 Enum identifying the AI provider adapter.
 
-Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`.
+Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Aihubmix`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Cohere`, `Ollama`.
 
 - `as_str()`: Display name (e.g., `"OpenAI"`, `"xAi"`).
 - `as_lower_str()`: Lowercase name (e.g., `"openai"`, `"xai"`).
@@ -506,7 +506,7 @@ Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`
   - `glm*` -> `Zai`.
   - Fallback -> `Ollama`.
 - **Namespacing**: `namespace::model_name` (e.g., `together::meta-llama/...`, `nebius::Qwen/...`).
-  - Namespace matches adapter lowercase name (e.g., `openai::`, `gemini::`, `anthropic::`, `fireworks::`, `together::`, `groq::`, `mimo::`, `nebius::`, `xai::`, `deepseek::`, `zai::`, `bigmodel::`, `aliyun::`, `cohere::`, `ollama::`, `openai_resp::`)
+	  - Namespace matches adapter lowercase name (e.g., `openai::`, `gemini::`, `anthropic::`, `fireworks::`, `together::`, `groq::`, `mimo::`, `nebius::`, `aihubmix::`, `xai::`, `deepseek::`, `zai::`, `bigmodel::`, `aliyun::`, `cohere::`, `ollama::`, `openai_resp::`)
   - Special: `coding::` namespace maps to `Zai` adapter.
 - **Ollama Fallback**: Unrecognized non-namespaced names default to `Ollama` adapter (localhost:11434).
 - **Reasoning Normalization**: Automatic extraction for DeepSeek/Ollama `<think>` blocks when `normalize_reasoning_content` is enabled.

--- a/examples/c10-aihubmix.rs
+++ b/examples/c10-aihubmix.rs
@@ -1,0 +1,58 @@
+//! AIHubMix adapter example
+//!
+//! Demonstrates how to use AIHubMix models with namespace-based access:
+//! - `aihubmix::gpt-4o-mini` → Routes to AIHubMix adapter (OpenAI-compatible)
+//!
+//! Required environment variable: AIHUBMIX_API_KEY
+
+use genai::chat::{ChatMessage, ChatRequest};
+use genai::Client;
+
+const MODEL: &str = "aihubmix::gpt-4o-mini";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let client = Client::default();
+
+	let chat_req = ChatRequest::default()
+		.with_system("You are a helpful assistant.")
+		.append_message(ChatMessage::user("Say 'hello' and nothing else."));
+
+	println!("\n=== AIHubMix Chat ===");
+	println!("Model: {MODEL}");
+
+	match client.exec_chat(MODEL, chat_req.clone(), None).await {
+		Ok(response) => {
+			println!("✅ Chat response:");
+			if let Some(content) = response.first_text() {
+				println!("  {}", content);
+			}
+		}
+		Err(e) => {
+			println!("❌ Error: {e}");
+			if e.to_string().contains("401") {
+				println!("ℹ️  Set AIHUBMIX_API_KEY environment variable");
+			}
+		}
+	}
+
+	println!("\n=== AIHubMix Stream ===");
+
+	match client.exec_chat_stream(MODEL, chat_req, None).await {
+		Ok(stream) => {
+			println!("✅ Stream response:");
+			use genai::chat::printer::{PrintChatStreamOptions, print_chat_stream};
+			let print_options = PrintChatStreamOptions::from_print_events(false);
+			print_chat_stream(stream, Some(&print_options)).await?;
+		}
+		Err(e) => {
+			println!("❌ Error: {e}");
+		}
+	}
+
+	println!("\n=== Summary ===");
+	println!("✅ AIHubMix adapter uses namespace routing (aihubmix::)");
+	println!("✅ Set AIHUBMIX_API_KEY environment variable");
+
+	Ok(())
+}

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -1,5 +1,6 @@
 use crate::adapter::adapters::ollama::OllamaAdapter;
 use crate::adapter::adapters::openai_resp::OpenAIRespAdapter;
+use crate::adapter::adapters::aihubmix::AihubmixAdapter;
 use crate::adapter::adapters::together::TogetherAdapter;
 use crate::adapter::adapters::zai::ZaiAdapter;
 use crate::adapter::aliyun::AliyunAdapter;
@@ -43,6 +44,8 @@ pub enum AdapterKind {
 	Mimo,
 	/// For Nebius (Mostly use OpenAI)
 	Nebius,
+	/// For AIHubMix (OpenAI-compatible proxy)
+	Aihubmix,
 	/// For xAI (Mostly use OpenAI)
 	Xai,
 	/// For DeepSeek (Mostly use OpenAI)
@@ -76,6 +79,7 @@ impl AdapterKind {
 			AdapterKind::Groq => "Groq",
 			AdapterKind::Mimo => "Mimo",
 			AdapterKind::Nebius => "Nebius",
+			AdapterKind::Aihubmix => "AIHubMix",
 			AdapterKind::Xai => "xAi",
 			AdapterKind::DeepSeek => "DeepSeek",
 			AdapterKind::Zai => "Zai",
@@ -99,6 +103,7 @@ impl AdapterKind {
 			AdapterKind::Groq => "groq",
 			AdapterKind::Mimo => "mimo",
 			AdapterKind::Nebius => "nebius",
+			AdapterKind::Aihubmix => "aihubmix",
 			AdapterKind::Xai => "xai",
 			AdapterKind::DeepSeek => "deepseek",
 			AdapterKind::Zai => "zai",
@@ -121,6 +126,7 @@ impl AdapterKind {
 			"groq" => Some(AdapterKind::Groq),
 			"mimo" => Some(AdapterKind::Mimo),
 			"nebius" => Some(AdapterKind::Nebius),
+			"aihubmix" => Some(AdapterKind::Aihubmix),
 			"xai" => Some(AdapterKind::Xai),
 			"deepseek" => Some(AdapterKind::DeepSeek),
 			"zai" => Some(AdapterKind::Zai),
@@ -148,6 +154,7 @@ impl AdapterKind {
 			AdapterKind::Groq => GroqAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Mimo => MimoAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Nebius => NebiusAdapter::DEFAULT_API_KEY_ENV_NAME,
+			AdapterKind::Aihubmix => AihubmixAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Xai => XaiAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::DeepSeek => DeepSeekAdapter::DEFAULT_API_KEY_ENV_NAME,
 			AdapterKind::Zai => ZaiAdapter::DEFAULT_API_KEY_ENV_NAME,

--- a/src/adapter/adapters/aihubmix/adapter_impl.rs
+++ b/src/adapter/adapters/aihubmix/adapter_impl.rs
@@ -1,0 +1,80 @@
+use crate::ModelIden;
+use crate::adapter::openai::OpenAIAdapter;
+use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
+use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::resolver::{AuthData, Endpoint};
+use crate::webc::WebResponse;
+use crate::{Result, ServiceTarget};
+use reqwest::RequestBuilder;
+
+pub struct AihubmixAdapter;
+
+impl AihubmixAdapter {
+	pub const API_KEY_DEFAULT_ENV_NAME: &str = "AIHUBMIX_API_KEY";
+}
+
+// The AIHubMix API adapter is modeled after the OpenAI adapter, as the AIHubMix API is compatible with the OpenAI API.
+impl Adapter for AihubmixAdapter {
+	const DEFAULT_API_KEY_ENV_NAME: Option<&'static str> = Some(Self::API_KEY_DEFAULT_ENV_NAME);
+
+	fn default_endpoint() -> Endpoint {
+		const BASE_URL: &str = "https://aihubmix.com/v1/";
+		Endpoint::from_static(BASE_URL)
+	}
+
+	fn default_auth() -> AuthData {
+		match Self::DEFAULT_API_KEY_ENV_NAME {
+			Some(env_name) => AuthData::from_env(env_name),
+			None => AuthData::None,
+		}
+	}
+
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
+	}
+
+	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {
+		OpenAIAdapter::util_get_service_url(model, service_type, endpoint)
+	}
+
+	fn to_web_request_data(
+		target: ServiceTarget,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		chat_options: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		OpenAIAdapter::util_to_web_request_data(target, service_type, chat_req, chat_options, None)
+	}
+
+	fn to_chat_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatResponse> {
+		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+	}
+
+	fn to_chat_stream(
+		model_iden: ModelIden,
+		reqwest_builder: RequestBuilder,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatStreamResponse> {
+		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
+}

--- a/src/adapter/adapters/aihubmix/mod.rs
+++ b/src/adapter/adapters/aihubmix/mod.rs
@@ -1,0 +1,11 @@
+//! API Documentation:     <https://docs.aihubmix.com/en/api/Aihubmix-Integration>
+//! Model Names:           <https://docs.aihubmix.com/en/api/Aihubmix-Integration>
+//! Endpoint:              <https://aihubmix.com/v1/>
+
+// region:    --- Modules
+
+mod adapter_impl;
+
+pub use adapter_impl::*;
+
+// endregion: --- Modules

--- a/src/adapter/adapters/mod.rs
+++ b/src/adapter/adapters/mod.rs
@@ -1,5 +1,6 @@
 mod support;
 
+pub(super) mod aihubmix;
 pub(super) mod aliyun;
 pub(super) mod anthropic;
 pub(super) mod bigmodel;

--- a/src/adapter/dispatcher.rs
+++ b/src/adapter/dispatcher.rs
@@ -9,6 +9,7 @@ use crate::adapter::cohere::CohereAdapter;
 use crate::adapter::deepseek::DeepSeekAdapter;
 use crate::adapter::fireworks::FireworksAdapter;
 use crate::adapter::gemini::GeminiAdapter;
+use crate::adapter::aihubmix::AihubmixAdapter;
 use crate::adapter::nebius::NebiusAdapter;
 use crate::adapter::ollama::OllamaAdapter;
 use crate::adapter::openai::OpenAIAdapter;
@@ -43,6 +44,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::default_endpoint(),
 			AdapterKind::Mimo => MimoAdapter::default_endpoint(),
 			AdapterKind::Nebius => NebiusAdapter::default_endpoint(),
+			AdapterKind::Aihubmix => AihubmixAdapter::default_endpoint(),
 			AdapterKind::Xai => XaiAdapter::default_endpoint(),
 			AdapterKind::DeepSeek => DeepSeekAdapter::default_endpoint(),
 			AdapterKind::Zai => ZaiAdapter::default_endpoint(),
@@ -65,6 +67,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::default_auth(),
 			AdapterKind::Mimo => MimoAdapter::default_auth(),
 			AdapterKind::Nebius => NebiusAdapter::default_auth(),
+			AdapterKind::Aihubmix => AihubmixAdapter::default_auth(),
 			AdapterKind::Xai => XaiAdapter::default_auth(),
 			AdapterKind::DeepSeek => DeepSeekAdapter::default_auth(),
 			AdapterKind::Zai => ZaiAdapter::default_auth(),
@@ -87,6 +90,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Mimo => MimoAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Nebius => NebiusAdapter::all_model_names(kind, endpoint, auth).await,
+			AdapterKind::Aihubmix => AihubmixAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Xai => XaiAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::DeepSeek => DeepSeekAdapter::all_model_names(kind, endpoint, auth).await,
 			AdapterKind::Zai => ZaiAdapter::all_model_names(kind, endpoint, auth).await,
@@ -109,6 +113,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Mimo => MimoAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Nebius => NebiusAdapter::get_service_url(model, service_type, endpoint),
+			AdapterKind::Aihubmix => AihubmixAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Xai => XaiAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::DeepSeek => DeepSeekAdapter::get_service_url(model, service_type, endpoint),
 			AdapterKind::Zai => ZaiAdapter::get_service_url(model, service_type, endpoint),
@@ -143,6 +148,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Mimo => MimoAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Nebius => NebiusAdapter::to_web_request_data(target, service_type, chat_req, options_set),
+			AdapterKind::Aihubmix => AihubmixAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Xai => XaiAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_web_request_data(target, service_type, chat_req, options_set),
 			AdapterKind::Zai => ZaiAdapter::to_web_request_data(target, service_type, chat_req, options_set),
@@ -169,6 +175,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Mimo => MimoAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Nebius => NebiusAdapter::to_chat_response(model_iden, web_response, options_set),
+			AdapterKind::Aihubmix => AihubmixAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Xai => XaiAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_response(model_iden, web_response, options_set),
 			AdapterKind::Zai => ZaiAdapter::to_chat_response(model_iden, web_response, options_set),
@@ -195,6 +202,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Mimo => MimoAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Nebius => NebiusAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
+			AdapterKind::Aihubmix => AihubmixAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Xai => XaiAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
 			AdapterKind::Zai => ZaiAdapter::to_chat_stream(model_iden, reqwest_builder, options_set),
@@ -225,6 +233,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Mimo => MimoAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Nebius => NebiusAdapter::to_embed_request_data(target, embed_req, options_set),
+			AdapterKind::Aihubmix => AihubmixAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Xai => XaiAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_embed_request_data(target, embed_req, options_set),
 			AdapterKind::Zai => ZaiAdapter::to_embed_request_data(target, embed_req, options_set),
@@ -254,6 +263,7 @@ impl AdapterDispatcher {
 			AdapterKind::Groq => GroqAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Mimo => MimoAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Nebius => NebiusAdapter::to_embed_response(model_iden, web_response, options_set),
+			AdapterKind::Aihubmix => AihubmixAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Xai => XaiAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::DeepSeek => DeepSeekAdapter::to_embed_response(model_iden, web_response, options_set),
 			AdapterKind::Zai => ZaiAdapter::to_embed_response(model_iden, web_response, options_set),

--- a/tests/data/yakbak/aihubmix/chat_stream/response_000.txt
+++ b/tests/data/yakbak/aihubmix/chat_stream/response_000.txt
@@ -1,0 +1,12 @@
+data: {"id":"chatcmpl-Df7rE7JcNSZq6avLPXcEGtelEhMjt","object":"chat.completion.chunk","created":1778694024,"model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"role":"assistant","content":""}}],"service_tier":"default","system_fingerprint":"fp_eb37e061ec"}
+
+data: {"id":"chatcmpl-Df7rE7JcNSZq6avLPXcEGtelEhMjt","object":"chat.completion.chunk","created":1778694024,"model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"content":"Hello"}}],"service_tier":"default","system_fingerprint":"fp_eb37e061ec"}
+
+data: {"id":"chatcmpl-Df7rE7JcNSZq6avLPXcEGtelEhMjt","object":"chat.completion.chunk","created":1778694024,"model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{"content":"."}}],"service_tier":"default","system_fingerprint":"fp_eb37e061ec"}
+
+data: {"id":"chatcmpl-Df7rE7JcNSZq6avLPXcEGtelEhMjt","object":"chat.completion.chunk","created":1778694024,"model":"gpt-4o-mini-2024-07-18","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"service_tier":"default","system_fingerprint":"fp_eb37e061ec"}
+
+data: {"id":"chatcmpl-Df7rE7JcNSZq6avLPXcEGtelEhMjt","object":"chat.completion.chunk","created":1778694024,"model":"gpt-4o-mini-2024-07-18","choices":[],"service_tier":"default","system_fingerprint":"fp_eb37e061ec","usage":{"prompt_tokens":15,"completion_tokens":3,"total_tokens":18,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0}}}
+
+data: [DONE]
+

--- a/tests/tests_p_aihubmix.rs
+++ b/tests/tests_p_aihubmix.rs
@@ -1,0 +1,38 @@
+mod support;
+
+use crate::support::{TestResult, common_tests};
+use genai::resolver::AuthData;
+
+const MODEL: &str = "aihubmix::gpt-4o-mini";
+
+// region:    --- Chat
+
+#[tokio::test]
+async fn test_chat_simple_ok() -> TestResult<()> {
+	common_tests::common_test_chat_simple_ok(MODEL, None).await
+}
+
+// endregion: --- Chat
+
+// region:    --- Chat Stream Tests
+
+#[tokio::test]
+async fn test_chat_stream_simple_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_simple_ok(MODEL, None).await
+}
+
+#[tokio::test]
+async fn test_chat_stream_capture_content_ok() -> TestResult<()> {
+	common_tests::common_test_chat_stream_capture_content_ok(MODEL).await
+}
+
+// endregion: --- Chat Stream Tests
+
+// region:    --- Resolver Tests
+
+#[tokio::test]
+async fn test_resolver_auth_ok() -> TestResult<()> {
+	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::from_env("AIHUBMIX_API_KEY")).await
+}
+
+// endregion: --- Resolver Tests

--- a/tests/tests_yakbak_aihubmix.rs
+++ b/tests/tests_yakbak_aihubmix.rs
@@ -1,0 +1,38 @@
+//! Replay integration tests for the AIHubMix adapter.
+//!
+//! These tests use pre-recorded cassettes from `tests/data/yakbak/aihubmix/`
+//! and assert that content and usage flow through correctly.
+
+mod support;
+
+use genai::chat::*;
+use support::yakbak::replay_client;
+use support::{TestResult, extract_stream_end};
+
+#[tokio::test]
+async fn test_yakbak_aihubmix_chat_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("aihubmix", "chat_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![ChatMessage::user("Say 'hello' and nothing else.")]);
+	let options = ChatOptions::default()
+		.with_capture_content(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("aihubmix::gpt-4o-mini", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	let content = extract.content.as_deref().ok_or("Should have streamed content")?;
+	assert!(
+		content.to_lowercase().contains("hello"),
+		"Content should contain 'hello', got: {content}"
+	);
+
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(15));
+	assert_eq!(usage.completion_tokens, Some(3));
+	assert_eq!(usage.total_tokens, Some(18));
+
+	Ok(())
+}

--- a/tests/tests_yakbak_record.rs
+++ b/tests/tests_yakbak_record.rs
@@ -120,6 +120,33 @@ async fn record_gemini_thinking_stream() -> TestResult<()> {
 	Ok(())
 }
 
+fn aihubmix_backend() -> String {
+	std::env::var("AIHUBMIX_BASE_URL").unwrap_or_else(|_| "https://aihubmix.com/v1/".to_string())
+}
+
+const AIHUBMIX_MODEL: &str = "aihubmix::gpt-4o-mini";
+
+#[tokio::test]
+#[ignore]
+async fn record_aihubmix_chat_stream() -> TestResult<()> {
+	let (client, mut server) = record_client("aihubmix", "chat_stream", &aihubmix_backend()).await?;
+
+	let chat_req = ChatRequest::new(vec![ChatMessage::user("Say 'hello' and nothing else.")]);
+	let options = ChatOptions::default()
+		.with_capture_content(true)
+		.with_capture_usage(true);
+
+	let stream_res = client.exec_chat_stream(AIHUBMIX_MODEL, chat_req, Some(&options)).await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+	eprintln!(
+		"[record] Stream content: {:?}",
+		extract.content.as_deref().map(|s| &s[..s.len().min(80)])
+	);
+
+	server.shutdown().await;
+	Ok(())
+}
+
 fn seed_tool_request() -> ChatRequest {
 	ChatRequest::new(vec![
 		ChatMessage::system("You are a helpful assistant. Use tools when needed."),


### PR DESCRIPTION
Hey, me again, let's add AIHubMix (https://aihubmix.com) as a new OpenAI-compatible adapter.

## Changes

- **Adapter**: `AdapterKind::Aihubmix` with namespace-based access (`aihubmix::gpt-4o-mini`)
  - Delegates to `OpenAIAdapter` (pure proxy, zero custom logic)
  - Endpoint: `https://aihubmix.com/v1/`
  - Default env var: `AIHUBMIX_API_KEY`
- **Tests**: 4 integration tests (chat, stream, stream capture, auth resolver) + YakBak replay test + cassette
- **Example**: `examples/c10-aihubmix.rs` demonstrating namespace usage
- **Docs**: Updated README.md and API reference

## Verification

- `cargo test --test tests_p_aihubmix` — 4/4 pass with real API
- `cargo test --test tests_yakbak_aihubmix` — replay passes (no API key needed)
- `cargo check` — clean