### PR TITLE
feat(anthropic): support fine-grained tool streaming (eager_input_streaming)

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -640,6 +640,7 @@ impl AnthropicAdapter {
 			schema,
 			config,
 			cache_control,
+			eager_input_streaming,
 			..
 		} = tool;
 
@@ -686,6 +687,10 @@ impl AnthropicAdapter {
 			if let Some(description) = description {
 				// TODO: need to handle error
 				let _ = tool_value.x_insert("description", description);
+			}
+			// Anthropic fine-grained tool streaming (GA): opt-in per tool.
+			if eager_input_streaming == Some(true) {
+				let _ = tool_value.x_insert("eager_input_streaming", true);
 			}
 		}
 
@@ -997,6 +1002,36 @@ mod tests {
 			output_config.get("format").and_then(|f| f.get("type")).and_then(|v| v.as_str()),
 			Some("json_schema"),
 			"format.type must be present in output_config"
+		);
+	}
+
+	#[test]
+	fn test_tool_eager_input_streaming_serializes() {
+		// with_eager_input_streaming(true) → the tool carries `eager_input_streaming: true`
+		// (Anthropic fine-grained tool streaming, GA — opt-in per tool).
+		let tool = Tool::new("manage_calendar")
+			.with_schema(json!({"type": "object", "properties": {}}))
+			.with_eager_input_streaming(true);
+		let req = ChatRequest::from_user("hi").with_tools(vec![tool]);
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-sonnet-4-6"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			req,
+			ChatOptionsSet::default().with_chat_options(None),
+		)
+		.expect("to_web_request_data should succeed");
+
+		let tools = web_req.payload.get("tools").and_then(|t| t.as_array()).expect("tools array");
+		assert_eq!(
+			tools[0].get("eager_input_streaming").and_then(|v| v.as_bool()),
+			Some(true),
+			"eager_input_streaming must serialize onto the tool"
 		);
 	}
 

--- a/src/chat/tool/tool_base.rs
+++ b/src/chat/tool/tool_base.rs
@@ -53,6 +53,12 @@ pub struct Tool {
 	/// Anthropic: set on the last tool to cache the entire tool list prefix.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cache_control: Option<CacheControl>,
+
+	/// Anthropic fine-grained tool streaming (GA): when `true`, sets
+	/// `eager_input_streaming` on the tool so the provider streams tool-call
+	/// input without server-side JSON buffering (token-granular `input_json_delta`).
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub eager_input_streaming: Option<bool>,
 }
 
 /// Computed accessors
@@ -97,6 +103,7 @@ impl Tool {
 			strict: None,
 			config: None,
 			cache_control: None,
+			eager_input_streaming: None,
 		}
 	}
 
@@ -138,6 +145,14 @@ impl Tool {
 	/// On Anthropic, set this on the last tool to cache the entire tool list prefix.
 	pub fn with_cache_control(mut self, cache_control: impl Into<CacheControl>) -> Self {
 		self.cache_control = Some(cache_control.into());
+		self
+	}
+
+	/// Enable Anthropic fine-grained tool streaming (`eager_input_streaming`).
+	/// The provider streams tool-call input without buffering the full JSON —
+	/// useful for rendering tool arguments progressively as they arrive.
+	pub fn with_eager_input_streaming(mut self, eager: bool) -> Self {
+		self.eager_input_streaming = Some(eager);
 		self
 	}
 }


### PR DESCRIPTION
## Summary

Adds support for Anthropic's **fine-grained tool streaming** (now GA), exposed as an opt-in per-tool flag.

- `Tool` gains `eager_input_streaming: Option<bool>` + builder `with_eager_input_streaming(bool)` (mirrors the existing `strict` / `cache_control` fields).
- The Anthropic adapter emits `"eager_input_streaming": true` on a custom tool when the flag is set.

## Why

By default Anthropic buffers tool-call input server-side and emits it in coarse `input_json_delta` grains. With `eager_input_streaming` enabled, the provider streams tool-call input token-granular, so consumers can render tool arguments progressively as they arrive (e.g. live UI that reflects a tool's parameters as the model writes them). This is the GA, per-tool successor to the old `anthropic-beta: fine-grained-tool-streaming-2025-05-14` header — no beta header required.

Docs: https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming

## Notes

- Opt-in and serialized only when `Some(true)`, so existing behavior is unchanged.
- Applied to custom tools (the `input_schema` branch); built-in tools are untouched.

## Test Plan

- [x] `test_tool_eager_input_streaming_serializes` — `with_eager_input_streaming(true)` round-trips through `to_web_request_data` and the serialized tool carries `eager_input_streaming: true`.
- [x] `cargo test --lib` (112 passing), `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)