### PR TITLE
feat(otel): optional OpenTelemetry GenAI instrumentation (feature `otel`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `+` otel - optional OpenTelemetry GenAI semantic-convention instrumentation behind the new `otel` feature (off by default; pure `tracing` bridge, no extra dependencies). Auto-instruments `exec_chat` / `exec_chat_stream` / `exec_embed` as `gen_ai.*` spans (operation, provider, request params, server address/port, usage tokens, finish reasons, response id/model, streaming time-to-first-chunk, and `error.type`). Prompt/response content capture is opt-in via `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Adds opt-in `genai::otel` helpers for agent/workflow/tool spans and the evaluation-result event. Export by wiring `tracing-opentelemetry` in the application. See `docs/otel.md` and `examples/c12-otel.rs`.
 - `+` anthropic - prompt caching on tools via `Tool::with_cache_control`, and request-level `ChatOptions::with_cache_control` now auto-applies a cache breakpoint to the static (tools+system) prefix (was previously ignored). `Ephemeral24h` is documented as clamped to Anthropic's max `1h` TTL.
 
 ## 2026-06-06 [v0.6.5](https://github.com/jeremychone/rust-genai/compare/v0.6.4...v0.6.5)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,15 @@ bedrock-sigv4 = [
 	"dep:aws-sigv4",
 ]
 
+# OpenTelemetry GenAI instrumentation (OFF by default).
+# Emits `gen_ai.*` tracing spans following the OpenTelemetry GenAI semantic
+# conventions (see docs/otel.md). This is a pure tracing-bridge: it only uses
+# the `tracing` crate (already a dependency) and adds no extra dependencies.
+# Bring your own OpenTelemetry pipeline in the application (e.g. wire
+# `tracing-opentelemetry` onto a `tracing-subscriber` registry) to export the
+# spans; genai records to whatever `tracing` subscriber is installed.
+otel = []
+
 [dependencies]
 # -- Tracing
 tracing = { version = "0.1", features = ["default"] }
@@ -70,6 +79,11 @@ regex = "1"
 aws-config = { version = "1", optional = true }
 aws-credential-types = { version = "1", optional = true }
 aws-sigv4 = { version = "1", optional = true }
+
+# The OTel example references `genai::otel`, so it only builds with the feature on.
+[[example]]
+name = "c12-otel"
+required-features = ["otel"]
 
 [dev-dependencies]
 simple-fs = "0.12"

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -1,0 +1,138 @@
+# OpenTelemetry GenAI instrumentation (`otel` feature)
+
+genai can instrument its operations following the
+[OpenTelemetry GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai)
+(status: Development). The feature is **off by default**.
+
+```toml
+[dependencies]
+genai = { version = "0.7", features = ["otel"] }
+```
+
+## How it works (tracing bridge)
+
+genai emits plain [`tracing`](https://docs.rs/tracing) spans whose field names
+follow the `gen_ai.*` conventions, plus the bridge fields `otel.kind`,
+`otel.name`, and `otel.status_code`. It adds **no new dependencies** and never
+owns an OpenTelemetry pipeline.
+
+To export them as OpenTelemetry spans, wire
+[`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry) onto your
+`tracing-subscriber` registry in the application:
+
+```rust,ignore
+use tracing_subscriber::prelude::*;
+
+let tracer = /* your OpenTelemetry tracer (OTLP, stdout, ...) */;
+tracing_subscriber::registry()
+    .with(tracing_opentelemetry::layer().with_tracer(tracer))
+    .init();
+```
+
+genai records to whatever subscriber is installed. See
+[`examples/c12-otel.rs`](../examples/c12-otel.rs) for a runnable example.
+
+## What is instrumented
+
+| Operation | Auto | Span name | Kind |
+|---|---|---|---|
+| `Client::exec_chat` | ✅ | `chat {model}` | client |
+| `Client::exec_chat_stream` | ✅ | `chat {model}` | client |
+| `Client::exec_embed` / `embed` / `embed_batch` | ✅ | `embeddings {model}` | client |
+
+The `chat`/`embeddings` spans cover the full operation (including streaming, to
+stream end) and record the request parameters, server address/port, response id
+and model, finish reasons, token usage, and — on failure — `error.type` with
+`otel.status_code = error`. Streaming spans also record
+`gen_ai.response.time_to_first_chunk`.
+
+### Recorded attributes (chat)
+
+- `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`,
+  `gen_ai.request.stream`
+- `gen_ai.request.{temperature, max_tokens, top_p, seed, stop_sequences}` (when set)
+- `gen_ai.output.type` (when an output format is requested)
+- `server.address`, `server.port`
+- `gen_ai.response.{id, model, finish_reasons}`
+- `gen_ai.usage.{input_tokens, output_tokens, cache_read.input_tokens,
+  cache_creation.input_tokens, reasoning.output_tokens}`
+- `gen_ai.response.time_to_first_chunk` (streaming)
+- `error.type` (on failure)
+
+### Provider names
+
+genai's `AdapterKind` is mapped to the spec's `gen_ai.provider.name` well-known
+values where one exists (`openai`, `anthropic`, `gcp.gemini`, `gcp.vertex_ai`,
+`aws.bedrock`, `groq`, `cohere`, `deepseek`, `x_ai`, `moonshot_ai`); other
+adapters fall back to their lower-case id (the spec permits custom values). See
+`genai::otel::provider_name`.
+
+## Content capture (opt-in, off by default)
+
+Prompt/response content is **not** recorded unless explicitly enabled, because
+it is likely to contain sensitive / PII data. Enable it with the standard env
+var (matching the OpenTelemetry GenAI instrumentations):
+
+```sh
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+```
+
+When enabled, these attributes are recorded as JSON strings following the spec
+message schemas:
+
+- `gen_ai.system_instructions`
+- `gen_ai.input.messages`
+- `gen_ai.output.messages`
+- `gen_ai.tool.definitions`
+
+## Opt-in helpers (agent / workflow / tool / evaluation)
+
+genai is a provider client — it has no agent, workflow, planning, tool
+execution, or evaluation machinery, so those signals are **not** emitted
+automatically. For applications building such flows on top of genai, the
+`genai::otel` module exposes builders that produce spec-compliant spans/events:
+
+```rust,ignore
+use genai::otel::agent;
+
+// `execute_tool` span from a genai ToolCall surfaced in a chat response.
+for tool_call in chat_res.tool_calls() {
+    let span = agent::execute_tool_span(tool_call);
+    let _guard = span.enter();
+    // ... run the tool ...
+    agent::ExecuteToolSpan::record_result(&span, &result_json);
+}
+
+// Agent / workflow / plan spans.
+let _span = agent::AgentSpan::invoke_agent().with_name("Greeter").start();
+let _span = agent::invoke_workflow_span("daily-report");
+let _span = agent::plan_span(Some("Greeter"));
+```
+
+```rust,ignore
+use genai::otel::events::EvalResult;
+
+EvalResult::new("Relevance")
+    .with_score_value(4.0)
+    .with_score_label("relevant")
+    .with_response_id(response_id)
+    .emit();
+```
+
+## Limitations
+
+- **Spans only.** The spec's metric instruments (`gen_ai.client.token.usage`,
+  `gen_ai.client.operation.duration`, ...) are not emitted; the equivalent data
+  is available as span attributes, and backends can derive metrics from spans.
+- **Array attributes as JSON strings.** `tracing` has no array field type, so
+  `gen_ai.response.finish_reasons`, `gen_ai.request.stop_sequences`, and the
+  message-content attributes are encoded as JSON strings. The spec permits
+  JSON-string encoding on spans.
+- **No cost attribute.** The GenAI semantic conventions define token usage but
+  no monetary cost attribute; cost is left to downstream tooling.
+- **Events as point-in-time spans.** Spec "events" (e.g.
+  `gen_ai.evaluation.result`) are emitted as zero-duration spans carrying the
+  event's attributes — the faithful representation in a tracing → OpenTelemetry
+  bridge.
+- The GenAI semantic conventions are at **Development** status; attribute names
+  may still change. They are centralized in `genai::otel::conventions`.

--- a/examples/c12-otel.rs
+++ b/examples/c12-otel.rs
@@ -1,0 +1,76 @@
+//! OpenTelemetry GenAI instrumentation example (feature `otel`).
+//!
+//! Run with:
+//! ```sh
+//! OPENAI_API_KEY=... cargo run --example c12-otel --features otel
+//! ```
+//!
+//! To also capture prompt/response content on the spans (off by default, since
+//! it may contain sensitive data), set the standard opt-in env var:
+//! ```sh
+//! OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true \
+//!   OPENAI_API_KEY=... cargo run --example c12-otel --features otel
+//! ```
+//!
+//! genai emits `gen_ai.*` `tracing` spans following the OpenTelemetry GenAI
+//! semantic conventions. This example installs a plain `tracing-subscriber`
+//! `fmt` subscriber and prints each span (with its attributes) when it closes,
+//! so you can see what gets recorded without standing up an OTel collector.
+//!
+//! To export real OpenTelemetry spans, replace the `fmt` layer below with a
+//! `tracing-opentelemetry` layer in your application, e.g.:
+//! ```ignore
+//! use tracing_subscriber::prelude::*;
+//! let tracer = /* your OpenTelemetry tracer (OTLP, stdout, ...) */;
+//! tracing_subscriber::registry()
+//!     .with(tracing_opentelemetry::layer().with_tracer(tracer))
+//!     .init();
+//! ```
+//! genai records to whatever subscriber is installed; it never owns the OTel
+//! pipeline itself.
+
+use genai::Client;
+use genai::chat::{ChatMessage, ChatRequest};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+const MODEL: &str = "gpt-5.4-mini";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	// Content capture (`gen_ai.input.messages` / `output.messages` / ...) is opt-in
+	// via the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` env var — see the
+	// run command in the module docs above.
+
+	// -- Print spans (and their `gen_ai.*` fields) as they close.
+	tracing_subscriber::fmt()
+		.with_env_filter(EnvFilter::new("genai=info"))
+		.with_span_events(FmtSpan::CLOSE)
+		.init();
+
+	let client = Client::default();
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one short sentence."),
+		ChatMessage::user("Why is the sky blue?"),
+	]);
+
+	// -- Non-streaming: produces a `chat <model>` span with usage + response attributes.
+	println!("\n=== exec_chat ===");
+	let chat_res = client.exec_chat(MODEL, chat_req.clone(), None).await?;
+	println!("Response: {}", chat_res.first_text().unwrap_or("NO ANSWER"));
+
+	// -- Streaming: the span stays open for the whole stream and records
+	//    `gen_ai.response.time_to_first_chunk` plus the captured end attributes.
+	println!("\n=== exec_chat_stream ===");
+	let mut chat_stream = client.exec_chat_stream(MODEL, chat_req, None).await?.stream;
+	use futures::StreamExt;
+	use genai::chat::ChatStreamEvent;
+	while let Some(event) = chat_stream.next().await {
+		if let ChatStreamEvent::Chunk(chunk) = event? {
+			print!("{}", chunk.content);
+		}
+	}
+	println!();
+
+	Ok(())
+}

--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -10,11 +10,30 @@ type InterStreamType = Pin<Box<dyn Stream<Item = crate::Result<InterStreamEvent>
 /// A stream of chat events produced by a streaming chat request.
 pub struct ChatStream {
 	inter_stream: InterStreamType,
+
+	/// OTel span state for the streaming operation (feature `otel`).
+	/// Set by `Client::exec_chat_stream` so the span covers the full stream
+	/// lifetime and records time-to-first-chunk and the captured end attributes.
+	#[cfg(feature = "otel")]
+	otel: Option<OtelStreamState>,
+}
+
+/// Per-stream OTel state: the operation span, the issuance instant (for
+/// time-to-first-chunk), and whether the first chunk was already recorded.
+#[cfg(feature = "otel")]
+struct OtelStreamState {
+	span: tracing::Span,
+	start: std::time::Instant,
+	first_chunk_recorded: bool,
 }
 
 impl ChatStream {
 	pub(crate) fn new(inter_stream: InterStreamType) -> Self {
-		ChatStream { inter_stream }
+		ChatStream {
+			inter_stream,
+			#[cfg(feature = "otel")]
+			otel: None,
+		}
 	}
 
 	pub(crate) fn from_inter_stream<T>(inter_stream: T) -> Self
@@ -23,6 +42,18 @@ impl ChatStream {
 	{
 		let boxed_stream: InterStreamType = Box::pin(inter_stream);
 		ChatStream::new(boxed_stream)
+	}
+
+	/// Attaches the OTel operation span, starting the time-to-first-chunk clock.
+	/// The span stays open until the stream is fully consumed or dropped.
+	#[cfg(feature = "otel")]
+	pub(crate) fn with_otel_span(mut self, span: tracing::Span) -> Self {
+		self.otel = Some(OtelStreamState {
+			span,
+			start: std::time::Instant::now(),
+			first_chunk_recorded: false,
+		});
+		self
 	}
 }
 
@@ -50,9 +81,35 @@ impl Stream for ChatStream {
 					}
 					InterStreamEvent::End(inter_end) => ChatStreamEvent::End(inter_end.into()),
 				};
