### PR TITLE
build(reqwest): selectable TLS backends with a working rustls default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- `!` build - reqwest TLS is now selectable via cargo features: `rustls-tls` (default; rustls + aws-lc-rs + OS trust store) and `native-tls`. reqwest switches to `default-features = false` with all previously-implicit features pinned explicitly; the default (`rustls-tls`) uses the same crypto backend as before, so HTTPS keeps working out of the box. BYO crypto provider / custom CA / mTLS via `ClientBuilder::with_reqwest`.
+- `!` build - reqwest TLS is now selectable via cargo features: `rustls-tls` (default; rustls + aws-lc-rs + OS trust store) and `native-tls`. reqwest switches to `default-features = false` with all previously-implicit features pinned explicitly; the default (`rustls-tls`) uses the same crypto backend as before, so HTTPS keeps working out of the box. BYO crypto provider / custom CA / mTLS via `ClientBuilder::with_reqwest`. Enabling both backends at once fails fast with a `compile_error!` instead of silently picking one.
 
 ## 2026-05-29 - [v0.6.1](https://github.com/jeremychone/rust-genai/compare/v0.6.2...v0.6.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 `.` minor | `-` Fix | `+` Addition | `^` improvement | `!` Change | `>` Refactor
 
+## Unreleased
+
+- `!` build - reqwest TLS is now selectable via cargo features: `rustls-tls` (default; rustls + aws-lc-rs + OS trust store) and `native-tls`. reqwest switches to `default-features = false` with all previously-implicit features pinned explicitly; the default (`rustls-tls`) uses the same crypto backend as before, so HTTPS keeps working out of the box. BYO crypto provider / custom CA / mTLS via `ClientBuilder::with_reqwest`.
+
 ## 2026-05-29 - [v0.6.1](https://github.com/jeremychone/rust-genai/compare/v0.6.2...v0.6.3)
 
 - `^` use adaptive thinking for opus 4.7 (and above)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ default = ["rustls-tls"]
 # Recommended: no system OpenSSL, works on musl/static, honors enterprise CAs.
 rustls-tls = ["reqwest/rustls"]
 # System TLS: OpenSSL (Linux) / SChannel (Windows) / Secure Transport (macOS).
-# NOTE: rustls-tls and native-tls are mutually exclusive at the reqwest level. When
-# selecting native-tls, set `default-features = false` — otherwise reqwest compiles
-# both backends and silently uses native-tls as the active one.
+# NOTE: rustls-tls and native-tls are mutually exclusive. When selecting native-tls,
+# set `default-features = false` — otherwise both backends compile and the build fails
+# with a `compile_error!` (see src/lib.rs) telling you to do so.
 native-tls = ["reqwest/native-tls"]
 #
 # BYO crypto provider (FIPS/ring), static OpenSSL, custom root CAs, or mTLS: not a genai

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,21 @@ unsafe_code = "forbid"
 # missing_docs = "warn"
 
 [features]
-default = []
+default = ["rustls-tls"]
+
+# -- TLS backend (forwarded to reqwest). Pick ONE; `rustls-tls` is the default.
+# rustls + aws-lc-rs provider + OS trust store (rustls-platform-verifier).
+# Recommended: no system OpenSSL, works on musl/static, honors enterprise CAs.
+rustls-tls = ["reqwest/rustls"]
+# System TLS: OpenSSL (Linux) / SChannel (Windows) / Secure Transport (macOS).
+# NOTE: rustls-tls and native-tls are mutually exclusive at the reqwest level. When
+# selecting native-tls, set `default-features = false` — otherwise reqwest compiles
+# both backends and silently uses native-tls as the active one.
+native-tls = ["reqwest/native-tls"]
+#
+# BYO crypto provider (FIPS/ring), static OpenSSL, custom root CAs, or mTLS: not a genai
+# feature — build your own `reqwest::Client` and inject it via `Client::builder().with_reqwest(...)`.
+
 # AWS Bedrock Converse adapter using SigV4 signing + the full AWS credential chain.
 # Pulls in aws-config (env → profile → SSO → IMDS → AssumeRole) and aws-sigv4 (request signing).
 # Heavy: aws-config transitively adds aws-smithy-*, hyper, tower, h2.
@@ -39,7 +53,7 @@ serde = { version = "1", features = ["derive", "rc"] } # Opted to rc for Arc<T> 
 serde_json = "1"
 serde_with = "3"
 # -- Web
-reqwest = {version = "0.13",  features = ["json", "stream", "gzip"]}
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "gzip", "charset", "http2", "system-proxy"] }
 eventsource-stream = "0.2"
 bytes = "1.6"
 # -- File

--- a/README.md
+++ b/README.md
@@ -313,6 +313,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 > Note: Feel free to send me a short description and a link to your application or library that uses genai. I'm happy to add it.
 
