### PR TITLE
feat: add cache_control on Tool for Anthropic prompt caching

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_impl.rs
+++ b/src/adapter/adapters/anthropic/adapter_impl.rs
@@ -827,6 +827,7 @@ impl AnthropicAdapter {
 			description,
 			schema,
 			config,
+			cache_control,
 			..
 		} = tool;
 
@@ -874,6 +875,10 @@ impl AnthropicAdapter {
 				// TODO: need to handle error
 				let _ = tool_value.x_insert("description", description);
 			}
+		}
+
+		if let Some(cc) = cache_control {
+			let _ = tool_value.x_insert("cache_control", cache_control_to_json(&cc));
 		}
 
 		Ok(tool_value)

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -599,6 +599,7 @@ impl OpenAIRespAdapter {
 			schema,
 			strict,
 			config,
+			..
 		} = tool;
 
 		let name = match name {

--- a/src/chat/tool/tool_base.rs
+++ b/src/chat/tool/tool_base.rs
@@ -1,4 +1,5 @@
 use super::{ToolConfig, ToolName};
+use crate::chat::CacheControl;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -47,6 +48,11 @@ pub struct Tool {
 	///
 	/// Useful with embedded provider tools (e.g., Google Search for Gemini).
 	pub config: Option<ToolConfig>,
+
+	/// Optional cache control hint for prompt caching.
+	/// Anthropic: set on the last tool to cache the entire tool list prefix.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cache_control: Option<CacheControl>,
 }
 
 /// Computed accessors
@@ -90,6 +96,7 @@ impl Tool {
 			schema: None,
 			strict: None,
 			config: None,
+			cache_control: None,
 		}
 	}
 
@@ -124,6 +131,13 @@ impl Tool {
 	/// Set provider-specific configuration (if any). Returns self for chaining.
 	pub fn with_config(mut self, config: impl Into<ToolConfig>) -> Self {
 		self.config = Some(config.into());
+		self
+	}
+
+	/// Set cache control for prompt caching. Returns self for chaining.
+	/// On Anthropic, set this on the last tool to cache the entire tool list prefix.
+	pub fn with_cache_control(mut self, cache_control: impl Into<CacheControl>) -> Self {
+		self.cache_control = Some(cache_control.into());
 		self
 	}
 }


### PR DESCRIPTION
## What

Adds `cache_control: Option<CacheControl>` to the `Tool` struct so callers can mark tool definitions for Anthropic prompt caching, and wires it through the Anthropic adapter.

## Why

Tool definitions are often large and static across requests. Marking the tool-definition prefix with `cache_control` lets Anthropic cache it, reducing re-tokenization (and cost/latency) on every subsequent request. Set `cache_control` on the last tool in the array to cache the entire tool block.

## How

- `src/chat/tool/tool_base.rs` — adds the `cache_control` field plus a `with_cache_control(...)` builder.
- `src/adapter/adapters/anthropic/adapter_impl.rs` — serializes it using the existing `cache_control_to_json()` helper.
- `src/adapter/adapters/openai_resp/adapter_impl.rs` — minor adjustment for the new field.

3 files changed, +20. Rebased onto current `main` (`v0.6.4-WIP`); `cargo check` passes.

## Usage

```rust
let tool = Tool::new("get_weather")
    .with_description("Get the current weather for a location")
    .with_schema(/* ... */)
    .with_cache_control(CacheControl::Ephemeral);
```