+
+				// -- OTel: record time-to-first-chunk on the first content chunk, and the
+				//          captured usage/finish/content on the end event.
+				#[cfg(feature = "otel")]
+				if let Some(otel) = this.otel.as_mut() {
+					match &chat_event {
+						ChatStreamEvent::Chunk(_) | ChatStreamEvent::ReasoningChunk(_) => {
+							if !otel.first_chunk_recorded {
+								otel.first_chunk_recorded = true;
+								let seconds = otel.start.elapsed().as_secs_f64();
+								crate::otel::span::record_time_to_first_chunk(&otel.span, seconds);
+							}
+						}
+						ChatStreamEvent::End(stream_end) => {
+							crate::otel::span::record_stream_end(&otel.span, stream_end);
+						}
+						_ => {}
+					}
+				}
+
 				Poll::Ready(Some(Ok(chat_event)))
 			}
-			Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+			Poll::Ready(Some(Err(e))) => {
+				#[cfg(feature = "otel")]
+				if let Some(otel) = this.otel.as_ref() {
+					crate::otel::span::record_error(&otel.span, &e);
+				}
+				Poll::Ready(Some(Err(e)))
+			}
 			Poll::Ready(None) => Poll::Ready(None),
 			Poll::Pending => Poll::Pending,
 		}

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -101,55 +101,69 @@ impl Client {
 		let model = target.model.clone();
 		let auth_data = target.auth.clone();
 
-		let WebRequestData {
-			mut url,
-			mut headers,
-			payload,
-		} = AdapterDispatcher::to_web_request_data(target, ServiceType::Chat, chat_req, options_set.clone())?;
+		// -- OTel: create the `chat` span (borrows end before `target`/`chat_req` are consumed below).
+		#[cfg(feature = "otel")]
+		let otel_span = crate::otel::span::chat_request_span(&model, &target.endpoint, &options_set, &chat_req, false);
 
-		if let Some(extra_headers) = options.and_then(|o| o.extra_headers.as_ref()) {
-			headers.merge_with(extra_headers);
-		}
+		// The operation is wrapped so every error path (request shaping, web call, response
+		// parsing) flows through the OTel span recorder below.
+		let result = async {
+			let WebRequestData {
+				mut url,
+				mut headers,
+				payload,
+			} = AdapterDispatcher::to_web_request_data(target, ServiceType::Chat, chat_req, options_set.clone())?;
 
-		if let AuthData::RequestOverride {
-			url: override_url,
-			headers: override_headers,
-		} = auth_data
-		{
-			url = override_url;
-			headers = override_headers;
-		};
-
-		let web_res = self
-			.web_client()
-			.do_post(&url, &headers, &payload)
-			.await
-			.map_err(|webc_error| Error::WebModelCall {
-				model_iden: model.clone(),
-				webc_error,
-			})?;
-
-		// Note: here we capture/clone the raw body if set in the options_set
-		let captured_raw_body = options_set.capture_raw_body().unwrap_or_default().then(|| web_res.body.clone());
-
-		match AdapterDispatcher::to_chat_response(model.clone(), web_res, options_set) {
-			Ok(mut chat_res) => {
-				chat_res.captured_raw_body = captured_raw_body;
-				Ok(chat_res)
+			if let Some(extra_headers) = options.and_then(|o| o.extra_headers.as_ref()) {
+				headers.merge_with(extra_headers);
 			}
-			Err(err) => {
-				let response_body = captured_raw_body.unwrap_or_else(|| {
-					"Raw response not captured. Use the ChatOptions.capturre_raw_body flag to see raw response in this error".into()
-				});
-				let err = Error::ChatResponseGeneration {
-					model_iden: model,
-					request_payload: Box::new(payload),
-					response_body: Box::new(response_body),
-					cause: err.to_string(),
-				};
-				Err(err)
+
+			if let AuthData::RequestOverride {
+				url: override_url,
+				headers: override_headers,
+			} = auth_data
+			{
+				url = override_url;
+				headers = override_headers;
+			};
+
+			let web_res = self
+				.web_client()
+				.do_post(&url, &headers, &payload)
+				.await
+				.map_err(|webc_error| Error::WebModelCall {
+					model_iden: model.clone(),
+					webc_error,
+				})?;
+
+			// Note: here we capture/clone the raw body if set in the options_set
+			let captured_raw_body = options_set.capture_raw_body().unwrap_or_default().then(|| web_res.body.clone());
+
+			match AdapterDispatcher::to_chat_response(model.clone(), web_res, options_set) {
+				Ok(mut chat_res) => {
+					chat_res.captured_raw_body = captured_raw_body;
+					Ok(chat_res)
+				}
+				Err(err) => {
+					let response_body = captured_raw_body.unwrap_or_else(|| {
+						"Raw response not captured. Use the ChatOptions.capturre_raw_body flag to see raw response in this error".into()
+					});
+					let err = Error::ChatResponseGeneration {
+						model_iden: model,
+						request_payload: Box::new(payload),
+						response_body: Box::new(response_body),
+						cause: err.to_string(),
+					};
+					Err(err)
+				}
 			}
 		}
+		.await;
+
+		#[cfg(feature = "otel")]
+		let result = crate::otel::span::record_chat_result(&otel_span, result);
+
+		result
 	}
 
 	/// Streams a chat response.
@@ -172,39 +186,63 @@ impl Client {
 		let model = target.model.clone();
 		let auth_data = target.auth.clone();
 
-		let WebRequestData {
-			mut url,
-			mut headers,
-			payload,
-		} = AdapterDispatcher::to_web_request_data(target, ServiceType::ChatStream, chat_req, options_set.clone())?;
+		// -- OTel: create the streaming `chat` span (borrows end before `target`/`chat_req` are consumed).
+		#[cfg(feature = "otel")]
+		let otel_span = crate::otel::span::chat_request_span(&model, &target.endpoint, &options_set, &chat_req, true);
 
-		if let Some(extra_headers) = options.and_then(|o| o.extra_headers.as_ref()) {
-			headers.merge_with(extra_headers);
+		// Stream setup is synchronous; wrap it so setup errors are recorded on the span too.
+		let result = (move || {
+			let WebRequestData {
+				mut url,
+				mut headers,
+				payload,
+			} = AdapterDispatcher::to_web_request_data(target, ServiceType::ChatStream, chat_req, options_set.clone())?;
+
+			if let Some(extra_headers) = options.and_then(|o| o.extra_headers.as_ref()) {
+				headers.merge_with(extra_headers);
+			}
+
+			// TODO: Need to check this.
+			//       This was part of the 429c5cee2241dbef9f33699b9c91202233c22816 commit
+			//       But now it is missing in the the exec_chat(..) above, which is probably an issue.
+			if let AuthData::RequestOverride {
+				url: override_url,
+				headers: override_headers,
+			} = auth_data
+			{
+				url = override_url;
+				headers = override_headers;
+			};
+
+			let reqwest_builder =
+				self.web_client()
+					.new_req_builder(&url, &headers, &payload)
+					.map_err(|webc_error| Error::WebModelCall {
+						model_iden: model.clone(),
+						webc_error,
+					})?;
+
+			let res = AdapterDispatcher::to_chat_stream(model, reqwest_builder, options_set)?;
+
+			Ok(res)
+		})();
+
+		match result {
+			Ok(res) => {
+				// Hand the span to the stream so it stays open for the stream's lifetime.
+				#[cfg(feature = "otel")]
+				let res = ChatStreamResponse {
+					stream: res.stream.with_otel_span(otel_span),
+					..res
+				};
+				Ok(res)
+			}
+			Err(err) => {
+				#[cfg(feature = "otel")]
+				crate::otel::span::record_error(&otel_span, &err);
+				Err(err)
+			}
 		}
-
-		// TODO: Need to check this.
-		//       This was part of the 429c5cee2241dbef9f33699b9c91202233c22816 commit
-		//       But now it is missing in the the exec_chat(..) above, which is probably an issue.
-		if let AuthData::RequestOverride {
-			url: override_url,
-			headers: override_headers,
-		} = auth_data
-		{
-			url = override_url;
-			headers = override_headers;
-		};
-
-		let reqwest_builder = self
-			.web_client()
-			.new_req_builder(&url, &headers, &payload)
-			.map_err(|webc_error| Error::WebModelCall {
-				model_iden: model.clone(),
-				webc_error,
-			})?;
-
-		let res = AdapterDispatcher::to_chat_stream(model, reqwest_builder, options_set)?;
-
-		Ok(res)
 	}
 
 	/// Creates embeddings for a single input string.
@@ -252,20 +290,32 @@ impl Client {
 		let target = self.config().resolve_model_spec(model.into()).await?;
 		let model = target.model.clone();
 
-		let WebRequestData { headers, payload, url } =
-			AdapterDispatcher::to_embed_request_data(target, embed_req, options_set.clone())?;
+		// -- OTel: create the `embeddings` span (borrow ends before `target` is consumed below).
+		#[cfg(feature = "otel")]
+		let otel_span = crate::otel::span::embeddings_request_span(&model, &target.endpoint, &options_set);
 
-		let web_res = self
-			.web_client()
-			.do_post(&url, &headers, &payload)
-			.await
-			.map_err(|webc_error| Error::WebModelCall {
-				model_iden: model.clone(),
-				webc_error,
-			})?;
+		let result = async {
+			let WebRequestData { headers, payload, url } =
+				AdapterDispatcher::to_embed_request_data(target, embed_req, options_set.clone())?;
 
-		let res = AdapterDispatcher::to_embed_response(model, web_res, options_set)?;
+			let web_res = self
+				.web_client()
+				.do_post(&url, &headers, &payload)
+				.await
+				.map_err(|webc_error| Error::WebModelCall {
+					model_iden: model.clone(),
+					webc_error,
+				})?;
 
-		Ok(res)
+			let res = AdapterDispatcher::to_embed_response(model, web_res, options_set)?;
+
+			Ok(res)
+		}
+		.await;
+
+		#[cfg(feature = "otel")]
+		let result = crate::otel::span::record_embed_result(&otel_span, result);
+
+		result
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ pub mod embed;
 pub mod resolver;
 pub mod webc;
 
+// -- OpenTelemetry GenAI instrumentation (feature `otel`, off by default)
+#[cfg(feature = "otel")]
+pub mod otel;
+
 // endregion: --- Modules
 
 // region:    --- TLS Backend Guard

--- a/src/otel/agent.rs
+++ b/src/otel/agent.rs
@@ -1,0 +1,300 @@
+//! Opt-in span builders for GenAI agent / workflow / tool operations.
+//!
+//! genai itself performs no agent, workflow, planning, or tool execution — it
+//! is a provider client. These builders exist so applications building such
+//! flows on top of genai can emit spec-compliant
+//! ([`gen-ai-agent-spans`](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md))
+//! spans without hand-rolling the `gen_ai.*` field names.
+//!
+//! Each builder returns a [`tracing::Span`]; enter it (`let _g = span.enter();`)
+//! around your own logic. Mark failures with [`set_error`] and, for tool spans,
+//! record the result with [`ExecuteToolSpan::record_result`].
+
+use crate::chat::ToolCall;
+use crate::otel::conventions as c;
+use crate::otel::{attrs, error as otel_error};
+use tracing::Span;
+use tracing::field::Empty;
+
+// region:    --- Shared helpers
+
+/// Marks a helper span as errored: sets `otel.status_code = error` and the given
+/// low-cardinality `error.type`.
+pub fn set_error(span: &Span, error_type: impl AsRef<str>) {
+	span.record(c::OTEL_STATUS_CODE, c::STATUS_ERROR);
+	span.record(c::ERROR_TYPE, error_type.as_ref());
+}
+
+/// Marks a helper span as errored from a genai [`Error`](crate::Error), deriving
+/// the `error.type` the same way the auto-instrumented spans do.
+pub fn set_genai_error(span: &Span, error: &crate::Error) {
+	set_error(span, otel_error::error_type(error));
+}
+
+// endregion: --- Shared helpers
+
+// region:    --- Execute tool span
+
+/// Builder for an `execute_tool` span (kind `INTERNAL`).
+#[derive(Debug, Clone, Default)]
+pub struct ExecuteToolSpan {
+	name: String,
+	call_id: Option<String>,
+	description: Option<String>,
+	tool_type: Option<String>,
+	arguments: Option<String>,
+}
+
+impl ExecuteToolSpan {
+	/// Starts a builder for the tool with the given name (`gen_ai.tool.name`).
+	pub fn new(name: impl Into<String>) -> Self {
+		Self {
+			name: name.into(),
+			..Default::default()
+		}
+	}
+
+	/// Sets `gen_ai.tool.call.id`.
+	pub fn with_call_id(mut self, call_id: impl Into<String>) -> Self {
+		self.call_id = Some(call_id.into());
+		self
+	}
+
+	/// Sets `gen_ai.tool.description`.
+	pub fn with_description(mut self, description: impl Into<String>) -> Self {
+		self.description = Some(description.into());
+		self
+	}
+
+	/// Sets `gen_ai.tool.type` (e.g. `function`, `extension`, `datastore`).
+	pub fn with_tool_type(mut self, tool_type: impl Into<String>) -> Self {
+		self.tool_type = Some(tool_type.into());
+		self
+	}
+
+	/// Sets the tool-call arguments (opt-in content; recorded only when content
+	/// capture is enabled — see [`capture_content`](crate::otel::capture_content)).
+	pub fn with_arguments(mut self, arguments: impl Into<String>) -> Self {
+		self.arguments = Some(arguments.into());
+		self
+	}
+
+	/// Builds and returns the span, recording the configured attributes.
+	pub fn start(&self) -> Span {
+		let span_name = format!("{} {}", c::OP_EXECUTE_TOOL, self.name);
+		let span = tracing::info_span!(
+			"genai.execute_tool",
+			"otel.name" = span_name.as_str(),
+			"otel.kind" = c::KIND_INTERNAL,
+			"otel.status_code" = Empty,
+			"error.type" = Empty,
+			"gen_ai.operation.name" = c::OP_EXECUTE_TOOL,
+			"gen_ai.tool.name" = self.name.as_str(),
+			"gen_ai.tool.call.id" = Empty,
+			"gen_ai.tool.description" = Empty,
+			"gen_ai.tool.type" = Empty,
+			"gen_ai.tool.call.arguments" = Empty,
+			"gen_ai.tool.call.result" = Empty,
+		);
+		if let Some(call_id) = &self.call_id {
+			span.record(c::TOOL_CALL_ID, call_id.as_str());
+		}
+		if let Some(description) = &self.description {
+			span.record(c::TOOL_DESCRIPTION, description.as_str());
+		}
+		if let Some(tool_type) = &self.tool_type {
+			span.record(c::TOOL_TYPE, tool_type.as_str());
+		}
+		if attrs::capture_content()
+			&& let Some(arguments) = &self.arguments
+		{
+			span.record(c::TOOL_CALL_ARGUMENTS, arguments.as_str());
+		}
+		span
+	}
+
+	/// Records the tool-call result on the span (opt-in content; recorded only
+	/// when content capture is enabled).
+	pub fn record_result(span: &Span, result: impl AsRef<str>) {
+		if attrs::capture_content() {
+			span.record(c::TOOL_CALL_RESULT, result.as_ref());
+		}
+	}
+}
+
+/// Convenience: builds an [`ExecuteToolSpan`] from a genai [`ToolCall`]
+/// (`function` type), serializing the arguments for opt-in content capture.
+pub fn execute_tool_span(tool_call: &ToolCall) -> Span {
+	let mut builder = ExecuteToolSpan::new(tool_call.fn_name.clone())
+		.with_call_id(tool_call.call_id.clone())
+		.with_tool_type("function");
+	if let Ok(arguments) = serde_json::to_string(&tool_call.fn_arguments) {
+		builder = builder.with_arguments(arguments);
+	}
+	builder.start()
+}
+
+// endregion: --- Execute tool span
+
+// region:    --- Agent span (create_agent / invoke_agent)
+
+/// Builder for `create_agent` / `invoke_agent` spans.
+#[derive(Debug, Clone)]
+pub struct AgentSpan {
+	operation: &'static str,
+	kind: &'static str,
+	name: Option<String>,
+	id: Option<String>,
+	description: Option<String>,
+	provider: Option<String>,
+	model: Option<String>,
+}
+
+impl AgentSpan {
+	/// Builder for a `create_agent` span (kind `CLIENT`).
+	pub fn create_agent() -> Self {
+		Self::new(c::OP_CREATE_AGENT, c::KIND_CLIENT)
+	}
+
+	/// Builder for an `invoke_agent` span (kind `CLIENT`).
+	///
+	/// Use [`AgentSpan::internal`] to switch to `INTERNAL` when invoking an agent
+	/// running in the same process.
+	pub fn invoke_agent() -> Self {
+		Self::new(c::OP_INVOKE_AGENT, c::KIND_CLIENT)
+	}
+
+	fn new(operation: &'static str, kind: &'static str) -> Self {
+		Self {
+			operation,
+			kind,
+			name: None,
+			id: None,
+			description: None,
+			provider: None,
+			model: None,
+		}
+	}
+
+	/// Uses `INTERNAL` span kind instead of the default `CLIENT`.
+	pub fn internal(mut self) -> Self {
+		self.kind = c::KIND_INTERNAL;
+		self
+	}
+
+	/// Sets `gen_ai.agent.name`.
+	pub fn with_name(mut self, name: impl Into<String>) -> Self {
+		self.name = Some(name.into());
+		self
+	}
+
+	/// Sets `gen_ai.agent.id`.
+	pub fn with_id(mut self, id: impl Into<String>) -> Self {
+		self.id = Some(id.into());
+		self
+	}
+
+	/// Sets `gen_ai.agent.description`.
+	pub fn with_description(mut self, description: impl Into<String>) -> Self {
+		self.description = Some(description.into());
+		self
+	}
+
+	/// Sets `gen_ai.provider.name`.
+	pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+		self.provider = Some(provider.into());
+		self
+	}
+
+	/// Sets `gen_ai.request.model`.
+	pub fn with_model(mut self, model: impl Into<String>) -> Self {
+		self.model = Some(model.into());
+		self
+	}
+
+	/// Builds and returns the span.
+	pub fn start(&self) -> Span {
+		// Span name is `{operation} {agent.name}` when the name is available.
+		let span_name = match &self.name {
+			Some(name) => format!("{} {name}", self.operation),
+			None => self.operation.to_string(),
+		};
+		let span = tracing::info_span!(
+			"genai.agent",
+			"otel.name" = span_name.as_str(),
+			"otel.kind" = self.kind,
+			"otel.status_code" = Empty,
+			"error.type" = Empty,
+			"gen_ai.operation.name" = self.operation,
+			"gen_ai.agent.name" = Empty,
+			"gen_ai.agent.id" = Empty,
+			"gen_ai.agent.description" = Empty,
+			"gen_ai.provider.name" = Empty,
+			"gen_ai.request.model" = Empty,
+		);
+		if let Some(name) = &self.name {
+			span.record(c::AGENT_NAME, name.as_str());
+		}
+		if let Some(id) = &self.id {
+			span.record(c::AGENT_ID, id.as_str());
+		}
+		if let Some(description) = &self.description {
+			span.record(c::AGENT_DESCRIPTION, description.as_str());
+		}
+		if let Some(provider) = &self.provider {
+			span.record(c::PROVIDER_NAME, provider.as_str());
+		}
+		if let Some(model) = &self.model {
+			span.record(c::REQUEST_MODEL, model.as_str());
+		}
+		span
+	}
+}
+
+// endregion: --- Agent span (create_agent / invoke_agent)
+
+// region:    --- Workflow span
+
+/// Creates an `invoke_workflow` span (kind `INTERNAL`).
+pub fn invoke_workflow_span(workflow_name: impl AsRef<str>) -> Span {
+	let workflow_name = workflow_name.as_ref();
+	let span_name = format!("{} {workflow_name}", c::OP_INVOKE_WORKFLOW);
+	let span = tracing::info_span!(
+		"genai.invoke_workflow",
+		"otel.name" = span_name.as_str(),
+		"otel.kind" = c::KIND_INTERNAL,
+		"otel.status_code" = Empty,
+		"error.type" = Empty,
+		"gen_ai.operation.name" = c::OP_INVOKE_WORKFLOW,
+		"gen_ai.workflow.name" = workflow_name,
+	);
+	span
+}
+
+// endregion: --- Workflow span
+
+// region:    --- Plan span
+
+/// Creates a `plan` span (kind `INTERNAL`). The optional agent name shapes the
+/// span name (`plan {agent.name}` when provided).
+pub fn plan_span(agent_name: Option<&str>) -> Span {
+	let span_name = match agent_name {
+		Some(name) => format!("{} {name}", c::OP_PLAN),
+		None => c::OP_PLAN.to_string(),
+	};
+	let span = tracing::info_span!(
+		"genai.plan",
+		"otel.name" = span_name.as_str(),
+		"otel.kind" = c::KIND_INTERNAL,
+		"otel.status_code" = Empty,
+		"error.type" = Empty,
+		"gen_ai.operation.name" = c::OP_PLAN,
+		"gen_ai.agent.name" = Empty,
+	);
+	if let Some(name) = agent_name {
+		span.record(c::AGENT_NAME, name);
+	}
+	span
+}
+
+// endregion: --- Plan span

--- a/src/otel/attrs.rs
+++ b/src/otel/attrs.rs
@@ -1,0 +1,350 @@
+//! Helpers to derive OTel attribute values from genai types.
+//!
+//! This covers `server.address` / `server.port` parsing, the opt-in
+//! content-capture gate, and the JSON serializers for the (opt-in, sensitive)
+//! message-content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`,
+//! `gen_ai.system_instructions`, `gen_ai.tool.definitions`).
+
+use crate::chat::{ChatMessage, ChatRole, ContentPart, MessageContent, StopReason, Tool};
+use serde_json::{Value, json};
+use std::sync::OnceLock;
+
+// region:    --- Content capture gate
+
+/// Environment variable that opts into capturing prompt/response content on
+/// GenAI spans. Matches the name used by the OpenTelemetry GenAI instrumentations.
+///
+/// Accepted truthy values (case-insensitive): `true`, `1`, `yes`, `on`.
+pub const CAPTURE_CONTENT_ENV: &str = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+
+/// Returns `true` when message content should be recorded on spans.
+///
+/// Content is **off by default** because it is likely to contain user/PII data
+/// (see the spec warnings). Enable it by setting [`CAPTURE_CONTENT_ENV`].
+/// The value is read once and cached for the process lifetime.
+pub fn capture_content() -> bool {
+	static CAPTURE: OnceLock<bool> = OnceLock::new();
+	*CAPTURE.get_or_init(|| {
+		std::env::var(CAPTURE_CONTENT_ENV)
+			.map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "on"))
+			.unwrap_or(false)
+	})
+}
+
+// endregion: --- Content capture gate
+
+// region:    --- server.address / server.port
+
+/// Parses a base URL into `(server.address, server.port)`.
+///
+/// Best-effort, dependency-free parse (genai does not depend on the `url`
+/// crate). When the port is not explicit it is inferred from the scheme
+/// (`https` → 443, `http` → 80).
+pub fn server_address_and_port(base_url: &str) -> (Option<String>, Option<u16>) {
+	// -- Split off the scheme.
+	let (scheme, rest) = match base_url.split_once("://") {
+		Some((scheme, rest)) => (Some(scheme), rest),
+		None => (None, base_url),
+	};
+
+	// -- Authority is everything up to the first '/', '?' or '#'.
+	let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest).trim_end_matches('.');
+
+	if authority.is_empty() {
+		return (None, None);
+	}
+
+	// -- Split host and optional port. Guard against IPv6 (`[::1]:443`).
+	let (host, explicit_port) = if let Some(stripped) = authority.strip_prefix('[') {
+		// IPv6 literal: `[host]` or `[host]:port`.
+		match stripped.split_once(']') {
+			Some((host, after)) => (host.to_string(), after.trim_start_matches(':')),
+			None => (stripped.to_string(), ""),
+		}
+	} else if let Some((host, port)) = authority.rsplit_once(':') {
+		(host.to_string(), port)
+	} else {
+		(authority.to_string(), "")
+	};
+
+	if host.is_empty() {
+		return (None, None);
+	}
+
+	let port = explicit_port.parse::<u16>().ok().or(match scheme {
+		Some("https") => Some(443),
+		Some("http") => Some(80),
+		_ => None,
+	});
+
+	(Some(host), port)
+}
+
+// endregion: --- server.address / server.port
+
+// region:    --- finish reasons
+
+/// Renders a single normalized stop reason as the `gen_ai.response.finish_reasons`
+/// JSON array string (genai surfaces a single reason per response).
+pub fn finish_reasons_json(stop_reason: &StopReason) -> String {
+	json!([stop_reason.raw()]).to_string()
+}
+
+// endregion: --- finish reasons
+
+// region:    --- Content serializers
+
+/// Lower-case `role` value per the message JSON schema.
+fn role_str(role: &ChatRole) -> &'static str {
+	match role {
+		ChatRole::System => "system",
+		ChatRole::User => "user",
+		ChatRole::Assistant => "assistant",
+		ChatRole::Tool => "tool",
+	}
+}
+
+/// Maps a single [`ContentPart`] to a message `part` object, or `None` for parts
+/// that have no meaningful (non-internal) representation.
+fn part_value(part: &ContentPart) -> Option<Value> {
+	match part {
+		ContentPart::Text(text) => Some(json!({ "type": "text", "content": text })),
+		ContentPart::ToolCall(tc) => Some(json!({
+			"type": "tool_call",
+			"id": tc.call_id,
+			"name": tc.fn_name,
+			"arguments": tc.fn_arguments,
+		})),
+		ContentPart::ToolResponse(tr) => Some(json!({
+			"type": "tool_call_response",
+			"id": tr.call_id,
+			"result": tr.content,
+		})),
+		ContentPart::ReasoningContent(text) => Some(json!({ "type": "reasoning", "content": text })),
+		// Opaque/internal parts: represented by type only (no content emitted).
+		ContentPart::Binary(_) => Some(json!({ "type": "blob" })),
+		ContentPart::ThoughtSignature(_) | ContentPart::Custom(_) => None,
+	}
+}
+
+fn parts_value(content: &MessageContent) -> Value {
+	let parts: Vec<Value> = content.parts().iter().filter_map(part_value).collect();
+	Value::Array(parts)
+}
+
+/// `gen_ai.input.messages` — the chat history sent to the model.
+///
+/// System-role messages are excluded here; they belong in
+/// [`system_instructions_json`] per the spec.
+pub fn input_messages_json(messages: &[ChatMessage]) -> String {
+	let msgs: Vec<Value> = messages
+		.iter()
+		.filter(|m| m.role != ChatRole::System)
+		.map(|m| {
+			json!({
+				"role": role_str(&m.role),
+				"parts": parts_value(&m.content),
+			})
+		})
+		.collect();
+	Value::Array(msgs).to_string()
+}
+
+/// `gen_ai.output.messages` — the message(s) returned by the model.
+///
+/// genai surfaces a single assistant choice, rendered as one message.
+pub fn output_messages_json(content: &MessageContent, finish_reason: Option<&StopReason>) -> String {
+	let mut msg = json!({
+		"role": "assistant",
+		"parts": parts_value(content),
+	});
+	if let Some(reason) = finish_reason {
+		msg["finish_reason"] = Value::String(reason.raw().to_string());
+	}
+	Value::Array(vec![msg]).to_string()
+}
+
+/// `gen_ai.system_instructions` — system content provided separately from the
+/// chat history, as an array of `{ "type": "text", "content": .. }` objects.
+pub fn system_instructions_json<'a>(systems: impl Iterator<Item = &'a str>) -> Option<String> {
+	let instructions: Vec<Value> = systems.map(|s| json!({ "type": "text", "content": s })).collect();
+	if instructions.is_empty() {
+		None
+	} else {
+		Some(Value::Array(instructions).to_string())
+	}
+}
+
+/// `gen_ai.tool.definitions` — the tools made available to the model.
+pub fn tool_definitions_json(tools: &[Tool]) -> String {
+	let defs: Vec<Value> = tools
+		.iter()
+		.map(|tool| {
+			let mut def = json!({
+				"type": "function",
+				"name": tool.name.as_str(),
+			});
+			if let Some(description) = &tool.description {
+				def["description"] = Value::String(description.clone());
+			}
+			if let Some(schema) = &tool.schema {
+				def["parameters"] = schema.clone();
+			}
+			def
+		})
+		.collect();
+	Value::Array(defs).to_string()
+}
+
+// endregion: --- Content serializers
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::chat::{ChatMessage, Tool, ToolCall};
+	use serde_json::json;
+
+	#[test]
+	fn test_otel_server_address_and_port() {
+		assert_eq!(
+			server_address_and_port("https://api.openai.com/v1/"),
+			(Some("api.openai.com".to_string()), Some(443))
+		);
+		assert_eq!(
+			server_address_and_port("http://localhost:11434/v1/"),
+			(Some("localhost".to_string()), Some(11434))
+		);
+		assert_eq!(
+			server_address_and_port("https://generativelanguage.googleapis.com"),
+			(Some("generativelanguage.googleapis.com".to_string()), Some(443))
+		);
+		// No scheme → no inferred port.
+		assert_eq!(
+			server_address_and_port("example.com"),
+			(Some("example.com".to_string()), None)
+		);
+		// IPv6 literal with explicit port.
+		assert_eq!(
+			server_address_and_port("https://[::1]:8443/v1"),
+			(Some("::1".to_string()), Some(8443))
+		);
+		assert_eq!(server_address_and_port(""), (None, None));
+	}
+
+	#[test]
+	fn test_otel_finish_reasons_json() {
+		let reason = StopReason::Completed("stop".to_string());
+		assert_eq!(finish_reasons_json(&reason), r#"["stop"]"#);
+		let reason = StopReason::MaxTokens("length".to_string());
+		assert_eq!(finish_reasons_json(&reason), r#"["length"]"#);
+	}
+
+	#[test]
+	fn test_otel_input_messages_json_excludes_system() {
+		let messages = vec![
+			ChatMessage::system("be brief"),
+			ChatMessage::user("Weather in Paris?"),
+			ChatMessage::assistant("It is rainy."),
+		];
+		let json_str = input_messages_json(&messages);
+		let value: Value = serde_json::from_str(&json_str).unwrap();
+
+		// System message is excluded; user + assistant remain.
+		assert_eq!(
+			value,
+			json!([
+				{ "role": "user", "parts": [{ "type": "text", "content": "Weather in Paris?" }] },
+				{ "role": "assistant", "parts": [{ "type": "text", "content": "It is rainy." }] },
+			])
+		);
+	}
+
+	#[test]
+	fn test_otel_input_messages_json_tool_call_parts() {
+		let tool_call = ToolCall {
+			call_id: "call_1".to_string(),
+			fn_name: "get_weather".to_string(),
+			fn_arguments: json!({ "location": "Paris" }),
+			thought_signatures: None,
+		};
+		let messages = vec![ChatMessage::from(vec![tool_call])];
+		let value: Value = serde_json::from_str(&input_messages_json(&messages)).unwrap();
+
+		assert_eq!(
+			value,
+			json!([
+				{
+					"role": "assistant",
+					"parts": [{
+						"type": "tool_call",
+						"id": "call_1",
+						"name": "get_weather",
+						"arguments": { "location": "Paris" },
+					}],
+				},
+			])
+		);
+	}
+
+	#[test]
+	fn test_otel_output_messages_json_with_finish_reason() {
+		let content = crate::chat::MessageContent::from_text("Hello!");
+		let reason = StopReason::Completed("stop".to_string());
+		let value: Value = serde_json::from_str(&output_messages_json(&content, Some(&reason))).unwrap();
+
+		assert_eq!(
+			value,
+			json!([
+				{
+					"role": "assistant",
+					"parts": [{ "type": "text", "content": "Hello!" }],
+					"finish_reason": "stop",
+				},
+			])
+		);
+	}
+
+	#[test]
+	fn test_otel_system_instructions_json() {
+		let systems = ["You are a translator.", "Translate to French."];
+		let json_str = system_instructions_json(systems.iter().copied()).unwrap();
+		let value: Value = serde_json::from_str(&json_str).unwrap();
+
+		assert_eq!(
+			value,
+			json!([
+				{ "type": "text", "content": "You are a translator." },
+				{ "type": "text", "content": "Translate to French." },
+			])
+		);
+
+		// Empty → None.
+		assert!(system_instructions_json(std::iter::empty()).is_none());
+	}
+
+	#[test]
+	fn test_otel_tool_definitions_json() {
+		let tool = Tool::new("get_weather")
+			.with_description("Get the weather")
+			.with_schema(json!({ "type": "object", "properties": { "location": { "type": "string" } } }));
+		let value: Value = serde_json::from_str(&tool_definitions_json(&[tool])).unwrap();
+
+		assert_eq!(
+			value,
+			json!([
+				{
+					"type": "function",
+					"name": "get_weather",
+					"description": "Get the weather",
+					"parameters": { "type": "object", "properties": { "location": { "type": "string" } } },
+				},
+			])
+		);
+	}
+
+	#[test]
+	fn test_otel_capture_content_default_off() {
+		// No env var set in the test process → content capture is off by default.
+		assert!(!capture_content());
+	}
+}

--- a/src/otel/conventions.rs
+++ b/src/otel/conventions.rs
@@ -1,0 +1,170 @@
+//! OpenTelemetry GenAI semantic-convention constants and value mappings.
+//!
+//! Attribute names, operation names, and provider names follow the
+//! [OpenTelemetry GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai)
+//! (status: Development). They are centralized here so that any future churn in
+//! the spec is absorbed in a single place. A snapshot of the spec lives under
+//! `docs/otel-genai-spec/`.
+
+use crate::adapter::AdapterKind;
+
+// region:    --- Span / "otel.*" bridge fields
+
+// These are the magic fields `tracing-opentelemetry` reads to shape the OTel span.
+/// Overrides the OTel span name (since `tracing` span names must be static).
+pub const OTEL_NAME: &str = "otel.name";
+/// OTel span kind (`client`, `server`, `internal`, ...).
+pub const OTEL_KIND: &str = "otel.kind";
+/// OTel span status code (`ok` / `error`).
+pub const OTEL_STATUS_CODE: &str = "otel.status_code";
+
+/// `otel.kind` value for client spans.
+pub const KIND_CLIENT: &str = "client";
+/// `otel.kind` value for internal spans.
+pub const KIND_INTERNAL: &str = "internal";
+/// `otel.status_code` value for errored operations.
+pub const STATUS_ERROR: &str = "error";
+
+// endregion: --- Span / "otel.*" bridge fields
+
+// region:    --- gen_ai.* attribute keys
+
+pub const OPERATION_NAME: &str = "gen_ai.operation.name";
+pub const PROVIDER_NAME: &str = "gen_ai.provider.name";
+pub const ERROR_TYPE: &str = "error.type";
+pub const CONVERSATION_ID: &str = "gen_ai.conversation.id";
+pub const OUTPUT_TYPE: &str = "gen_ai.output.type";
+
+pub const REQUEST_MODEL: &str = "gen_ai.request.model";
+pub const REQUEST_TEMPERATURE: &str = "gen_ai.request.temperature";
+pub const REQUEST_MAX_TOKENS: &str = "gen_ai.request.max_tokens";
+pub const REQUEST_TOP_P: &str = "gen_ai.request.top_p";
+pub const REQUEST_TOP_K: &str = "gen_ai.request.top_k";
+pub const REQUEST_STOP_SEQUENCES: &str = "gen_ai.request.stop_sequences";
+pub const REQUEST_SEED: &str = "gen_ai.request.seed";
+pub const REQUEST_CHOICE_COUNT: &str = "gen_ai.request.choice.count";
+pub const REQUEST_STREAM: &str = "gen_ai.request.stream";
+pub const REQUEST_FREQUENCY_PENALTY: &str = "gen_ai.request.frequency_penalty";
+pub const REQUEST_PRESENCE_PENALTY: &str = "gen_ai.request.presence_penalty";
+pub const REQUEST_ENCODING_FORMATS: &str = "gen_ai.request.encoding_formats";
+pub const EMBEDDINGS_DIMENSION_COUNT: &str = "gen_ai.embeddings.dimension.count";
+
+pub const RESPONSE_ID: &str = "gen_ai.response.id";
+pub const RESPONSE_MODEL: &str = "gen_ai.response.model";
+pub const RESPONSE_FINISH_REASONS: &str = "gen_ai.response.finish_reasons";
+pub const RESPONSE_TIME_TO_FIRST_CHUNK: &str = "gen_ai.response.time_to_first_chunk";
+
+pub const USAGE_INPUT_TOKENS: &str = "gen_ai.usage.input_tokens";
+pub const USAGE_OUTPUT_TOKENS: &str = "gen_ai.usage.output_tokens";
+pub const USAGE_CACHE_READ_INPUT_TOKENS: &str = "gen_ai.usage.cache_read.input_tokens";
+pub const USAGE_CACHE_CREATION_INPUT_TOKENS: &str = "gen_ai.usage.cache_creation.input_tokens";
+pub const USAGE_REASONING_OUTPUT_TOKENS: &str = "gen_ai.usage.reasoning.output_tokens";
+
+pub const SERVER_ADDRESS: &str = "server.address";
+pub const SERVER_PORT: &str = "server.port";
+
+// -- Opt-in content (sensitive; see `attrs::capture_content`)
+pub const SYSTEM_INSTRUCTIONS: &str = "gen_ai.system_instructions";
+pub const INPUT_MESSAGES: &str = "gen_ai.input.messages";
+pub const OUTPUT_MESSAGES: &str = "gen_ai.output.messages";
+pub const TOOL_DEFINITIONS: &str = "gen_ai.tool.definitions";
+
+// -- Agent / workflow / tool spans (opt-in helpers)
+pub const AGENT_NAME: &str = "gen_ai.agent.name";
+pub const AGENT_ID: &str = "gen_ai.agent.id";
+pub const AGENT_DESCRIPTION: &str = "gen_ai.agent.description";
+pub const WORKFLOW_NAME: &str = "gen_ai.workflow.name";
+pub const TOOL_NAME: &str = "gen_ai.tool.name";
+pub const TOOL_CALL_ID: &str = "gen_ai.tool.call.id";
+pub const TOOL_DESCRIPTION: &str = "gen_ai.tool.description";
+pub const TOOL_TYPE: &str = "gen_ai.tool.type";
+pub const TOOL_CALL_ARGUMENTS: &str = "gen_ai.tool.call.arguments";
+pub const TOOL_CALL_RESULT: &str = "gen_ai.tool.call.result";
+
+// -- Evaluation event
+pub const EVALUATION_NAME: &str = "gen_ai.evaluation.name";
+pub const EVALUATION_SCORE_VALUE: &str = "gen_ai.evaluation.score.value";
+pub const EVALUATION_SCORE_LABEL: &str = "gen_ai.evaluation.score.label";
+pub const EVALUATION_EXPLANATION: &str = "gen_ai.evaluation.explanation";
+
+// endregion: --- gen_ai.* attribute keys
+
+// region:    --- gen_ai.operation.name values
+
+pub const OP_CHAT: &str = "chat";
+pub const OP_EMBEDDINGS: &str = "embeddings";
+pub const OP_EXECUTE_TOOL: &str = "execute_tool";
+pub const OP_CREATE_AGENT: &str = "create_agent";
+pub const OP_INVOKE_AGENT: &str = "invoke_agent";
+pub const OP_INVOKE_WORKFLOW: &str = "invoke_workflow";
+pub const OP_PLAN: &str = "plan";
+
+// endregion: --- gen_ai.operation.name values
+
+// region:    --- gen_ai.output.type values
+
+pub const OUTPUT_TYPE_TEXT: &str = "text";
+pub const OUTPUT_TYPE_JSON: &str = "json";
+
+// endregion: --- gen_ai.output.type values
+
+// region:    --- Provider name mapping
+
+/// Maps a genai [`AdapterKind`] to the `gen_ai.provider.name` value.
+///
+/// Uses the spec's well-known provider names where one exists; otherwise falls
+/// back to the adapter's lower-case identifier (the spec permits custom values).
+pub fn provider_name(adapter_kind: AdapterKind) -> &'static str {
+	match adapter_kind {
+		AdapterKind::OpenAI | AdapterKind::OpenAIResp => "openai",
+		AdapterKind::Anthropic => "anthropic",
+		AdapterKind::Gemini => "gcp.gemini",
+		AdapterKind::Vertex => "gcp.vertex_ai",
+		AdapterKind::BedrockApi => "aws.bedrock",
+		#[cfg(feature = "bedrock-sigv4")]
+		AdapterKind::BedrockSigv4 => "aws.bedrock",
+		AdapterKind::Groq => "groq",
+		AdapterKind::Cohere => "cohere",
+		AdapterKind::DeepSeek => "deepseek",
+		AdapterKind::Xai => "x_ai",
+		AdapterKind::Moonshot => "moonshot_ai",
+		// -- Not in the spec's well-known list: fall back to the adapter's lower-case id.
+		other => other.as_lower_str(),
+	}
+}
+
+// endregion: --- Provider name mapping
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_otel_provider_name_well_known() {
+		assert_eq!(provider_name(AdapterKind::OpenAI), "openai");
+		assert_eq!(provider_name(AdapterKind::OpenAIResp), "openai");
+		assert_eq!(provider_name(AdapterKind::Anthropic), "anthropic");
+		assert_eq!(provider_name(AdapterKind::Gemini), "gcp.gemini");
+		assert_eq!(provider_name(AdapterKind::Vertex), "gcp.vertex_ai");
+		assert_eq!(provider_name(AdapterKind::BedrockApi), "aws.bedrock");
+		assert_eq!(provider_name(AdapterKind::Groq), "groq");
+		assert_eq!(provider_name(AdapterKind::Cohere), "cohere");
+		assert_eq!(provider_name(AdapterKind::DeepSeek), "deepseek");
+		assert_eq!(provider_name(AdapterKind::Xai), "x_ai");
+		assert_eq!(provider_name(AdapterKind::Moonshot), "moonshot_ai");
+	}
+
+	#[test]
+	fn test_otel_provider_name_fallback() {
+		// Not in the spec's well-known list → adapter lower-case id.
+		assert_eq!(provider_name(AdapterKind::Ollama), AdapterKind::Ollama.as_lower_str());
+		assert_eq!(
+			provider_name(AdapterKind::Together),
+			AdapterKind::Together.as_lower_str()
+		);
+		assert_eq!(
+			provider_name(AdapterKind::Fireworks),
+			AdapterKind::Fireworks.as_lower_str()
+		);
+	}
+}