+## TLS Backends
+
+TLS is selectable via cargo features. The default works out of the box and is right for almost everyone.
+
+| You want… | Use |
+|---|---|
+| A backend that just works (default) | nothing — `rustls-tls` (rustls + aws-lc-rs + OS trust store) |
+| System trust policy / OpenSSL or SChannel | `genai = { default-features = false, features = ["native-tls"] }` |
+| ring / FIPS / no `aws-lc-sys` (lean musl & cross builds) | `genai = { default-features = false }`, add your own `reqwest = { features = ["rustls-no-provider"] }` + a provider (e.g. `rustls` with `ring`), and call `CryptoProvider::install_default()` at startup |
+| Static OpenSSL | `genai = { default-features = false }` + your own `reqwest = { features = ["native-tls-vendored"] }` |
+| Custom root CA / mTLS / fully custom client | build your own `reqwest::Client` and inject it via `with_reqwest(...)` |
+
+`rustls-tls` and `native-tls` are mutually exclusive. When selecting `native-tls`, set `default-features = false` (as shown above) — otherwise both backends compile and reqwest silently uses native-tls.
+
+`rustls-tls` reads the OS trust store via `rustls-platform-verifier`, so enterprise/custom CAs work without `native-tls`, and it needs no system OpenSSL. Note the default `aws-lc-rs` provider builds `aws-lc-sys` (a C/assembly crate); for a leaner static-musl or cross build, drop it with `default-features = false` and use the `ring` provider as in the table above.
+
+For full control, build a `reqwest::Client` yourself and inject it:
+
+```rust
+let reqwest_client = reqwest::Client::builder()
+    // .add_root_certificate(...), client identity for mTLS, custom CryptoProvider, etc.
+    .build()?;
+
+let client = genai::Client::builder()
+    .with_reqwest(reqwest_client)
+    .build();
+```
+
+If you set `default-features = false` on `genai` without enabling a TLS feature, add `reqwest` with a TLS feature directly to your own `Cargo.toml` (or use the `rustls-no-provider` path and install a `CryptoProvider`) — otherwise HTTPS requests fail at runtime.
+
 ## Links
 
 - crates.io: [crates.io/crates/genai](https://crates.io/crates/genai)

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ TLS is selectable via cargo features. The default works out of the box and is ri
 | Static OpenSSL | `genai = { default-features = false }` + your own `reqwest = { features = ["native-tls-vendored"] }` |
 | Custom root CA / mTLS / fully custom client | build your own `reqwest::Client` and inject it via `with_reqwest(...)` |
 
-`rustls-tls` and `native-tls` are mutually exclusive. When selecting `native-tls`, set `default-features = false` (as shown above) — otherwise both backends compile and reqwest silently uses native-tls.
+`rustls-tls` and `native-tls` are mutually exclusive. When selecting `native-tls`, set `default-features = false` (as shown above) — otherwise both backends compile and the build fails with a `compile_error!` telling you to do so.
 
 `rustls-tls` reads the OS trust store via `rustls-platform-verifier`, so enterprise/custom CAs work without `native-tls`, and it needs no system OpenSSL. Note the default `aws-lc-rs` provider builds `aws-lc-sys` (a C/assembly crate); for a leaner static-musl or cross build, drop it with `default-features = false` and use the `ring` provider as in the table above.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,18 @@ pub mod resolver;
 pub mod webc;
 
 // endregion: --- Modules
+
+// region:    --- TLS Backend Guard
+
+// TLS backends are mutually exclusive (forwarded to reqwest; see Cargo.toml / README).
+// Enabling `native-tls` without `default-features = false` leaves `rustls-tls` on from
+// the default set; turn that silent mis-selection into a clear compile-time error.
+// The "neither feature" case is intentionally allowed — it is the supported
+// bring-your-own-client path (`with_reqwest`).
+#[cfg(all(feature = "rustls-tls", feature = "native-tls"))]
+compile_error!(
+	"genai: `rustls-tls` and `native-tls` are mutually exclusive. \
+	 To use native-tls, set `default-features = false` and enable `native-tls`."
+);
+
+// endregion: --- TLS Backend Guard


### PR DESCRIPTION
## Why

genai pins reqwest's `rustls` feature, which forces the **aws-lc-rs** crypto provider and pulls in `aws-lc-sys` — a C/assembly crate that needs aws-lc's kernel headers / libatomic and breaks (or badly complicates) lean **static-musl** and cross-compiled builds. Today there's no supported way to opt out without forking genai: a downstream shipping a static-musl service that standardizes on the `ring` provider had to fork just to keep `aws-lc-sys` out of its tree.

## What

Disable reqwest's default features and pin the non-TLS set (`json, stream, gzip, charset, http2, system-proxy`). Expose TLS via two genai features:

- **`rustls-tls`** (default) → `reqwest/rustls` = aws-lc-rs + OS trust store via `rustls-platform-verifier`. **Identical crypto to reqwest's own `default-tls`**, so existing users are unaffected and HTTPS works out of the box.
- **`native-tls`** → system OpenSSL / SChannel / Secure Transport.

Setting `default-features = false` drops the provider entirely, so a downstream can supply its own — e.g. `ring` via `CryptoProvider::install_default()` plus its own `reqwest` with `rustls-no-provider` — and keep `aws-lc-sys` off the tree. Custom root CAs / mTLS go through the existing `Client::builder().with_reqwest(...)`.

Adds a README **"TLS Backends"** decision table.

## Notes

- `rustls-tls` and `native-tls` are mutually exclusive at the reqwest level; select `native-tls` with `default-features = false`.
- Feature names use the ecosystem `-tls` convention — happy to rename to taste.
- Verified: the default (`rustls-tls`) and `--no-default-features` builds compile, and the replay test suite is green. `native-tls` wiring is correct (a local build just needs system OpenSSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
