### PR TITLE
feat(anthropic): prompt caching on tools + request-level cache control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 `.` minor | `-` Fix | `+` Addition | `^` improvement | `!` Change | `>` Refactor
 
+## Unreleased
+
+- `+` anthropic - prompt caching on tools via `Tool::with_cache_control`, and request-level `ChatOptions::with_cache_control` now auto-applies a cache breakpoint to the static (tools+system) prefix (was previously ignored). `Ephemeral24h` is documented as clamped to Anthropic's max `1h` TTL.
+
 ## 2026-06-06 [v0.6.5](https://github.com/jeremychone/rust-genai/compare/v0.6.4...v0.6.5)
 
 - `-` fix: capture OpenAI stream usage tail (PR #242)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here’s what’s new:
 - **Chat extra body**: `ChatOptions::with_extra_body(...)` provides a low-level request body extension point for provider-specific fields in OpenAI-compatible chat payloads.
 - **Tool choice**: `ChatOptions::with_tool_choice(...)` adds provider-neutral tool selection hints for automatic, disabled, required, or specific tool calls.
 - **Built-in tools and WebSearch**: Added typed built-in tool support, including `ToolName`, `ToolConfig`, `WebSearch`, and provider mappings for Anthropic, OpenAI, and Gemini.
-- **Prompt cache controls**: Chat-level `CacheControl` support adds provider-specific prompt caching options, including OpenAI `prompt_cache_key` and cache retention.
+- **Prompt cache controls**: Chat-level `CacheControl` support adds provider-specific prompt caching options, including OpenAI `prompt_cache_key` and cache retention. On Anthropic, `Tool::with_cache_control` marks individual tools, and request-level `ChatOptions::with_cache_control` auto-applies a breakpoint to the static (tools+system) prefix.
 - **Updated API**: Refined `ReasoningContent` and `StopReason` handling (v0.6.0-beta.20), including `ContentPart::ReasoningContent` and provider stop reasons.
 - **Perf Improvements**: HTTP requests use performance optimizations such as gzip, `TCP_NODELAY`, and HTTP/2 tuning.
 - Numerous fixes, optimizations, and API enhancements.

--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -12,7 +12,6 @@ use crate::webc::WebResponse;
 use crate::{Headers, ModelIden};
 use serde_json::{Map, Value, json};
 use std::sync::OnceLock;
-use tracing::info;
 use tracing::warn;
 use value_ext::JsonValueExt;
 
@@ -107,7 +106,8 @@ impl AnthropicAdapter {
 	/// Takes the GenAI ChatMessages and constructs the System string and JSON Messages for Anthropic.
 	/// - Will push the `ChatRequest.system` and system message to `AnthropicRequestParts.system`
 	pub(in crate::adapter::adapters) fn into_anthropic_request_parts(
-		chat_req: ChatRequest,
+		mut chat_req: ChatRequest,
+		request_cache_control: Option<CacheControl>,
 	) -> Result<AnthropicRequestParts> {
 		let mut messages: Vec<Value> = Vec::new();
 		// (content, cache_control)
@@ -122,9 +122,17 @@ impl AnthropicAdapter {
 			systems.push((system, None));
 		}
 
+		// Track explicit message-level breakpoints so request-level cache_control can defer to them.
+		let mut has_msg_cache = false;
+
 		// -- Process the messages
 		for msg in chat_req.messages {
 			let cache_control = msg.options.and_then(|o| o.cache_control);
+			// Any explicit message cache_control (incl. System-role, part of the static prefix)
+			// counts as a breakpoint; request-level placement (below) defers to it.
+			if cache_control.is_some() {
+				has_msg_cache = true;
+			}
 
 			// Check TTL ordering constraint
 			if let Some(ref cc) = cache_control {
@@ -135,8 +143,8 @@ impl AnthropicAdapter {
 					CacheControl::Ephemeral1h | CacheControl::Ephemeral24h => {
 						if seen_5m_cache {
 							warn!(
-								"Anthropic cache TTL ordering violation: Ephemeral1h appears after Ephemeral/Ephemeral5m. \
-								1-hour cache entries must appear before 5-minute cache entries. \
+								"Anthropic cache TTL ordering violation: a longer-TTL entry (Ephemeral1h/Ephemeral24h) appears after Ephemeral/Ephemeral5m. \
+								Longer-TTL cache entries must appear before shorter (5-minute) entries. \
 								See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#mixing-different-ttls"
 							);
 						}
@@ -310,6 +318,24 @@ impl AnthropicAdapter {
 			}
 		}
 
+		// -- Request-level cache control (Approach B): with no explicit breakpoint, auto-mark the
+		// static prefix — the last system block (caches tools+system), else the last tool; no-op otherwise.
+		if let Some(req_cc) = request_cache_control {
+			let has_tool_cache = chat_req
+				.tools
+				.as_ref()
+				.map(|tools| tools.iter().any(|t| t.cache_control.is_some()))
+				.unwrap_or(false);
+
+			if !has_msg_cache && !has_tool_cache {
+				if let Some(last_system) = systems.last_mut() {
+					last_system.1 = Some(req_cc);
+				} else if let Some(last_tool) = chat_req.tools.as_mut().and_then(|tools| tools.last_mut()) {
+					last_tool.cache_control = Some(req_cc);
+				}
+			}
+		}
+
 		// -- Create the Anthropic system
 		// NOTE: Anthropic does not have a "role": "system", just a single optional system property
 		let system = if !systems.is_empty() {
@@ -382,7 +408,7 @@ impl AnthropicAdapter {
 			system,
 			messages,
 			tools,
-		} = Self::into_anthropic_request_parts(chat_req)?;
+		} = Self::into_anthropic_request_parts(chat_req, options_set.cache_control().cloned())?;
 
 		// -- Extract Model Name and Reasoning
 		let (_, raw_model_name) = model.model_name.namespace_and_name();
@@ -442,12 +468,6 @@ impl AnthropicAdapter {
 
 		if let Some(computed_reasoning_effort) = computed_reasoning_effort {
 			insert_anthropic_reasoning(&mut payload, &mut output_config, model_name, &computed_reasoning_effort)?;
-		}
-
-		if let Some(cache_control) = options_set.cache_control() {
-			info!(
-				"Anthropic request-level cache_control '{cache_control:?}' is currently ignored. Use message-level cache_control instead."
-			);
 		}
 
 		// -- Add supported ChatOptions
@@ -615,6 +635,7 @@ impl AnthropicAdapter {
 			description,
 			schema,
 			config,
+			cache_control,
 			..
 		} = tool;
 
@@ -662,6 +683,10 @@ impl AnthropicAdapter {
 				// TODO: need to handle error
 				let _ = tool_value.x_insert("description", description);
 			}
+		}
+
+		if let Some(cc) = cache_control {
+			let _ = tool_value.x_insert("cache_control", cache_control_to_json(&cc));
 		}
 
 		Ok(tool_value)
@@ -828,6 +853,7 @@ fn cache_control_to_json(cache_control: &CacheControl) -> Value {
 		CacheControl::Ephemeral1h => {
 			json!({"type": "ephemeral", "ttl": "1h"})
 		}
+		// Anthropic's max ephemeral TTL is 1h, so 24h clamps to 1h (see CacheControl::Ephemeral24h docs).
 		CacheControl::Ephemeral24h => {
 			json!({"type": "ephemeral", "ttl": "1h"})
 		}
@@ -913,7 +939,7 @@ mod tests {
 	use super::*;
 	use crate::ServiceTarget;
 	use crate::adapter::{Adapter, ServiceType};
-	use crate::chat::{ChatOptions, ChatRequest, JsonSpec, Tool, ToolChoice};
+	use crate::chat::{ChatMessage, ChatOptions, ChatRequest, JsonSpec, Tool, ToolChoice};
 	use crate::resolver::AuthData;
 
 	/// Regression guard: when both `reasoning_effort` and `JsonSpec` response format are set
@@ -1000,6 +1026,164 @@ mod tests {
 			.expect("to_web_request_data should succeed");
 
 		assert_eq!(web_req.payload["tool_choice"], json!({"type": "any"}));
+	}
+
+	/// A `cache_control` set on a `Tool` must be serialized onto that tool in the
+	/// Anthropic `tools` payload, so the tool-definition prefix can be prompt-cached.
+	#[test]
+	fn test_tool_cache_control_serialized_on_anthropic_payload() {
+		// -- Setup & Fixtures
+		let ephemeral_tool = Tool::new("get_weather")
+			.with_description("Get the current weather for a location")
+			.with_schema(json!({"type": "object", "properties": {}}))
+			.with_cache_control(CacheControl::Ephemeral);
+		let one_hour_tool = Tool::new("get_time")
+			.with_description("Get the current time for a location")
+			.with_schema(json!({"type": "object", "properties": {}}))
+			.with_cache_control(CacheControl::Ephemeral1h);
+		let plain_tool = Tool::new("get_news")
+			.with_description("Get the latest news")
+			.with_schema(json!({"type": "object", "properties": {}}));
+
+		let chat_req = ChatRequest::from_user("hello").with_tools([ephemeral_tool, one_hour_tool, plain_tool]);
+
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+		};
+		let options_set = ChatOptionsSet::default();
+
+		// -- Exec
+		let web_req = AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, options_set)
+			.expect("to_web_request_data should succeed");
+
+		// -- Check
+		let tools = web_req
+			.payload
+			.get("tools")
+			.and_then(|t| t.as_array())
+			.expect("tools array must be present");
+		assert_eq!(tools.len(), 3, "all three tools must be present");
+		assert_eq!(
+			tools[0].get("cache_control"),
+			Some(&json!({"type": "ephemeral"})),
+			"Ephemeral must serialize without a ttl"
+		);
+		assert_eq!(
+			tools[1].get("cache_control"),
+			Some(&json!({"type": "ephemeral", "ttl": "1h"})),
+			"Ephemeral1h must serialize with ttl '1h'"
+		);
+		assert_eq!(
+			tools[2].get("cache_control"),
+			None,
+			"a tool without cache_control must not emit the field"
+		);
+	}
+
+	/// Request-level cache_control with no explicit breakpoint must auto-mark the last
+	/// system block (caching the tools+system prefix) on Anthropic.
+	#[test]
+	fn test_request_level_cache_control_auto_breakpoint_on_system() {
+		let chat_req = ChatRequest::from_user("hello").with_system("a long, stable system prompt");
+		let chat_options = ChatOptions::default().with_cache_control(CacheControl::Ephemeral);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, options_set)
+			.expect("to_web_request_data should succeed");
+
+		let system = web_req.payload.get("system").expect("system must be present");
+		let parts = system
+			.as_array()
+			.expect("system must be a multi-part array when cache_control is applied");
+		let last = parts.last().expect("system must have at least one part");
+		assert_eq!(
+			last.get("cache_control"),
+			Some(&json!({"type": "ephemeral"})),
+			"request-level cache_control must auto-apply to the last system block"
+		);
+	}
+
+	/// With no system but tools present, request-level cache_control falls back to the last tool.
+	#[test]
+	fn test_request_level_cache_control_falls_back_to_last_tool_when_no_system() {
+		let tool_a = Tool::new("a").with_schema(json!({"type": "object", "properties": {}}));
+		let tool_b = Tool::new("b").with_schema(json!({"type": "object", "properties": {}}));
+		let chat_req = ChatRequest::from_user("hello").with_tools([tool_a, tool_b]);
+		let chat_options = ChatOptions::default().with_cache_control(CacheControl::Ephemeral);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, options_set)
+			.expect("to_web_request_data should succeed");
+
+		let tools = web_req.payload.get("tools").and_then(|t| t.as_array()).expect("tools array");
+		assert_eq!(tools.len(), 2);
+		assert_eq!(tools[0].get("cache_control"), None, "non-last tool must not be marked");
+		assert_eq!(
+			tools[1].get("cache_control"),
+			Some(&json!({"type": "ephemeral"})),
+			"request-level cache_control must fall back to the last tool"
+		);
+		assert!(web_req.payload.get("system").is_none(), "no system should be present");
+	}
+
+	/// With neither system nor tools, request-level cache_control is a no-op.
+	#[test]
+	fn test_request_level_cache_control_noop_without_static_prefix() {
+		let chat_req = ChatRequest::from_user("hello");
+		let chat_options = ChatOptions::default().with_cache_control(CacheControl::Ephemeral);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, options_set)
+			.expect("to_web_request_data should succeed");
+
+		assert!(web_req.payload.get("system").is_none(), "no system");
+		assert!(web_req.payload.get("tools").is_none(), "no tools");
+		let messages = web_req.payload.get("messages").and_then(|m| m.as_array()).expect("messages");
+		assert!(
+			messages[0]["content"].is_string(),
+			"user content must be a plain string with no cache_control breakpoint"
+		);
+	}
+
+	/// When an explicit message-level breakpoint exists, request-level cache_control must
+	/// NOT auto-apply to the system prefix (defer to the explicit breakpoint).
+	#[test]
+	fn test_request_level_cache_control_deferred_when_explicit_present() {
+		let user_msg = ChatMessage::user("hello").with_options(CacheControl::Ephemeral);
+		let chat_req = ChatRequest::new(vec![user_msg]).with_system("a long, stable system prompt");
+		let chat_options = ChatOptions::default().with_cache_control(CacheControl::Ephemeral1h);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, options_set)
+			.expect("to_web_request_data should succeed");
+
+		let system = web_req.payload.get("system").expect("system present");
+		assert!(
+			system.is_string(),
+			"system must remain a plain string (request-level deferred to the explicit message breakpoint)"
+		);
 	}
 
 	#[test]

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -598,6 +598,7 @@ impl OpenAIRespAdapter {
 			schema,
 			strict,
 			config,
+			..
 		} = tool;
 
 		let name = match name {

--- a/src/adapter/adapters/opencode_go/adapter_impl.rs
+++ b/src/adapter/adapters/opencode_go/adapter_impl.rs
@@ -95,7 +95,7 @@ impl Adapter for OpenCodeGoAdapter {
 					system,
 					messages,
 					tools,
-				} = AnthropicAdapter::into_anthropic_request_parts(chat_req)?;
+				} = AnthropicAdapter::into_anthropic_request_parts(chat_req, options_set.cache_control().cloned())?;
 
 				let stream = matches!(service_type, ServiceType::ChatStream);
 				let mut payload = json!({

--- a/src/adapter/adapters/vertex/adapter_impl.rs
+++ b/src/adapter/adapters/vertex/adapter_impl.rs
@@ -246,7 +246,7 @@ impl VertexAdapter {
 			system,
 			messages,
 			tools,
-		} = AnthropicAdapter::into_anthropic_request_parts(chat_req)?;
+		} = AnthropicAdapter::into_anthropic_request_parts(chat_req, options_set.cache_control().cloned())?;
 
 		// Vertex Anthropic: model is in URL, not body; anthropic_version goes in body
 		let stream = matches!(service_type, ServiceType::ChatStream);

--- a/src/chat/chat_message.rs
+++ b/src/chat/chat_message.rs
@@ -133,8 +133,11 @@ impl MessageOptions {
 /// - This is the unified cache policy abstraction used at both chat-request and message level.
 /// - Anthropic applies cache_control at the content-part level; genai exposes it at the
 ///   ChatMessage level and maps it appropriately.
-/// - OpenAI currently uses request-level mappings for a subset of variants and ignores
-///   unsupported message-level cache control.
+/// - OpenAI uses request-level mappings (`prompt_cache_retention` / `prompt_cache_key`) for a
+///   subset of variants and ignores unsupported message-level cache control.
+/// - Anthropic applies request-level cache_control by auto-marking the static (tools+system)
+///   prefix when no explicit message/tool breakpoint is set; otherwise it defers to the
+///   explicit breakpoints. Tools can be marked individually via `Tool::with_cache_control`.
 /// - Different providers support different variants and scopes.
 ///
 /// ## TTL Ordering Constraint (Anthropic)
@@ -163,6 +166,9 @@ pub enum CacheControl {
 	/// Note: Costs 2x base input token price vs 1.25x for 5m.
 	Ephemeral1h,
 	/// Extended 24-hour TTL cache.
+	///
+	/// Note: Anthropic's max ephemeral TTL is 1h, so this is clamped to `1h` there. On
+	/// providers with native 24h retention (e.g. OpenAI `prompt_cache_retention`), it maps to 24h.
 	Ephemeral24h,
 }
 

--- a/src/chat/tool/tool_base.rs
+++ b/src/chat/tool/tool_base.rs
@@ -1,4 +1,5 @@
 use super::{ToolConfig, ToolName};
+use crate::chat::CacheControl;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -47,6 +48,11 @@ pub struct Tool {
 	///
 	/// Useful with embedded provider tools (e.g., Google Search for Gemini).
 	pub config: Option<ToolConfig>,
+
+	/// Optional cache control hint for prompt caching.
+	/// Anthropic: set on the last tool to cache the entire tool list prefix.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cache_control: Option<CacheControl>,
 }
 
 /// Computed accessors
@@ -90,6 +96,7 @@ impl Tool {
 			schema: None,
 			strict: None,
 			config: None,
+			cache_control: None,
 		}
 	}
 
@@ -124,6 +131,13 @@ impl Tool {
 	/// Set provider-specific configuration (if any). Returns self for chaining.
 	pub fn with_config(mut self, config: impl Into<ToolConfig>) -> Self {
 		self.config = Some(config.into());
+		self
+	}
+
+	/// Set cache control for prompt caching. Returns self for chaining.
+	/// On Anthropic, set this on the last tool to cache the entire tool list prefix.
+	pub fn with_cache_control(mut self, cache_control: impl Into<CacheControl>) -> Self {
+		self.cache_control = Some(cache_control.into());
 		self
 	}
 }


### PR DESCRIPTION
## Why

Anthropic prompt caching makes cache reads ~10× cheaper than normal input tokens and cuts latency when an app re-sends a large, stable prefix — tool definitions and system prompts — on every request (agents, RAG, long-system-prompt chatbots). genai couldn't fully exploit it:

- **tool definitions had no way to be cached**, and
- **request-level `ChatOptions::with_cache_control` was silently ignored on Anthropic** (logged, then dropped) — so the most ergonomic "just cache my stable prefix" knob did nothing.

This PR closes both gaps.

## What

- **`Tool::with_cache_control(...)`** — serialized onto the Anthropic `tools` payload, so the tool-definition prefix can be cached.
- **Request-level `ChatOptions::with_cache_control(...)`** now auto-marks the static prefix on Anthropic — the last `system` block (caches tools+system in canonical order), or the last tool when there's no system — **only** when no explicit message/tool breakpoint exists. It never overwrites an explicit TTL; no static prefix → no-op. So `ChatOptions::default().with_cache_control(CacheControl::Ephemeral)` now caches the stable tools+system prefix instead of doing nothing.
- Documents that **`CacheControl::Ephemeral24h` clamps to Anthropic's max `1h`** TTL (it still maps to a real 24h on providers that support it, e.g. OpenAI `prompt_cache_retention`).
- `into_anthropic_request_parts` gained a `request_cache_control` param, so the `vertex` and `opencode_go` call sites (both Anthropic-protocol) were updated and consistently gain request-level caching.

## Tests

4 unit tests: system auto-mark, tool fallback, no-op-without-prefix, and defer-to-explicit. `cargo test --lib`, `cargo clippy --all-targets`, and the yakbak replay suite pass.

---

*Rebased onto current `main` (`0.7.0-beta.2-WIP`): after the `anthropic_shared` refactor, the request-building logic and these cache changes now live in `adapter_shared.rs` (`adapter_impl.rs` unchanged). `cargo test --lib` and `cargo clippy --all-targets` pass.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