--- a/src/otel/error.rs
+++ b/src/otel/error.rs
@@ -1,0 +1,130 @@
+//! Derivation of the `error.type` attribute from a genai [`Error`].
+//!
+//! Per the GenAI spec, `error.type` SHOULD be the error code returned by the
+//! provider (e.g. an HTTP status), the canonical exception name, or another
+//! low-cardinality identifier. HTTP failures are reported as their numeric
+//! status code; everything else maps to a short, stable, snake-case identifier.
+
+use crate::Error;
+use crate::webc;
+
+/// Returns the `error.type` value for the given error.
+pub fn error_type(error: &Error) -> String {
+	match error {
+		Error::WebModelCall { webc_error, .. } | Error::WebAdapterCall { webc_error, .. } => {
+			webc_error_type(webc_error)
+		}
+		Error::HttpError { status, .. } => status.as_u16().to_string(),
+
+		// -- Input / request shaping
+		Error::ChatReqHasNoMessages { .. } => "chat_req_has_no_messages".to_string(),
+		Error::LastChatMessageIsNotUser { .. } => "last_chat_message_is_not_user".to_string(),
+		Error::MessageRoleNotSupported { .. } => "message_role_not_supported".to_string(),
+		Error::MessageContentTypeNotSupported { .. } => "message_content_type_not_supported".to_string(),
+		Error::JsonModeWithoutInstruction => "json_mode_without_instruction".to_string(),
+		Error::VerbosityParsing { .. } => "verbosity_parsing".to_string(),
+		Error::ReasoningParsingError { .. } => "reasoning_parsing".to_string(),
+		Error::ServiceTierParsing { .. } => "service_tier_parsing".to_string(),
+		Error::PromptCacheRetentionParsing { .. } => "prompt_cache_retention_parsing".to_string(),
+
+		// -- Output / response shaping
+		Error::NoChatResponse { .. } => "no_chat_response".to_string(),
+		Error::InvalidJsonResponseElement { .. } => "invalid_json_response_element".to_string(),
+		Error::ChatResponseGeneration { .. } => "chat_response_generation".to_string(),
+		Error::ChatResponse { .. } => "chat_response".to_string(),
+
+		// -- Auth
+		Error::RequiresApiKey { .. } => "requires_api_key".to_string(),
+		Error::NoAuthResolver { .. } => "no_auth_resolver".to_string(),
+		Error::NoAuthData { .. } => "no_auth_data".to_string(),
+
+		// -- Mapping / resolving
+		Error::ModelMapperFailed { .. } => "model_mapper_failed".to_string(),
+		Error::Resolver { .. } => "resolver".to_string(),
+
+		// -- Stream
+		Error::StreamParse { .. } => "stream_parse".to_string(),
+		Error::WebStream { .. } => "web_stream".to_string(),
+
+		// -- Adapter support
+		Error::AdapterNotSupported { .. } => "adapter_not_supported".to_string(),
+		Error::AdapterKindMismatch { .. } => "adapter_kind_mismatch".to_string(),
+
+		// -- Internals / externals
+		Error::Internal(_) => "internal".to_string(),
+		Error::JsonValueExt(_) => "json_value_ext".to_string(),
+		Error::SerdeJson(_) => "serde_json".to_string(),
+	}
+}
+
+/// Maps a [`webc::Error`] to an `error.type` value, preferring the HTTP status
+/// code when one is available.
+fn webc_error_type(error: &webc::Error) -> String {
+	match error {
+		webc::Error::ResponseFailedStatus { status, .. } => status.as_u16().to_string(),
+		webc::Error::Reqwest(reqwest_error) => {
+			if let Some(status) = reqwest_error.status() {
+				status.as_u16().to_string()
+			} else if reqwest_error.is_timeout() {
+				"timeout".to_string()
+			} else if reqwest_error.is_connect() {
+				"connect".to_string()
+			} else {
+				"reqwest".to_string()
+			}
+		}
+		webc::Error::ResponseFailedNotJson { .. } => "response_not_json".to_string(),
+		webc::Error::ResponseFailedInvalidJson { .. } => "response_invalid_json".to_string(),
+		webc::Error::JsonValueExt(_) => "json_value_ext".to_string(),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::ModelIden;
+	use crate::adapter::AdapterKind;
+	use reqwest::StatusCode;
+	use reqwest::header::HeaderMap;
+
+	fn model() -> ModelIden {
+		ModelIden::from_static(AdapterKind::OpenAI, "gpt-4o")
+	}
+
+	#[test]
+	fn test_otel_error_type_http_status() {
+		let error = Error::HttpError {
+			status: StatusCode::TOO_MANY_REQUESTS,
+			canonical_reason: "Too Many Requests".to_string(),
+			body: String::new(),
+		};
+		assert_eq!(error_type(&error), "429");
+	}
+
+	#[test]
+	fn test_otel_error_type_web_model_call_status() {
+		let webc_error = webc::Error::ResponseFailedStatus {
+			status: StatusCode::INTERNAL_SERVER_ERROR,
+			body: String::new(),
+			headers: Box::new(HeaderMap::new()),
+		};
+		let error = Error::WebModelCall {
+			model_iden: model(),
+			webc_error,
+		};
+		assert_eq!(error_type(&error), "500");
+	}
+
+	#[test]
+	fn test_otel_error_type_low_cardinality_names() {
+		assert_eq!(error_type(&Error::Internal("boom".to_string())), "internal");
+		assert_eq!(
+			error_type(&Error::NoChatResponse { model_iden: model() }),
+			"no_chat_response"
+		);
+		assert_eq!(
+			error_type(&Error::JsonModeWithoutInstruction),
+			"json_mode_without_instruction"
+		);
+	}
+}

--- a/src/otel/events.rs
+++ b/src/otel/events.rs
@@ -1,0 +1,119 @@
+//! Opt-in emitters for the GenAI
+//! [events](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md).
+//!
+//! ## Representation in the tracing bridge
+//!
+//! The spec models these as log-based events. In genai's tracing-bridge a
+//! `tracing` *event* cannot carry conditionally-present fields (its field set is
+//! fixed at the macro call site with no post-hoc `record`). So each emitter here
+//! produces a **point-in-time span** (created and immediately closed) carrying
+//! the event's attributes and parented to the currently-active operation span.
+//! Through `tracing-opentelemetry` this surfaces as a zero-duration span with
+//! the same attributes and parenting the spec prescribes for the event.
+//!
+//! The inference request/response content (the
+//! `gen_ai.client.inference.operation.details` event) is, by default, captured
+//! directly on the auto-instrumented `chat` span when content capture is enabled
+//! — the spec explicitly allows recording content on the span as an alternative
+//! to the event — so a separate emitter is not required for that signal.
+
+use crate::otel::conventions as c;
+use tracing::field::Empty;
+
+// region:    --- Evaluation result
+
+/// Result of evaluating a GenAI output, emitted as a `gen_ai.evaluation.result`
+/// signal (see [module docs](self) for how it surfaces in the tracing bridge).
+///
+/// Build it, set the optional fields, and call [`EvalResult::emit`] while the
+/// span being evaluated is active so the signal is correlated to it.
+#[derive(Debug, Clone)]
+pub struct EvalResult {
+	name: String,
+	score_value: Option<f64>,
+	score_label: Option<String>,
+	explanation: Option<String>,
+	response_id: Option<String>,
+	error_type: Option<String>,
+}
+
+impl EvalResult {
+	/// Starts an evaluation result with the (required) evaluation metric name
+	/// (`gen_ai.evaluation.name`, e.g. `Relevance`).
+	pub fn new(name: impl Into<String>) -> Self {
+		Self {
+			name: name.into(),
+			score_value: None,
+			score_label: None,
+			explanation: None,
+			response_id: None,
+			error_type: None,
+		}
+	}
+
+	/// Sets `gen_ai.evaluation.score.value`.
+	pub fn with_score_value(mut self, value: f64) -> Self {
+		self.score_value = Some(value);
+		self
+	}
+
+	/// Sets `gen_ai.evaluation.score.label` (e.g. `relevant`, `pass`).
+	pub fn with_score_label(mut self, label: impl Into<String>) -> Self {
+		self.score_label = Some(label.into());
+		self
+	}
+
+	/// Sets `gen_ai.evaluation.explanation`.
+	pub fn with_explanation(mut self, explanation: impl Into<String>) -> Self {
+		self.explanation = Some(explanation.into());
+		self
+	}
+
+	/// Sets `gen_ai.response.id` to correlate the evaluation with the completion
+	/// it evaluates (useful when the operation span id is not available).
+	pub fn with_response_id(mut self, response_id: impl Into<String>) -> Self {
+		self.response_id = Some(response_id.into());
+		self
+	}
+
+	/// Sets `error.type` when the evaluation itself ended in an error.
+	pub fn with_error_type(mut self, error_type: impl Into<String>) -> Self {
+		self.error_type = Some(error_type.into());
+		self
+	}
+
+	/// Emits the evaluation result signal.
+	pub fn emit(&self) {
+		let span = tracing::info_span!(
+			"genai.evaluation.result",
+			"otel.name" = "gen_ai.evaluation.result",
+			"otel.kind" = c::KIND_INTERNAL,
+			"otel.status_code" = Empty,
+			"gen_ai.evaluation.name" = self.name.as_str(),
+			"gen_ai.evaluation.score.value" = Empty,
+			"gen_ai.evaluation.score.label" = Empty,
+			"gen_ai.evaluation.explanation" = Empty,
+			"gen_ai.response.id" = Empty,
+			"error.type" = Empty,
+		);
+		if let Some(score_value) = self.score_value {
+			span.record(c::EVALUATION_SCORE_VALUE, score_value);
+		}
+		if let Some(score_label) = &self.score_label {
+			span.record(c::EVALUATION_SCORE_LABEL, score_label.as_str());
+		}
+		if let Some(explanation) = &self.explanation {
+			span.record(c::EVALUATION_EXPLANATION, explanation.as_str());
+		}
+		if let Some(response_id) = &self.response_id {
+			span.record(c::RESPONSE_ID, response_id.as_str());
+		}
+		if let Some(error_type) = &self.error_type {
+			span.record(c::OTEL_STATUS_CODE, c::STATUS_ERROR);
+			span.record(c::ERROR_TYPE, error_type.as_str());
+		}
+		// Created and dropped here → a point-in-time span (see module docs).
+	}
+}
+
+// endregion: --- Evaluation result

--- a/src/otel/mod.rs
+++ b/src/otel/mod.rs
@@ -1,0 +1,51 @@
+//! OpenTelemetry GenAI instrumentation (feature `otel`).
+//!
+//! This module instruments genai operations following the
+//! [OpenTelemetry GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai)
+//! (status: Development; a spec snapshot lives under `docs/otel-genai-spec/`).
+//!
+//! ## How it works
+//!
+//! genai emits plain [`tracing`] spans whose field names follow the `gen_ai.*`
+//! conventions, plus the `otel.kind` / `otel.name` / `otel.status_code` bridge
+//! fields. To export them as OpenTelemetry spans, wire
+//! [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry) onto your
+//! `tracing-subscriber` registry in the application — genai records to whatever
+//! subscriber is installed and never owns the OTel pipeline itself.
+//!
+//! The `chat` (inference) and `embeddings` operations are instrumented
+//! automatically. Agent / workflow / tool spans and the evaluation event have
+//! no genai-internal trigger and are exposed as opt-in builder helpers
+//! ([`agent`], [`events`]) for applications building higher-level flows on top
+//! of genai.
+//!
+//! ## Content capture
+//!
+//! Prompt and response content (`gen_ai.input.messages`, `gen_ai.output.messages`,
+//! `gen_ai.system_instructions`, `gen_ai.tool.definitions`) is **off by default**
+//! because it is likely to contain sensitive / PII data. Enable it by setting the
+//! [`CAPTURE_CONTENT_ENV`](attrs::CAPTURE_CONTENT_ENV) environment variable.
+//!
+//! ## Limitations
+//!
+//! - Spans only — the spec's metric instruments are not emitted (usage/duration
+//!   are available as span attributes; backends can derive metrics from spans).
+//! - Array-valued attributes (`finish_reasons`, `stop_sequences`) and message
+//!   content are encoded as JSON strings, which the spec permits on spans.
+
+pub mod conventions;
+
+pub mod agent;
+pub mod events;
+
+pub(crate) mod attrs;
+pub(crate) mod error;
+pub(crate) mod span;
+
+#[cfg(test)]
+mod tests;
+
+// -- Public re-exports
+pub use attrs::{CAPTURE_CONTENT_ENV, capture_content};
+pub use conventions::provider_name;
+pub use error::error_type;

--- a/src/otel/span.rs
+++ b/src/otel/span.rs
@@ -1,0 +1,284 @@
+//! Builders and recorders for the auto-instrumented GenAI client spans
+//! (`chat` inference and `embeddings`), following the OTel GenAI spec.
+//!
+//! The spans are plain `tracing` spans whose field names follow the
+//! `gen_ai.*` conventions; an application that wires `tracing-opentelemetry`
+//! onto its subscriber turns them into spec-compliant OpenTelemetry spans.
+//! `otel.name` / `otel.kind` / `otel.status_code` are the bridge fields the
+//! `tracing-opentelemetry` layer interprets.
+//!
+//! All optional attributes are declared with [`tracing::field::Empty`] at span
+//! creation and recorded later only when a value is available, so unset
+//! attributes do not appear on the exported span.
+
+use crate::ModelIden;
+use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, StreamEnd, Usage};
+use crate::embed::{EmbedOptionsSet, EmbedResponse};
+use crate::otel::{attrs, conventions as c, error as otel_error};
+use crate::resolver::Endpoint;
+use crate::{Error, Result};
+use tracing::Span;
+use tracing::field::Empty;
+
+// region:    --- Chat (inference) span
+
+/// Creates the `chat` inference span and records the request attributes.
+///
+/// Returns the [`Span`]; the caller keeps it alive for the duration of the
+/// operation and feeds the response/usage/error into the `record_*` helpers.
+pub(crate) fn chat_request_span(
+	model_iden: &ModelIden,
+	endpoint: &Endpoint,
+	options: &ChatOptionsSet,
+	chat_req: &ChatRequest,
+	stream: bool,
+) -> Span {
+	let provider = c::provider_name(model_iden.adapter_kind);
+	let model = model_iden.model_name.as_str();
+	let span_name = format!("{} {model}", c::OP_CHAT);
+
+	let span = tracing::info_span!(
+		"genai.chat",
+		"otel.name" = span_name.as_str(),
+		"otel.kind" = c::KIND_CLIENT,
+		"otel.status_code" = Empty,
+		"error.type" = Empty,
+		"gen_ai.operation.name" = c::OP_CHAT,
+		"gen_ai.provider.name" = provider,
+		"gen_ai.request.model" = model,
+		"gen_ai.request.stream" = stream,
+		"gen_ai.request.temperature" = Empty,
+		"gen_ai.request.max_tokens" = Empty,
+		"gen_ai.request.top_p" = Empty,
+		"gen_ai.request.seed" = Empty,
+		"gen_ai.request.stop_sequences" = Empty,
+		"gen_ai.output.type" = Empty,
+		"server.address" = Empty,
+		"server.port" = Empty,
+		"gen_ai.response.id" = Empty,
+		"gen_ai.response.model" = Empty,
+		"gen_ai.response.finish_reasons" = Empty,
+		"gen_ai.usage.input_tokens" = Empty,
+		"gen_ai.usage.output_tokens" = Empty,
+		"gen_ai.usage.cache_read.input_tokens" = Empty,
+		"gen_ai.usage.cache_creation.input_tokens" = Empty,
+		"gen_ai.usage.reasoning.output_tokens" = Empty,
+		"gen_ai.response.time_to_first_chunk" = Empty,
+		"gen_ai.system_instructions" = Empty,
+		"gen_ai.input.messages" = Empty,
+		"gen_ai.output.messages" = Empty,
+		"gen_ai.tool.definitions" = Empty,
+	);
+
+	record_server(&span, endpoint);
+	record_chat_request_options(&span, options);
+
+	// -- Opt-in (sensitive) request content.
+	if attrs::capture_content() {
+		if let Some(instructions) = attrs::system_instructions_json(chat_req.iter_systems()) {
+			span.record(c::SYSTEM_INSTRUCTIONS, instructions.as_str());
+		}
+		span.record(
+			c::INPUT_MESSAGES,
+			attrs::input_messages_json(&chat_req.messages).as_str(),
+		);
+		if let Some(tools) = chat_req.tools.as_ref() {
+			span.record(c::TOOL_DEFINITIONS, attrs::tool_definitions_json(tools).as_str());
+		}
+	}
+
+	span
+}
+
+fn record_chat_request_options(span: &Span, options: &ChatOptionsSet) {
+	if let Some(temperature) = options.temperature() {
+		span.record(c::REQUEST_TEMPERATURE, temperature);
+	}
+	if let Some(max_tokens) = options.max_tokens() {
+		span.record(c::REQUEST_MAX_TOKENS, i64::from(max_tokens));
+	}
+	if let Some(top_p) = options.top_p() {
+		span.record(c::REQUEST_TOP_P, top_p);
+	}
+	if let Some(seed) = options.seed() {
+		span.record(c::REQUEST_SEED, seed as i64);
+	}
+	let stop_sequences = options.stop_sequences();
+	if !stop_sequences.is_empty()
+		&& let Ok(json) = serde_json::to_string(stop_sequences)
+	{
+		span.record(c::REQUEST_STOP_SEQUENCES, json.as_str());
+	}
+	// `gen_ai.output.type` is only set when an output format is requested.
+	if options.response_format().is_some() {
+		span.record(c::OUTPUT_TYPE, c::OUTPUT_TYPE_JSON);
+	}
+}
+
+/// Records the response attributes (id, model, finish reasons, usage, and —
+/// when content capture is enabled — the output messages).
+pub(crate) fn record_chat_response(span: &Span, res: &ChatResponse) {
+	if let Some(response_id) = res.response_id.as_deref() {
+		span.record(c::RESPONSE_ID, response_id);
+	}
+	span.record(c::RESPONSE_MODEL, res.provider_model_iden.model_name.as_str());
+	if let Some(stop_reason) = res.stop_reason.as_ref() {
+		span.record(
+			c::RESPONSE_FINISH_REASONS,
+			attrs::finish_reasons_json(stop_reason).as_str(),
+		);
+	}
+	record_usage(span, &res.usage);
+
+	if attrs::capture_content() {
+		let messages = attrs::output_messages_json(&res.content, res.stop_reason.as_ref());
+		span.record(c::OUTPUT_MESSAGES, messages.as_str());
+	}
+}
+
+/// Records token usage on the span. Counts are emitted only when present.
+pub(crate) fn record_usage(span: &Span, usage: &Usage) {
+	if let Some(input_tokens) = usage.prompt_tokens {
+		span.record(c::USAGE_INPUT_TOKENS, i64::from(input_tokens));
+	}
+	if let Some(output_tokens) = usage.completion_tokens {
+		span.record(c::USAGE_OUTPUT_TOKENS, i64::from(output_tokens));
+	}
+	if let Some(details) = usage.prompt_tokens_details.as_ref() {
+		if let Some(cached) = details.cached_tokens {
+			span.record(c::USAGE_CACHE_READ_INPUT_TOKENS, i64::from(cached));
+		}
+		if let Some(cache_creation) = details.cache_creation_tokens {
+			span.record(c::USAGE_CACHE_CREATION_INPUT_TOKENS, i64::from(cache_creation));
+		}
+	}
+	if let Some(details) = usage.completion_tokens_details.as_ref()
+		&& let Some(reasoning) = details.reasoning_tokens
+	{
+		span.record(c::USAGE_REASONING_OUTPUT_TOKENS, i64::from(reasoning));
+	}
+}
+
+// endregion: --- Chat (inference) span
+
+// region:    --- Streaming helpers
+
+/// Records `gen_ai.response.time_to_first_chunk` (in seconds) on a streaming span.
+pub(crate) fn record_time_to_first_chunk(span: &Span, seconds: f64) {
+	span.record(c::RESPONSE_TIME_TO_FIRST_CHUNK, seconds);
+}
+
+/// Records the captured response attributes from a streaming `End` event:
+/// usage, finish reason, response id, and — when content capture is enabled —
+/// the output messages.
+pub(crate) fn record_stream_end(span: &Span, end: &StreamEnd) {
+	if let Some(response_id) = end.captured_response_id.as_deref() {
+		span.record(c::RESPONSE_ID, response_id);
+	}
+	if let Some(stop_reason) = end.captured_stop_reason.as_ref() {
+		span.record(
+			c::RESPONSE_FINISH_REASONS,
+			attrs::finish_reasons_json(stop_reason).as_str(),
+		);
+	}
+	if let Some(usage) = end.captured_usage.as_ref() {
+		record_usage(span, usage);
+	}
+	if attrs::capture_content()
+		&& let Some(content) = end.captured_content.as_ref()
+	{
+		let messages = attrs::output_messages_json(content, end.captured_stop_reason.as_ref());
+		span.record(c::OUTPUT_MESSAGES, messages.as_str());
+	}
+}
+
+// endregion: --- Streaming helpers
+
+// region:    --- Embeddings span
+
+/// Creates the `embeddings` span and records the request attributes.
+pub(crate) fn embeddings_request_span(model_iden: &ModelIden, endpoint: &Endpoint, options: &EmbedOptionsSet) -> Span {
+	let provider = c::provider_name(model_iden.adapter_kind);
+	let model = model_iden.model_name.as_str();
+	let span_name = format!("{} {model}", c::OP_EMBEDDINGS);
+
+	let span = tracing::info_span!(
+		"genai.embeddings",
+		"otel.name" = span_name.as_str(),
+		"otel.kind" = c::KIND_CLIENT,
+		"otel.status_code" = Empty,
+		"error.type" = Empty,
+		"gen_ai.operation.name" = c::OP_EMBEDDINGS,
+		"gen_ai.provider.name" = provider,
+		"gen_ai.request.model" = model,
+		"gen_ai.embeddings.dimension.count" = Empty,
+		"gen_ai.request.encoding_formats" = Empty,
+		"server.address" = Empty,
+		"server.port" = Empty,
+		"gen_ai.response.model" = Empty,
+		"gen_ai.usage.input_tokens" = Empty,
+	);
+
+	record_server(&span, endpoint);
+	if let Some(dimensions) = options.dimensions() {
+		span.record(c::EMBEDDINGS_DIMENSION_COUNT, dimensions as i64);
+	}
+	if let Some(encoding_format) = options.encoding_format()
+		&& let Ok(json) = serde_json::to_string(&[encoding_format])
+	{
+		span.record(c::REQUEST_ENCODING_FORMATS, json.as_str());
+	}
+
+	span
+}
+
+/// Records the embeddings response attributes (response model + input tokens).
+pub(crate) fn record_embed_response(span: &Span, res: &EmbedResponse) {
+	span.record(c::RESPONSE_MODEL, res.provider_model_iden.model_name.as_str());
+	if let Some(input_tokens) = res.usage.prompt_tokens {
+		span.record(c::USAGE_INPUT_TOKENS, i64::from(input_tokens));
+	}
+}
+
+// endregion: --- Embeddings span
+
+// region:    --- Shared recorders
+
+/// Records `server.address` / `server.port` parsed from the endpoint base URL.
+fn record_server(span: &Span, endpoint: &Endpoint) {
+	let (address, port) = attrs::server_address_and_port(endpoint.base_url());
+	if let Some(address) = address {
+		span.record(c::SERVER_ADDRESS, address.as_str());
+	}
+	if let Some(port) = port {
+		span.record(c::SERVER_PORT, i64::from(port));
+	}
+}
+
+/// Records the error status (`otel.status_code = error`) and `error.type` for a
+/// failed operation.
+pub(crate) fn record_error(span: &Span, error: &Error) {
+	span.record(c::OTEL_STATUS_CODE, c::STATUS_ERROR);
+	span.record(c::ERROR_TYPE, otel_error::error_type(error).as_str());
+}
+
+/// Records the outcome of an operation onto its span: response attributes on
+/// success, error status on failure. Returns the result unchanged.
+pub(crate) fn record_chat_result(span: &Span, result: Result<ChatResponse>) -> Result<ChatResponse> {
+	match &result {
+		Ok(res) => record_chat_response(span, res),
+		Err(err) => record_error(span, err),
+	}
+	result
+}
+
+/// Records the outcome of an embeddings operation onto its span.
+pub(crate) fn record_embed_result(span: &Span, result: Result<EmbedResponse>) -> Result<EmbedResponse> {
+	match &result {
+		Ok(res) => record_embed_response(span, res),
+		Err(err) => record_error(span, err),
+	}
+	result
+}
+
+// endregion: --- Shared recorders

