### PR TITLE
fix(anthropic): propagate mid-stream error events as typed errors

### DIFF
--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -239,7 +239,24 @@ impl futures::Stream for AnthropicStreamer {
 						}
 
 						"ping" => continue, // Loop to the next event
-						other => tracing::warn!("UNKNOWN MESSAGE TYPE: {other}"),
+						"error" => {
+							// Anthropic may emit an `event: error` mid-stream (e.g. overloaded_error,
+							// rate_limit, internal_server_error). Propagate it as a typed error so the
+							// caller can surface the real cause instead of silently ending the stream.
+							tracing::warn!("Anthropic stream error event, data: {}", message.data);
+							let body: Value = serde_json::from_str(&message.data).unwrap_or_else(|_| {
+								Value::String(message.data.clone())
+							});
+							self.done = true;
+							return Poll::Ready(Some(Err(Error::ChatResponse {
+								model_iden: self.options.model_iden.clone(),
+								body,
+							})));
+						}
+						other => tracing::warn!(
+							"UNKNOWN MESSAGE TYPE: {other}, data: {}",
+							message.data
+						),
 					}
 				}
 				Some(Err(err)) => {


### PR DESCRIPTION
## Problem

Anthropic can emit an `event: error` **mid-stream** (e.g. `overloaded_error`, `rate_limit`, `internal_server_error`) after a stream has already started. The Anthropic streamer's event `match` has no arm for `"error"`, so such events fall through to:

```rust
other => tracing::warn!("UNKNOWN MESSAGE TYPE: {other}"),
```

The error is only logged as a warning and the **stream silently ends**. Callers receive a truncated/empty response with no `Err`, so they cannot tell a real failure (overload/rate-limit) from a normal completion, nor retry.

## Fix

Add an `"error"` arm to the streamer that:

1. parses the error payload (falling back to the raw string if it isn't valid JSON),
2. marks the streamer done to stop further polling,
3. returns a typed `Error::ChatResponse { model_iden, body }` so the caller sees the real cause.

The existing `other =>` warning is also extended to include `message.data` for easier diagnostics.

## Notes

- Single file, +18/-1, no new dependencies.
- `Error::ChatResponse` already exists and its display message is literally "Error event in stream …", so this is exactly its intended use.
- `cargo check` passes.
