### PR TITLE
OpenRouter Support

### DIFF
--- a/docs/for-llm/api-reference-for-llm.md
+++ b/docs/for-llm/api-reference-for-llm.md
@@ -30,7 +30,7 @@ genai (crate root / lib.rs)
 - **ModelSpec**: Specifies a model at three resolution levels: `Name`, `Iden`, or `Target`.
 - **ServiceTarget**: Fully resolved call target: `ModelIden` + `Endpoint` + `AuthData`.
 - **Resolvers**: User hooks to customize model mapping, authentication, and service endpoints.
-- **AdapterKind**: Supported providers: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Aliyun`, `Cohere`, `Ollama`, `OllamaCloud`, `OpenCodeGo`, `Vertex`, `GithubCopilot`.
+- **AdapterKind**: Supported providers: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Aliyun`, `Cohere`, `Ollama`, `OllamaCloud`, `OpenCodeGo`, `Vertex`, `GithubCopilot`, `OpenRouter`.
   - `GithubCopilot` is a GitHub Models gateway with multi-publisher namespaced models such as `github_copilot::openai/gpt-4.1-mini`, `github_copilot::anthropic/claude-sonnet-4-6`, and `github_copilot::google/gemini-2.5-pro`.
   - `OllamaCloud` is the hosted Ollama Cloud service (`ollama.com`). Uses the same native Ollama protocol as the local `Ollama` adapter but authenticates with `Authorization: Bearer $OLLAMA_API_KEY`. Use via `ollama_cloud::model_name` namespace (e.g., `ollama_cloud::gemma3:4b`).
   - `Vertex` is Google Vertex AI Model Garden routing for Gemini and Anthropic models via the `vertex::` namespace.
@@ -504,7 +504,7 @@ Single-value-per-name HTTP header map.
 
 Enum identifying the AI provider adapter.
 
-Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Aliyun`, `Cohere`, `Ollama`, `OllamaCloud`, `OpenCodeGo`, `Vertex`, `GithubCopilot`.
+Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`, `Groq`, `Mimo`, `Nebius`, `Xai`, `DeepSeek`, `Zai`, `BigModel`, `Aliyun`, `Cohere`, `Ollama`, `OllamaCloud`, `OpenCodeGo`, `Vertex`, `GithubCopilot`, `OpenRouter`.
 
 - `as_str()`: Display name (e.g., `"OpenAI"`, `"xAi"`).
 - `as_lower_str()`: Lowercase name (e.g., `"openai"`, `"xai"`).
@@ -527,7 +527,7 @@ Variants: `OpenAI`, `OpenAIResp`, `Gemini`, `Anthropic`, `Fireworks`, `Together`
   - `glm*` -> `Zai`.
   - Fallback -> `Ollama`.
 - **Namespacing**: `namespace::model_name` (e.g., `together::meta-llama/...`, `nebius::Qwen/...`).
-  - Namespace matches adapter lowercase name (e.g., `openai::`, `gemini::`, `anthropic::`, `fireworks::`, `together::`, `groq::`, `mimo::`, `nebius::`, `xai::`, `deepseek::`, `zai::`, `bigmodel::`, `aliyun::`, `cohere::`, `ollama::`, `ollama_cloud::`, `opencode_go::`, `vertex::`, `openai_resp::`, `github_copilot::`)
+  - Namespace matches adapter lowercase name (e.g., `openai::`, `gemini::`, `anthropic::`, `fireworks::`, `together::`, `groq::`, `mimo::`, `nebius::`, `xai::`, `deepseek::`, `zai::`, `bigmodel::`, `aliyun::`, `cohere::`, `ollama::`, `ollama_cloud::`, `opencode_go::`, `vertex::`, `openai_resp::`, `github_copilot::`, `open_router::`)
   - Special: `coding::` namespace maps to `Zai` adapter.
 - **Namespace-only or recommended namespace providers**:
   - `groq::model_name` is required for direct Groq targeting in v0.6.0-beta.

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -7,6 +7,7 @@ use crate::adapter::adapters::github_copilot::GithubCopilotAdapter;
 use crate::adapter::adapters::ollama::OllamaAdapter;
 use crate::adapter::adapters::ollama_cloud::OllamaCloudAdapter;
 use crate::adapter::adapters::openai_resp::OpenAIRespAdapter;