--- a/src/otel/tests.rs
+++ b/src/otel/tests.rs
@@ -1,0 +1,415 @@
+//! Integration tests for span/event field emission.
+//!
+//! These install a capturing [`tracing_subscriber::Layer`] for the duration of a
+//! closure and assert on the exact `gen_ai.*` fields genai records. This
+//! validates what genai owns (the field names/values); the field → OpenTelemetry
+//! attribute mapping is `tracing-opentelemetry`'s own (separately tested)
+//! responsibility.
+
+use crate::ModelIden;
+use crate::adapter::AdapterKind;
+use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
+use crate::chat::{
+	ChatMessage, ChatOptions, ChatOptionsSet, ChatRequest, ChatResponse, ChatStream, MessageContent, StopReason, Usage,
+};
+use crate::otel::{agent, events, span};
+use crate::resolver::Endpoint;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+
+// region:    --- Capture layer
+
+/// A captured span: its (static) metadata name and recorded field values
+/// (formatted as strings). Empty/unrecorded fields are absent from `fields`.
+#[derive(Clone, Debug, Default)]
+struct CapturedSpan {
+	name: String,
+	fields: HashMap<String, String>,
+}
+
+impl CapturedSpan {
+	fn get(&self, key: &str) -> Option<&str> {
+		self.fields.get(key).map(|s| s.as_str())
+	}
+
+	fn has(&self, key: &str) -> bool {
+		self.fields.contains_key(key)
+	}
+}
+
+#[derive(Clone, Default)]
+struct Captured {
+	spans: Arc<Mutex<Vec<(u64, CapturedSpan)>>>,
+}
+
+impl Captured {
+	/// Returns the first captured span whose metadata name matches.
+	fn by_name(&self, name: &str) -> CapturedSpan {
+		self.spans
+			.lock()
+			.unwrap()
+			.iter()
+			.find(|(_, span)| span.name == name)
+			.map(|(_, span)| span.clone())
+			.unwrap_or_else(|| panic!("no captured span named `{name}`"))
+	}
+}
+
+struct FieldVisitor<'a>(&'a mut HashMap<String, String>);
+
+impl Visit for FieldVisitor<'_> {
+	fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+		self.0.insert(field.name().to_string(), format!("{value:?}"));
+	}
+	fn record_str(&mut self, field: &Field, value: &str) {
+		self.0.insert(field.name().to_string(), value.to_string());
+	}
+	fn record_i64(&mut self, field: &Field, value: i64) {
+		self.0.insert(field.name().to_string(), value.to_string());
+	}
+	fn record_u64(&mut self, field: &Field, value: u64) {
+		self.0.insert(field.name().to_string(), value.to_string());
+	}
+	fn record_f64(&mut self, field: &Field, value: f64) {
+		self.0.insert(field.name().to_string(), value.to_string());
+	}
+	fn record_bool(&mut self, field: &Field, value: bool) {
+		self.0.insert(field.name().to_string(), value.to_string());
+	}
+}
+
+struct CaptureLayer {
+	captured: Captured,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+	S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+	fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, _ctx: Context<'_, S>) {
+		let mut span = CapturedSpan {
+			name: attrs.metadata().name().to_string(),
+			fields: HashMap::new(),
+		};
+		attrs.record(&mut FieldVisitor(&mut span.fields));
+		self.captured.spans.lock().unwrap().push((id.into_u64(), span));
+	}
+
+	fn on_record(&self, id: &Id, values: &Record<'_>, _ctx: Context<'_, S>) {
+		let mut spans = self.captured.spans.lock().unwrap();
+		if let Some((_, span)) = spans.iter_mut().find(|(span_id, _)| *span_id == id.into_u64()) {
+			values.record(&mut FieldVisitor(&mut span.fields));
+		}
+	}
+}
+
+/// Runs `f` with a capturing subscriber installed on the current thread and
+/// returns the captured spans.
+fn capture(f: impl FnOnce()) -> Captured {
+	let captured = Captured::default();
+	let layer = CaptureLayer {
+		captured: captured.clone(),
+	};
+	let subscriber = tracing_subscriber::registry().with(layer);
+	tracing::subscriber::with_default(subscriber, f);
+	captured
+}
+
+// endregion: --- Capture layer
+
+// region:    --- Fixtures
+
+fn model() -> ModelIden {
+	ModelIden::from_static(AdapterKind::OpenAI, "gpt-4o")
+}
+
+fn endpoint() -> Endpoint {
+	Endpoint::from_static("https://api.openai.com/v1/")
+}
+
+fn chat_response() -> ChatResponse {
+	ChatResponse {
+		content: MessageContent::from_text("Hello!"),
+		reasoning_content: None,
+		model_iden: model(),
+		provider_model_iden: ModelIden::from_static(AdapterKind::OpenAI, "gpt-4o-2024-08-06"),
+		stop_reason: Some(StopReason::Completed("stop".to_string())),
+		usage: Usage {
+			prompt_tokens: Some(10),
+			completion_tokens: Some(20),
+			total_tokens: Some(30),
+			..Default::default()
+		},
+		captured_raw_body: None,
+		response_id: Some("chatcmpl-123".to_string()),
+	}
+}
+
+// endregion: --- Fixtures
+
+// region:    --- Chat span tests
+
+#[test]
+fn test_otel_chat_span_request_and_response_attributes() {
+	let captured = capture(|| {
+		let options = ChatOptions::default().with_temperature(0.7).with_max_tokens(256);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&options));
+		let chat_req = ChatRequest::new(vec![ChatMessage::user("Hello")]);
+
+		let span = span::chat_request_span(&model(), &endpoint(), &options_set, &chat_req, false);
+		span::record_chat_response(&span, &chat_response());
+	});
+
+	let span = captured.by_name("genai.chat");
+
+	// -- Span shape / required attributes
+	assert_eq!(span.get("otel.name"), Some("chat gpt-4o"));
+	assert_eq!(span.get("otel.kind"), Some("client"));
+	assert_eq!(span.get("gen_ai.operation.name"), Some("chat"));
+	assert_eq!(span.get("gen_ai.provider.name"), Some("openai"));
+	assert_eq!(span.get("gen_ai.request.model"), Some("gpt-4o"));
+	assert_eq!(span.get("gen_ai.request.stream"), Some("false"));
+
+	// -- Request options
+	assert_eq!(span.get("gen_ai.request.temperature"), Some("0.7"));
+	assert_eq!(span.get("gen_ai.request.max_tokens"), Some("256"));
+
+	// -- Server
+	assert_eq!(span.get("server.address"), Some("api.openai.com"));
+	assert_eq!(span.get("server.port"), Some("443"));
+
+	// -- Response
+	assert_eq!(span.get("gen_ai.response.id"), Some("chatcmpl-123"));
+	assert_eq!(span.get("gen_ai.response.model"), Some("gpt-4o-2024-08-06"));
+	assert_eq!(span.get("gen_ai.response.finish_reasons"), Some(r#"["stop"]"#));
+
+	// -- Usage
+	assert_eq!(span.get("gen_ai.usage.input_tokens"), Some("10"));
+	assert_eq!(span.get("gen_ai.usage.output_tokens"), Some("20"));
+
+	// -- No error on the success path
+	assert!(!span.has("error.type"));
+	assert!(!span.has("otel.status_code"));
+}
+
+#[test]
+fn test_otel_chat_span_content_absent_by_default() {
+	let captured = capture(|| {
+		let options_set = ChatOptionsSet::default();
+		let chat_req = ChatRequest::from_system("be brief").append_message(ChatMessage::user("Hello"));
+		let span = span::chat_request_span(&model(), &endpoint(), &options_set, &chat_req, false);
+		span::record_chat_response(&span, &chat_response());
+	});
+
+	let span = captured.by_name("genai.chat");
+
+	// Content capture is off by default → no sensitive content attributes.
+	assert!(!span.has("gen_ai.system_instructions"));
+	assert!(!span.has("gen_ai.input.messages"));
+	assert!(!span.has("gen_ai.output.messages"));
+	assert!(!span.has("gen_ai.tool.definitions"));
+}
+
+#[test]
+fn test_otel_chat_span_records_error() {
+	let captured = capture(|| {
+		let options_set = ChatOptionsSet::default();
+		let chat_req = ChatRequest::new(vec![ChatMessage::user("Hello")]);
+		let span = span::chat_request_span(&model(), &endpoint(), &options_set, &chat_req, false);
+		span::record_error(&span, &crate::Error::Internal("boom".to_string()));
+	});
+
+	let span = captured.by_name("genai.chat");
+	assert_eq!(span.get("otel.status_code"), Some("error"));
+	assert_eq!(span.get("error.type"), Some("internal"));
+}
+
+// endregion: --- Chat span tests
+
+// region:    --- Streaming span tests
+
+#[test]
+fn test_otel_chat_stream_span_records_ttfc_and_end() {
+	use futures::StreamExt;
+
+	let captured = capture(|| {
+		let options_set = ChatOptionsSet::default();
+		let chat_req = ChatRequest::new(vec![ChatMessage::user("Hello")]);
+		let span = span::chat_request_span(&model(), &endpoint(), &options_set, &chat_req, true);
+
+		let inter = futures::stream::iter(vec![
+			Ok(InterStreamEvent::Start),
+			Ok(InterStreamEvent::Chunk("Hel".to_string())),
+			Ok(InterStreamEvent::Chunk("lo".to_string())),
+			Ok(InterStreamEvent::End(InterStreamEnd {
+				captured_usage: Some(Usage {
+					prompt_tokens: Some(5),
+					completion_tokens: Some(7),
+					total_tokens: Some(12),
+					..Default::default()
+				}),
+				captured_stop_reason: Some(StopReason::Completed("stop".to_string())),
+				..Default::default()
+			})),
+		]);
+
+		let mut stream = ChatStream::from_inter_stream(inter).with_otel_span(span);
+		futures::executor::block_on(async { while stream.next().await.is_some() {} });
+	});
+
+	let span = captured.by_name("genai.chat");
+	assert_eq!(span.get("gen_ai.request.stream"), Some("true"));
+	// Time-to-first-chunk recorded (value is timing-dependent; assert presence).
+	assert!(span.has("gen_ai.response.time_to_first_chunk"));
+	// End attributes captured.
+	assert_eq!(span.get("gen_ai.usage.input_tokens"), Some("5"));
+	assert_eq!(span.get("gen_ai.usage.output_tokens"), Some("7"));
+	assert_eq!(span.get("gen_ai.response.finish_reasons"), Some(r#"["stop"]"#));
+}
+
+#[test]
+fn test_otel_chat_stream_span_records_error() {
+	use futures::StreamExt;
+
+	let captured = capture(|| {
+		let options_set = ChatOptionsSet::default();
+		let chat_req = ChatRequest::new(vec![ChatMessage::user("Hello")]);
+		let span = span::chat_request_span(&model(), &endpoint(), &options_set, &chat_req, true);
+
+		let inter = futures::stream::iter(vec![
+			Ok(InterStreamEvent::Start),
+			Err(crate::Error::Internal("stream boom".to_string())),
+		]);
+
+		let mut stream = ChatStream::from_inter_stream(inter).with_otel_span(span);
+		futures::executor::block_on(async { while stream.next().await.is_some() {} });
+	});
+
+	let span = captured.by_name("genai.chat");
+	assert_eq!(span.get("otel.status_code"), Some("error"));
+	assert_eq!(span.get("error.type"), Some("internal"));
+}
+
+// endregion: --- Streaming span tests
+
+// region:    --- Embeddings span tests
+
+#[test]
+fn test_otel_embeddings_span_attributes() {
+	use crate::embed::{EmbedOptions, EmbedOptionsSet, EmbedResponse};
+
+	let captured = capture(|| {
+		let options = EmbedOptions::default().with_dimensions(512);
+		let options_set = EmbedOptionsSet::new().with_request_options(Some(&options));
+		let model = ModelIden::from_static(AdapterKind::OpenAI, "text-embedding-3-small");
+		let span = span::embeddings_request_span(&model, &endpoint(), &options_set);
+
+		let res = EmbedResponse {
+			embeddings: vec![],
+			model_iden: model.clone(),
+			provider_model_iden: ModelIden::from_static(AdapterKind::OpenAI, "text-embedding-3-small"),
+			usage: Usage {
+				prompt_tokens: Some(8),
+				total_tokens: Some(8),
+				..Default::default()
+			},
+			captured_raw_body: None,
+		};
+		span::record_embed_response(&span, &res);
+	});
+
+	let span = captured.by_name("genai.embeddings");
+	assert_eq!(span.get("otel.name"), Some("embeddings text-embedding-3-small"));
+	assert_eq!(span.get("otel.kind"), Some("client"));
+	assert_eq!(span.get("gen_ai.operation.name"), Some("embeddings"));
+	assert_eq!(span.get("gen_ai.provider.name"), Some("openai"));
+	assert_eq!(span.get("gen_ai.request.model"), Some("text-embedding-3-small"));
+	assert_eq!(span.get("gen_ai.embeddings.dimension.count"), Some("512"));
+	assert_eq!(span.get("gen_ai.usage.input_tokens"), Some("8"));
+}
+
+// endregion: --- Embeddings span tests
+
+// region:    --- Helper builder tests
+
+#[test]
+fn test_otel_execute_tool_span() {
+	use crate::chat::ToolCall;
+	use serde_json::json;
+
+	let captured = capture(|| {
+		let tool_call = ToolCall {
+			call_id: "call_42".to_string(),
+			fn_name: "get_weather".to_string(),
+			fn_arguments: json!({ "location": "Paris" }),
+			thought_signatures: None,
+		};
+		let _span = agent::execute_tool_span(&tool_call);
+	});
+
+	let span = captured.by_name("genai.execute_tool");
+	assert_eq!(span.get("otel.name"), Some("execute_tool get_weather"));
+	assert_eq!(span.get("otel.kind"), Some("internal"));
+	assert_eq!(span.get("gen_ai.operation.name"), Some("execute_tool"));
+	assert_eq!(span.get("gen_ai.tool.name"), Some("get_weather"));
+	assert_eq!(span.get("gen_ai.tool.call.id"), Some("call_42"));
+	assert_eq!(span.get("gen_ai.tool.type"), Some("function"));
+	// Arguments are opt-in content → absent by default.
+	assert!(!span.has("gen_ai.tool.call.arguments"));
+}
+
+#[test]
+fn test_otel_agent_spans() {
+	let captured = capture(|| {
+		let _create = agent::AgentSpan::create_agent()
+			.with_name("Greeter")
+			.with_id("agent_1")
+			.with_model("gpt-4o")
+			.start();
+		let _invoke = agent::AgentSpan::invoke_agent().with_name("Greeter").internal().start();
+		let _workflow = agent::invoke_workflow_span("daily-report");
+		let _plan = agent::plan_span(Some("Greeter"));
+	});
+
+	let create = captured.by_name("genai.agent");
+	assert_eq!(create.get("gen_ai.operation.name"), Some("create_agent"));
+	assert_eq!(create.get("otel.name"), Some("create_agent Greeter"));
+	assert_eq!(create.get("otel.kind"), Some("client"));
+	assert_eq!(create.get("gen_ai.agent.name"), Some("Greeter"));
+	assert_eq!(create.get("gen_ai.agent.id"), Some("agent_1"));
+	assert_eq!(create.get("gen_ai.request.model"), Some("gpt-4o"));
+
+	let workflow = captured.by_name("genai.invoke_workflow");
+	assert_eq!(workflow.get("otel.name"), Some("invoke_workflow daily-report"));
+	assert_eq!(workflow.get("otel.kind"), Some("internal"));
+	assert_eq!(workflow.get("gen_ai.workflow.name"), Some("daily-report"));
+
+	let plan = captured.by_name("genai.plan");
+	assert_eq!(plan.get("otel.name"), Some("plan Greeter"));
+	assert_eq!(plan.get("gen_ai.agent.name"), Some("Greeter"));
+}
+
+#[test]
+fn test_otel_evaluation_result_event() {
+	let captured = capture(|| {
+		events::EvalResult::new("Relevance")
+			.with_score_value(4.0)
+			.with_score_label("relevant")
+			.with_response_id("chatcmpl-123")
+			.emit();
+	});
+
+	let event = captured.by_name("genai.evaluation.result");
+	assert_eq!(event.get("otel.name"), Some("gen_ai.evaluation.result"));
+	assert_eq!(event.get("gen_ai.evaluation.name"), Some("Relevance"));
+	assert_eq!(event.get("gen_ai.evaluation.score.value"), Some("4"));
+	assert_eq!(event.get("gen_ai.evaluation.score.label"), Some("relevant"));
+	assert_eq!(event.get("gen_ai.response.id"), Some("chatcmpl-123"));
+}
+
+// endregion: --- Helper builder tests


### PR DESCRIPTION
## Summary

Adds an optional **`otel` feature (off by default)** that instruments genai
operations following the [OpenTelemetry GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai)
(currently at *Development* status).

It's a **pure `tracing` bridge with no new dependencies** — genai emits
`gen_ai.*` spans (plus the `otel.kind`/`otel.name`/`otel.status_code` bridge
fields) on whatever `tracing` subscriber is installed. Applications export them
by wiring [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry); genai
never owns the OTel pipeline. With the feature off, the build is unchanged.

## What's auto-instrumented

`exec_chat`, `exec_chat_stream`, and `exec_embed` become CLIENT spans named
`{operation} {model}`, recording:

- `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.request.stream`
- request params: `temperature`, `max_tokens`, `top_p`, `seed`, `stop_sequences`, `output.type`
- `server.address` / `server.port`
- `gen_ai.response.{id, model, finish_reasons}`
- usage: `input_tokens`, `output_tokens`, `cache_read.input_tokens`, `cache_creation.input_tokens`, `reasoning.output_tokens`
- `gen_ai.response.time_to_first_chunk` (streaming)
- `error.type` + `otel.status_code=error` on every failure path (HTTP status code where available)

`AdapterKind` maps to `gen_ai.provider.name` using the spec's well-known values
where defined (`openai`, `anthropic`, `gcp.gemini`, `gcp.vertex_ai`,
`aws.bedrock`, `groq`, `cohere`, `deepseek`, `x_ai`, `moonshot_ai`), falling
back to the adapter's lower-case id otherwise.

## Content capture (opt-in, off by default)

`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`,
and `gen_ai.tool.definitions` (as spec-schema JSON) are recorded **only** when
`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is set — matching the
OpenTelemetry GenAI instrumentations' convention — since this data is sensitive.

## Opt-in helpers

genai is a provider client, so agent/workflow/tool/evaluation signals have no
internal trigger. `genai::otel` exposes builders (`execute_tool_span`,
`AgentSpan::{create_agent,invoke_agent}`, `invoke_workflow_span`, `plan_span`,
`events::EvalResult`) for apps building higher-level flows on top of genai.

## Design notes / limitations

- **Spans only.** The spec's metric instruments aren't emitted; usage/duration
  live as span attributes (backends can derive metrics from spans).
- **Array/content attributes as JSON strings**, which the spec permits on spans
  (`tracing` has no array field type).
- **No cost attribute** — the GenAI semconv defines tokens, not monetary cost.
- The semconv is at *Development* status; attribute names are centralized in
  `genai::otel::conventions` to absorb churn.

## Testing & docs

- Unit tests (provider mapping, server addr/port parsing, `error.type`
  derivation, content serializers) + integration tests that install a capturing
  `tracing` layer and assert the exact emitted `gen_ai.*` fields for chat,
  streaming, embeddings, and the helper spans/events.
- `cargo test`/`clippy`/`fmt` clean with and without `--features otel`.
- `docs/otel.md` and runnable `examples/c12-otel.rs`.

## Verified end-to-end

Exported through `tracing-opentelemetry` + OTLP to a real collector and
confirmed the spans land correctly typed: `span_name="chat gpt-4o-mini"`,
`span_kind=CLIENT`, integer token usage, `finish_reasons=["stop"]`, streaming
`time_to_first_chunk`, `status_code=ERROR` + `error.type="500"` on the failure
path, and the opt-in content as spec-schema JSON.

Happy to split this into a smaller core-only PR (chat/stream/embed spans) and
propose the helpers separately if you'd prefer.
