### PR TITLE
openai_resp: round-trip encrypted reasoning blobs as input items

### DIFF
--- a/examples/c11-openai-resp-reasoning-roundtrip.rs
+++ b/examples/c11-openai-resp-reasoning-roundtrip.rs
@@ -1,0 +1,169 @@
+//! Demonstrate the OpenAI Responses prefix-cache + reasoning round-trip.
+//!
+//! Reasoning models on the Responses API (gpt-5.x, o-series) emit
+//! `type:"reasoning"` items with an `encrypted_content` blob during
+//! streaming. To maintain reasoning state — and to keep the
+//! provider-side prefix cache warm — the next request in a
+//! conversation must replay those blobs as inputs alongside the
+//! assistant message they belong to.
+//!
+//! This example performs two turns:
+//!   1. Ask a reasoning-triggering question with `reasoning_effort=Medium`
+//!      and `capture_reasoning_content=true` (which causes the adapter
+//!      to set `include: ["reasoning.encrypted_content"]` on the request).
+//!   2. Re-send the conversation, attaching the captured
+//!      `ContentPart::ThoughtSignature` parts to the assistant turn.
+//!      The adapter emits each blob as a top-level `type:"reasoning"`
+//!      input item before the assistant message.
+//!
+//! Inspect `Usage.prompt_tokens_details.cached_tokens` on turn 2: when
+//! the backend honors prompt caching and the prefix matches, it will be
+//! non-zero. Cache-hit ratios vary by backend and conversation shape.
+//!
+//! Requires: OPENAI_API_KEY environment variable.
+//!
+//! Run: `OPENAI_API_KEY=sk-... cargo run --example c11-openai-resp-reasoning-roundtrip`
+
+use std::env;
+
+use futures::StreamExt;
+use genai::Client;
+use genai::ModelIden;
+use genai::adapter::AdapterKind;
+use genai::chat::{
+	ChatMessage, ChatOptions, ChatRequest, ChatStreamEvent, ContentPart, MessageContent, ReasoningEffort,
+};
+use genai::resolver::{AuthData, AuthResolver};
+
+/// A small reasoning-class model on the Responses API. Bump to a larger
+/// model (e.g. `gpt-5.1`, `gpt-5`) for richer reasoning traces — the
+/// shape of the response stream and the round-trip protocol is the same.
+const MODEL: &str = "gpt-5.4-mini";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let api_key =
+		env::var("OPENAI_API_KEY").map_err(|_| "set OPENAI_API_KEY to a key with access to the Responses API")?;
+
+	let auth_resolver =
+		AuthResolver::from_resolver_fn(move |_iden: ModelIden| Ok(Some(AuthData::from_single(api_key.clone()))));
+	let client = Client::builder()
+		.with_adapter_kind(AdapterKind::OpenAIResp)
+		.with_auth_resolver(auth_resolver)
+		.build();
+
+	let options = ChatOptions::default()
+		.with_capture_content(true)
+		.with_capture_usage(true)
+		.with_capture_reasoning_content(true)
+		.with_reasoning_effort(ReasoningEffort::Medium)
+		// Stable across turns in a session — lets the Responses API
+		// recognise the cacheable prefix even when content hashes shift
+		// in cheap ways. Hit-rate shows up as `cached_tokens` in usage.
+		.with_prompt_cache_key("genai-example-reasoning-roundtrip");
+
+	// ============== Turn 1 ==============
+	let req1 = ChatRequest::default()
+		.with_system("You are a careful assistant. Show your reasoning before each answer.")
+		.append_message(ChatMessage::user(
+			"A farmer has 17 cows. If all but 9 die, how many are left? \
+             Reason carefully — many people get this wrong by misreading.",
+		));
+	let (text1, sigs1, usage1) = run_turn(&client, MODEL, req1.clone(), &options).await?;
+	print_turn(1, &text1, &sigs1, &usage1);
+
+	// ============== Turn 2 ==============
+	// Build the assistant turn with the captured reasoning blobs FIRST
+	// (the adapter emits them as top-level `type:"reasoning"` input
+	// items that precede the assistant message), then the text reply.
+	let mut asst_content = MessageContent::default();
+	for blob in &sigs1 {
+		asst_content.push(ContentPart::ThoughtSignature(blob.clone()));
+	}
+	if !text1.is_empty() {
+		asst_content.push(ContentPart::Text(text1.clone()));
+	}
+
+	let req2 = req1
+		.append_message(ChatMessage::assistant(asst_content))
+		.append_message(ChatMessage::user(
+			"What if the puzzle said 'all but 3 die' instead? Reason briefly.",
+		));
+	let (text2, sigs2, usage2) = run_turn(&client, MODEL, req2, &options).await?;
+	print_turn(2, &text2, &sigs2, &usage2);
+
+	Ok(())
+}
+
+#[derive(Default)]
+struct TurnUsage {
+	prompt: i32,
+	completion: i32,
+	cached: i32,
+	reasoning: i32,
+}
+
+fn print_turn(n: usize, text: &str, sigs: &[String], u: &TurnUsage) {
+	println!("\n=== turn {n} ===");
+	println!(
+		"  usage: prompt={} cached={} completion={} reasoning_tokens={}",
+		u.prompt, u.cached, u.completion, u.reasoning
+	);
+	println!("  thought_signatures captured: {}", sigs.len());
+	let preview: String = text.lines().take(6).collect::<Vec<_>>().join("\n  ");
+	println!("  reply:\n  {preview}");
+}
+
+async fn run_turn(
+	client: &Client,
+	model: &str,
+	req: ChatRequest,
+	options: &ChatOptions,
+) -> Result<(String, Vec<String>, TurnUsage), Box<dyn std::error::Error>> {
+	let stream_res = client.exec_chat_stream(model, req, Some(options)).await?;
+	let mut stream = stream_res.stream;
+	let mut text = String::new();
+	let mut end_opt = None;
+	while let Some(event) = stream.next().await {
+		match event? {
+			ChatStreamEvent::Chunk(c) => text.push_str(&c.content),
+			ChatStreamEvent::End(e) => {
+				end_opt = Some(e);
+				break;
+			}
+			_ => {}
+		}
+	}
+	let end = end_opt.ok_or("stream ended without End event")?;
+	let sigs: Vec<String> = end
+		.captured_thought_signatures()
+		.map(|v| v.into_iter().map(String::from).collect())
+		.unwrap_or_default();
+	let usage = end.captured_usage.as_ref();
+	let prompt = usage.and_then(|u| u.prompt_tokens).unwrap_or(0);
+	let completion = usage.and_then(|u| u.completion_tokens).unwrap_or(0);
+	let cached = usage
+		.and_then(|u| u.prompt_tokens_details.as_ref())
+		.and_then(|d| d.cached_tokens)
+		.unwrap_or(0);
+	let reasoning = usage
+		.and_then(|u| u.completion_tokens_details.as_ref())
+		.and_then(|d| d.reasoning_tokens)
+		.unwrap_or(0);
+	let captured_text = end
+		.captured_content
+		.as_ref()
+		.and_then(|c| c.first_text())
+		.map(String::from)
+		.unwrap_or(text);
+	Ok((
+		captured_text,
+		sigs,
+		TurnUsage {
+			prompt,
+			completion,
+			cached,
+			reasoning,
+		},
+	))
+}

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -468,6 +468,39 @@ impl OpenAIRespAdapter {
 					// In the new OpenAI Responses API, the tool call are just items out of assistant message
 					let mut item_message_content: Vec<Value> = Vec::new();
 
+					// Pre-pass: encrypted reasoning blobs from prior turns must be
+					// carried back as top-level `{type: "reasoning"}` input items
+					// to keep the Responses-API prefix cache warm. Without this,
+					// even a verbatim resend of a prior turn re-processes every
+					// token. They precede the assistant message they belong to,
+					// mirroring the order the API emits them in the streaming
+					// response. The blobs ride in on `ContentPart::ThoughtSignature`
+					// parts (from `StreamEnd::captured_content`) or on
+					// `ToolCall::thought_signatures` (rust-genai's streamer stashes
+					// captured blobs there when there are tool calls).
+					for part in msg.content.iter() {
+						if let ContentPart::ThoughtSignature(blob) = part {
+							input_items.push(json!({
+								"type": "reasoning",
+								"encrypted_content": blob,
+								"summary": [],
+							}));
+						}
+					}
+					for part in msg.content.iter() {
+						if let ContentPart::ToolCall(tool_call) = part
+							&& let Some(sigs) = tool_call.thought_signatures.as_ref()
+						{
+							for blob in sigs {
+								input_items.push(json!({
+									"type": "reasoning",
+									"encrypted_content": blob,
+									"summary": [],
+								}));
+							}
+						}
+					}
+
 					for part in msg.content {
 						match part {
 							ContentPart::Text(text) => {
@@ -498,6 +531,8 @@ impl OpenAIRespAdapter {
 							// TODO: Probably need towarn on this one (probably need to add binary here)
 							ContentPart::Binary(_) => {}
 							ContentPart::ToolResponse(_) => {}
+							// ThoughtSignature and ReasoningContent are emitted as
+							// top-level `type:reasoning` items in the pre-pass above.
 							ContentPart::ThoughtSignature(_) => {}
 							ContentPart::ReasoningContent(_) => {}
 							// Custom are ignored for this logic

--- a/src/adapter/adapters/openai_resp/streamer.rs
+++ b/src/adapter/adapters/openai_resp/streamer.rs
@@ -35,9 +35,18 @@ enum RespStreamEvent {
 	#[serde(rename = "response.output_item.added")]
 	OutputItemAdded { output_index: usize, item: Value },
 
+	#[serde(rename = "response.output_item.done")]
+	OutputItemDone {
+		#[serde(default)]
+		_output_index: usize,
+		item: Value,
+	},
+
 	#[serde(rename = "response.content_part.added")]
 	ContentPartAdded {
+		#[serde(default)]
 		_output_index: usize,
+		#[serde(default)]
 		_content_index: usize,
 		#[serde(default)]
 		_part: Value,
@@ -159,6 +168,27 @@ impl futures::Stream for OpenAIRespStreamer {
 							continue;
 						}
 
+						RespStreamEvent::OutputItemDone { item, .. } => {
+							// Capture encrypted reasoning blobs from `type: "reasoning"`
+							// items as they finalise. Some backends (tasfn-class proxies)
+							// don't include `response.output` in the terminal
+							// `response.completed` event — they emit reasoning items only
+							// via this stream of `output_item.done` events. Reading them
+							// here keeps the prefix cache round-trip working regardless
+							// of whether the backend echoes `output` at the end.
+							if self.options.capture_reasoning_content
+								&& item.x_get_str("type").ok() == Some("reasoning")
+								&& let Ok(encrypted) = item.x_get_str("encrypted_content")
+								&& !encrypted.is_empty()
+							{
+								self.captured_data
+									.thought_signatures
+									.get_or_insert_with(Vec::new)
+									.push(encrypted.to_string());
+							}
+							continue;
+						}
+
 						RespStreamEvent::ContentPartAdded { .. } => {
 							// We can ignore this as deltas will follow
 							continue;
@@ -226,13 +256,41 @@ impl futures::Stream for OpenAIRespStreamer {
 								tool_calls.push(tc);
 							}
 
+							// Fallback: if no tool calls were captured incrementally
+							// (e.g., the server sent only response.completed without
+							// preceding OutputItemAdded / FunctionCallArgumentsDelta
+							// events), extract them from the response.output payload.
+							if tool_calls.is_empty() {
+								for item in &response.output {
+									if item.x_get_str("type").ok() == Some("function_call") {
+										let call_id = item.x_get_str("call_id").unwrap_or_default().to_string();
+										let fn_name = item.x_get_str("name").unwrap_or_default().to_string();
+										let args_str = item.x_get_str("arguments").unwrap_or_default();
+										let fn_arguments: Value = serde_json::from_str(args_str)
+											.unwrap_or_else(|_| Value::String(args_str.to_string()));
+
+										tool_calls.push(ToolCall {
+											call_id,
+											fn_name,
+											fn_arguments,
+											thought_signatures: None,
+										});
+									}
+								}
+							}
+
 							if self.options.capture_tool_calls && !tool_calls.is_empty() {
 								self.captured_data.tool_calls = Some(tool_calls.clone());
 							}
 
 							// Extract encrypted reasoning content from output items
 							// (OpenAI equivalent of Gemini thought signatures).
-							if self.options.capture_reasoning_content {
+							// Only used as a fallback — `output_item.done` is the
+							// primary source. Some backends don't echo `output` in
+							// `response.completed` (it comes back empty), but for
+							// backends that do, this picks up anything missed.
+							if self.options.capture_reasoning_content && self.captured_data.thought_signatures.is_none()
+							{
 								let mut thought_sigs: Vec<String> = Vec::new();
 								for item in &response.output {
 									if item.x_get_str("type").ok() == Some("reasoning")

--- a/tests/data/yakbak/openai_resp/reasoning_stream_completed_empty/response_000.txt
+++ b/tests/data/yakbak/openai_resp/reasoning_stream_completed_empty/response_000.txt
@@ -1,0 +1,123 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_024bf228dd4d6ece0169cb13c666f88191855bb06bead52a11","object":"response","created_at":1774916550,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Answer in one sentence.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"7eac412d-25d9-4c88-895d-5772447bc5ce","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":"detailed"},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_024bf228dd4d6ece0169cb13c666f88191855bb06bead52a11","object":"response","created_at":1774916550,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Answer in one sentence.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"7eac412d-25d9-4c88-895d-5772447bc5ce","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":"detailed"},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"rs_024bf228dd4d6ece0169cb13c6a0008191b5f7e1633c5f3b38","type":"reasoning","encrypted_content":"gAAAAABpyxPGZycpAQsMCsIaSEgjc3XB5jpBFnNDZx1wQEbnQbJFHyM1YTzsrqAqxw0VwPrmyApkIChK6yMkUHYp3Ql7YvECQiqpA8vArl47Zun94rH0T2GbRJZWXwlfAumQyaj7zN1rKzwEx1j83eKuMJsxocHAJEiaiUmFe6xOoxEc6RK8B4bkPel_kEY81oXigHrfZprxGPDRlg4J2968VOzP7vfpFZVKQgDcVLKPaXMHV7IxUdPywOB9_wBnmU9P2Skv4tHxVtqu_LJeW3Hrb_KtiK0LNDNF8Q8TlKypG4WdCI8fHoGe9I7DGyM5FjB7t7uZNcrNvclLSfzTuPiUAfonTQDBrzXytfdedHV7SUk0EGMOYnbZ_TUzM-No3_z6abhbg8w5QijsSE9F2wm0W-yYa8xYOFNXwYyo9920gA85v7QWU9uSDftIinbGVIYFk6UKAqsGimq3bRfuLBlaMSIonS7fO02jPWyGwXUn1wgAy_a61dXGL2MbnaDk54WKD8WKijYgQgGJmA7nlRBESduUTq5gusgJS08b58iXT-c09gBS6tquavcxopAzgr-vMretXsQcvX7GJlQEbNbe92EOuJOZpfhKTvO_436stvtstoPmfa8Bl9NG2tmlq5ILn_ZrzcCJleZML1lNLBvBTllwf6fHjhSMvM60Wp4oaZoUW-4AgHPCYTe7C0DyPhZVHHnVV3qoCf7DJNsHaFPBR1SIO1e2UucRpwBwvalsr005jZ4I2KibnnY-DDwtGNTHP4pot-0PAPG7T8wJwUuX0_JWx0Gb_P5lZG_o0UuHuDY_CdZBo15gF7d2O_O4JQk5xdTbl_Jh","summary":[]},"output_index":0,"sequence_number":2}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"rs_024bf228dd4d6ece0169cb13c6a0008191b5f7e1633c5f3b38","type":"reasoning","encrypted_content":"gAAAAABpyxPGHE6t9AIxM1VQEn667HAaoGQhoK_M5bIcAGpy7l7geUHxJsErTyHNbV1nz7_oGNsbPMsAWiCA4aYEa4Z-5WwY4UoNCIPPyCKvOD66TNrNWlnX5lX57V0i-PwSgw0iH1L_l6EyOfYvMyThoLnzYGl55te4l52NgJN5o5KXL4z-hhsUNlVhy-6Sj9T_TRHjJ9jNQATF6g5ydj85GxfcPzUaxtPHcRUmm-v_lWZQOkj7FXK_xuaIYRy2l0le_aQE890sI1kAzHLebL4F6vvGnVcuPNVcxkfObGtSKgbV65f11vhc0T1RTjt29FNgPBDhYjka72NGgmlRnzSR5k2Smrngbb39qqfL0YUkqPsrfLjujyMYd2aDANB_GFOzWqkf4grEjv8asTLTlfDczmTfMBy9hRjKLziHTNixrQyMt1I6Ndryy9rdbo9vGjG8OJDDsxC9Yo2V8NHNxOKQWQZPAdGzpT3I0JLSs_H_A02K7YYim9QSQQ5RweCGFRXrspUSfVnsv6kBz6N-k3-78kJZfqysJGgHadPGC08yGHVDPWJBNHBr9EviWd1sh5e0Pm72_lMWVPO3cMKIAd9gHfu7wzg9TnGkLjFCDzMKdQEhtVqYpVoUiUlJjXEmdlznt2PA7kD5taolDLEcqegnO4sH50gnQAOkxEJTnGfeyRehgvkvPAQO6O-gyges-gfwYyljd-jrkpiaJb4gnbd3PYVsLzoUZD3eh6t5wpbey4nhu5ZEVaa69ByFcYoQAlPmUE4nGpQe5zoiWDVyeNuVPCltRj_TZfYGXXJeBmVztMqFb-PweoqvpqPzHzrqKPYAOm1qsb6eaublipC_Qm3NLMLbNu5vzABh8vR0XLgEbr7Y4m-6nY4=","summary":[]},"output_index":0,"sequence_number":3}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":4}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":5}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"CPp20acasANQC","output_index":1,"sequence_number":6}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" sky","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"6q8158Y8tJ3j","output_index":1,"sequence_number":7}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" looks","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"6Ei8F0oc7I","output_index":1,"sequence_number":8}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" blue","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"bwAjNgFxKuM","output_index":1,"sequence_number":9}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" because","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"lWj3YKEF","output_index":1,"sequence_number":10}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" molecules","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"Uu5A5Y","output_index":1,"sequence_number":11}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" in","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"aVI6Uzf34sMiV","output_index":1,"sequence_number":12}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" Earth","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"11PMB3VjMg","output_index":1,"sequence_number":13}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"\u2019s","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"XmHKwY4l7liJG3","output_index":1,"sequence_number":14}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" atmosphere","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"RDBcK","output_index":1,"sequence_number":15}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" scatter","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"W34I0DZD","output_index":1,"sequence_number":16}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" shorter","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"JMrV8jnA","output_index":1,"sequence_number":17}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" blue","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"xT8lLnkR56V","output_index":1,"sequence_number":18}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" wavelengths","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"wh02","output_index":1,"sequence_number":19}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"weto75XwQfCRO","output_index":1,"sequence_number":20}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" sunlight","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"RhwzsCN","output_index":1,"sequence_number":21}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" more","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"GEqgM5BduGm","output_index":1,"sequence_number":22}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" strongly","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"RpsHl8O","output_index":1,"sequence_number":23}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" than","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"slsYTN1ybAn","output_index":1,"sequence_number":24}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" longer","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"tqJ2MVtet","output_index":1,"sequence_number":25}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" red","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"VFVPp0cq3Aws","output_index":1,"sequence_number":26}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" wavelengths","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"g470","output_index":1,"sequence_number":27}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"HqcXdjHrmEaYeY6","output_index":1,"sequence_number":28}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" sending","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"xlPIlU7r","output_index":1,"sequence_number":29}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" more","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"7uSKlQ2pfcw","output_index":1,"sequence_number":30}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" blue","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"3sl2lHfLbRU","output_index":1,"sequence_number":31}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" light","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"u5nv9DatKW","output_index":1,"sequence_number":32}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" to","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"UoFMDoWe3Nq13","output_index":1,"sequence_number":33}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" our","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"XBoGoe6DpQT1","output_index":1,"sequence_number":34}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":" eyes","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"uo3gNTKQprr","output_index":1,"sequence_number":35}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"obfuscation":"AQ7sLk0Ic24sHIN","output_index":1,"sequence_number":36}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","logprobs":[],"output_index":1,"sequence_number":37,"text":"The sky looks blue because molecules in Earth\u2019s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, sending more blue light to our eyes."}
+
+event: response.content_part.done
+data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The sky looks blue because molecules in Earth\u2019s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, sending more blue light to our eyes."},"sequence_number":38}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"msg_024bf228dd4d6ece0169cb13c6ebc481918738aef4d4bad2f4","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The sky looks blue because molecules in Earth\u2019s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, sending more blue light to our eyes."}],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":39}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_024bf228dd4d6ece0169cb13c666f88191855bb06bead52a11","object":"response","created_at":1774916550,"status":"completed","background":false,"completed_at":1774916550,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Answer in one sentence.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.4-mini-2026-03-17","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"7eac412d-25d9-4c88-895d-5772447bc5ce","prompt_cache_retention":null,"reasoning":{"effort":"low","summary":"detailed"},"safety_identifier":"user-ikDiRjiBr34aJFdyfK5kwIEM","service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":21,"input_tokens_details":{"cached_tokens":0},"output_tokens":45,"output_tokens_details":{"reasoning_tokens":8},"total_tokens":66},"user":null,"metadata":{}},"sequence_number":40}
+