+use crate::adapter::adapters::open_router::OpenRouterAdapter;
 use crate::adapter::adapters::opencode_go::OpenCodeGoAdapter;
 use crate::adapter::adapters::together::TogetherAdapter;
 use crate::adapter::adapters::zai::ZaiAdapter;
@@ -92,6 +93,10 @@ pub enum AdapterKind {
 	/// Requires the `bedrock-sigv4` Cargo feature.
 	#[cfg(feature = "bedrock-sigv4")]
 	BedrockSigv4,
+	/// OpenRouter — OpenAI-compatible gateway for many providers (OpenAI, Anthropic, Google, etc.).
+	/// Namespace: `open_router::openai/gpt-4.1`, `open_router::anthropic/claude-sonnet-4-5`.
+	/// Uses `OPEN_ROUTER_API_KEY`.
+	OpenRouter,
 }
 
 /// Serialization/Parse implementations
@@ -124,6 +129,7 @@ impl AdapterKind {
 			AdapterKind::BedrockApi => "BedrockApi",
 			#[cfg(feature = "bedrock-sigv4")]
 			AdapterKind::BedrockSigv4 => "BedrockSigv4",
+			AdapterKind::OpenRouter => "OpenRouter",
 		}
 	}
 
@@ -155,6 +161,7 @@ impl AdapterKind {
 			AdapterKind::BedrockApi => "bedrock_api",
 			#[cfg(feature = "bedrock-sigv4")]
 			AdapterKind::BedrockSigv4 => "bedrock_sigv4",
+			AdapterKind::OpenRouter => "open_router",
 		}
 	}
 
@@ -185,6 +192,7 @@ impl AdapterKind {
 			"bedrock_api" => Some(AdapterKind::BedrockApi),
 			#[cfg(feature = "bedrock-sigv4")]
 			"bedrock_sigv4" => Some(AdapterKind::BedrockSigv4),
+			"open_router" => Some(AdapterKind::OpenRouter),
 			_ => None,
 		}
 	}
@@ -220,6 +228,7 @@ impl AdapterKind {
 			AdapterKind::BedrockApi => BedrockApiAdapter::DEFAULT_API_KEY_ENV_NAME,
 			#[cfg(feature = "bedrock-sigv4")]
 			AdapterKind::BedrockSigv4 => BedrockSigv4Adapter::DEFAULT_API_KEY_ENV_NAME,
+			AdapterKind::OpenRouter => OpenRouterAdapter::DEFAULT_API_KEY_ENV_NAME,
 		}
 	}
 }

--- a/src/adapter/adapters/mod.rs
+++ b/src/adapter/adapters/mod.rs
@@ -16,6 +16,7 @@ pub(super) mod moonshot;
 pub(super) mod nebius;
 pub(super) mod ollama;
 pub(super) mod ollama_cloud;
+pub(super) mod open_router;
 pub(super) mod openai;
 pub(super) mod openai_resp;
 pub(super) mod opencode_go;