--- a/tests/tests_yakbak_openai_resp.rs
+++ b/tests/tests_yakbak_openai_resp.rs
@@ -280,3 +280,66 @@ async fn test_yakbak_openai_resp_multi_tool_ordering() -> TestResult<()> {
 
 	Ok(())
 }
+
+#[tokio::test]
+async fn test_yakbak_openai_resp_reasoning_stream_completed_empty() -> TestResult<()> {
+	// Regression for the `output_item.done` capture path in `streamer.rs`.
+	//
+	// Some Responses-API-shaped backends (proxies that forward to ChatGPT
+	// internal endpoints, custom Azure deployments, etc.) emit each
+	// `type:"reasoning"` item via `response.output_item.added` and
+	// `response.output_item.done` events, but then send a terminal
+	// `response.completed` whose `response.output` array is empty `[]`.
+	//
+	// Before the fix, the streamer only scanned `response.output` at
+	// completion time to pull out encrypted reasoning blobs — so on these
+	// backends, `captured_thought_signatures()` came back empty even
+	// though the wire had clearly delivered the blob. After the fix, the
+	// blob is captured as the `output_item.done` event fires, and falls
+	// back to the `response.output` scan only if the streaming events
+	// didn't carry it.
+	let (client, _server) = replay_client("openai_resp", "reasoning_stream_completed_empty").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(ReasoningEffort::Low)
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("openai_resp::gpt-5.4-mini", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// Encrypted reasoning content should still be captured — sourced from
+	// the `output_item.done` event, not from `response.output`.
+	let thought_sigs = extract
+		.stream_end
+		.captured_thought_signatures()
+		.ok_or("Should have captured thought signatures from output_item.done")?;
+	assert_eq!(
+		thought_sigs.len(),
+		1,
+		"Should have exactly one thought signature even when response.completed.output is empty"
+	);
+	assert!(
+		thought_sigs[0].len() > 100,
+		"Encrypted content should be substantial, got {} bytes",
+		thought_sigs[0].len()
+	);
+
+	// Text content still flows through the delta events.
+	assert_eq!(
+		extract.content.as_deref(),
+		Some(
+			"The sky looks blue because molecules in Earth\u{2019}s atmosphere scatter shorter blue wavelengths of sunlight more strongly than longer red wavelengths, sending more blue light to our eyes."
+		),
+		"Text content should still arrive via delta events"
+	);
+
+	Ok(())
+}


### PR DESCRIPTION
## Problem

Reasoning models on the OpenAI Responses API (gpt-5.x, o-series, etc.) emit `type:"reasoning"` output items with an `encrypted_content` blob during streaming. To maintain reasoning state across turns — and to keep the provider-side prefix cache warm — those blobs need to ride back into the next request as top-level `type:"reasoning"` input items.

Today, `rust-genai` captures the blobs in some cases but drops them when serialising the next request, so the round-trip never closes. Also, some Responses-API-shaped backends (proxies that forward to internal endpoints, custom Azure deployments) deliver reasoning items *only* via `response.output_item.added` / `response.output_item.done` events and return an empty `response.output: []` at completion — so the existing capture path comes up empty there too.

## Fix

### 1. Capture path (`streamer.rs`)

- Add a `RespStreamEvent::OutputItemDone` variant + handler that pulls `encrypted_content` off `type:"reasoning"` items into `captured_data.thought_signatures` as the items finalise.
- Keep the prior `response.completed.response.output` scan as a fallback (gated on `thought_signatures.is_none()`), so behaviour is unchanged on backends that populate `output`.
- Mark `ContentPartAdded`'s `_output_index` / `_content_index` as `#[serde(default)]`. They're sometimes absent on the wire and currently trip a parse warning + drop the event.

### 2. Replay path (`adapter_impl.rs`)

The assistant-message arm of the OpenAI Responses input builder silently dropped `ContentPart::ThoughtSignature` (and any `thought_signatures` stashed on a `ToolCall`). Now emits each blob as a top-level `{type: "reasoning", encrypted_content: <blob>, summary: []}` input item *before* the message / function_call items it belongs to, matching the order the API uses in its own streaming output.

## Tests

- New cassette `tests/data/yakbak/openai_resp/reasoning_stream_completed_empty/` reproduces the empty-`output` failure mode (synthesised from the existing `reasoning_stream` cassette by clearing `response.completed.response.output`).
- New `test_yakbak_openai_resp_reasoning_stream_completed_empty` asserts that `captured_thought_signatures()` still surfaces the blob from `output_item.done` in that case.
- Existing `test_yakbak_openai_resp_reasoning_stream` and all other yakbak tests in the file still pass — the `response.output` scan is preserved.

## Example

`examples/c11-openai-resp-reasoning-roundtrip.rs` walks through a two-turn conversation against the real OpenAI Responses API:
- Turn 1: ask a reasoning-triggering question, capture the encrypted blob via `StreamEnd::captured_thought_signatures()`.
- Turn 2: rebuild the assistant message with `ContentPart::ThoughtSignature(blob)` parts so the adapter emits the corresponding `type:"reasoning"` input item.
- Print `prompt_tokens_details.cached_tokens` each turn so the user can observe cache behaviour.

Run with `OPENAI_API_KEY=sk-... cargo run --example c11-openai-resp-reasoning-roundtrip`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --examples`
- [x] `cargo test --test tests_yakbak_openai_resp` — 6/6 pass (5 pre-existing + 1 new)
- [ ] Live run of the new example against `api.openai.com` — recommend the maintainer try this with their own key before merging