--- a/src/adapter/adapters/open_router/adapter_impl.rs
+++ b/src/adapter/adapters/open_router/adapter_impl.rs
@@ -1,0 +1,81 @@
+use crate::ModelIden;
+use crate::adapter::openai::OpenAIAdapter;
+use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
+use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStreamResponse};
+use crate::resolver::{AuthData, Endpoint};
+use crate::webc::WebResponse;
+use crate::{Result, ServiceTarget};
+use reqwest::RequestBuilder;
+
+/// The OpenRouter API is compatible with the OpenAI API.
+/// NOTE: This adapter is activated for namespaced model names (e.g., `open_router::openai/gpt-4.1`)
+pub struct OpenRouterAdapter;
+
+impl OpenRouterAdapter {
+	pub const API_KEY_DEFAULT_ENV_NAME: &str = "OPEN_ROUTER_API_KEY";
+}
+
+impl Adapter for OpenRouterAdapter {
+	const DEFAULT_API_KEY_ENV_NAME: Option<&'static str> = Some(Self::API_KEY_DEFAULT_ENV_NAME);
+
+	fn default_endpoint() -> Endpoint {
+		const BASE_URL: &str = "https://openrouter.ai/api/v1/";
+		Endpoint::from_static(BASE_URL)
+	}
+
+	fn default_auth() -> AuthData {
+		match Self::DEFAULT_API_KEY_ENV_NAME {
+			Some(env_name) => AuthData::from_env(env_name),
+			None => AuthData::None,
+		}
+	}
+
+	async fn all_model_names(kind: AdapterKind, endpoint: Endpoint, auth: AuthData) -> Result<Vec<String>> {
+		OpenAIAdapter::list_model_names_for_end_target(kind, endpoint, auth).await
+	}
+
+	fn get_service_url(model: &ModelIden, service_type: ServiceType, endpoint: Endpoint) -> Result<String> {
+		OpenAIAdapter::util_get_service_url(model, service_type, endpoint)
+	}
+
+	fn to_web_request_data(
+		target: ServiceTarget,
+		service_type: ServiceType,
+		chat_req: ChatRequest,
+		chat_options: ChatOptionsSet<'_, '_>,
+	) -> Result<WebRequestData> {
+		OpenAIAdapter::util_to_web_request_data(target, service_type, chat_req, chat_options, None)
+	}
+
+	fn to_chat_response(
+		model_iden: ModelIden,
+		web_response: WebResponse,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatResponse> {
+		OpenAIAdapter::to_chat_response(model_iden, web_response, options_set)
+	}
+
+	fn to_chat_stream(
+		model_iden: ModelIden,
+		reqwest_builder: RequestBuilder,
+		options_set: ChatOptionsSet<'_, '_>,
+	) -> Result<ChatStreamResponse> {
+		OpenAIAdapter::to_chat_stream(model_iden, reqwest_builder, options_set)
+	}
+
+	fn to_embed_request_data(
+		service_target: crate::ServiceTarget,
+		embed_req: crate::embed::EmbedRequest,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::adapter::WebRequestData> {
+		OpenAIAdapter::to_embed_request_data(service_target, embed_req, options_set)
+	}
+
+	fn to_embed_response(
+		model_iden: crate::ModelIden,
+		web_response: crate::webc::WebResponse,
+		options_set: crate::embed::EmbedOptionsSet<'_, '_>,
+	) -> Result<crate::embed::EmbedResponse> {
+		OpenAIAdapter::to_embed_response(model_iden, web_response, options_set)
+	}
+}

--- a/src/adapter/adapters/open_router/mod.rs
+++ b/src/adapter/adapters/open_router/mod.rs
@@ -1,0 +1,6 @@
+//! API Documentation: <https://openrouter.ai/docs>
+//! Model Names:       <https://openrouter.ai/models>
+
+mod adapter_impl;
+
+pub use adapter_impl::*;

--- a/src/adapter/dispatcher_macros.rs
+++ b/src/adapter/dispatcher_macros.rs
@@ -116,6 +116,10 @@ macro_rules! dispatch_adapter {
 				type A = crate::adapter::adapters::bedrock::[<BedrockSigv4 Adapter>];
 				$body
 			}
+			crate::adapter::AdapterKind::OpenRouter => {
+				type A = crate::adapter::adapters::open_router::[<OpenRouter Adapter>];
+				$body
+			}
 		}
 	};
 }


### PR DESCRIPTION
This PR adds support for the OpenRouter adapter.

OpenRouter provides an OpenAI-compatible API (https://openrouter.ai/) with a wide range of models.

Features:
- Namespace-based routing: open_router::model-name
- OpenAI-compatible protocol (delegates to OpenAIAdapter)
- API key via environment variable OPEN_ROUTER_API_KEY
- Default endpoint: https://openrouter.ai/api/v1/

I'm a little confused about whether tests is mandatory.