### PR TITLE
fix: ReasoningEffort::Zero (rename from ::None) disables reasoning on Anthropic (#251)

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -419,13 +419,12 @@ impl AnthropicAdapter {
 
 		// -- Reasoning Budget
 		let (model_name, computed_reasoning_effort) = match (raw_model_name, options_set.reasoning_effort()) {
-			// No explicity reasoning_effor, try to infer from model name suffix (supports -zero)
+			// No explicity reasoning_effor, try to infer from model name suffix (supports -zero and -none)
 			(model, None) => {
 				// let model_name: &str = &model.model_name;
 				if let Some((prefix, last)) = raw_model_name.rsplit_once('-') {
 					let reasoning = match last {
-						"zero" => None,
-						"None" => Some(ReasoningEffort::Low),
+						"zero" | "none" => Some(ReasoningEffort::Zero),
 						"minimal" => Some(ReasoningEffort::Low),
 						"low" => Some(ReasoningEffort::Low),
 						"medium" => Some(ReasoningEffort::Medium),
@@ -730,6 +729,16 @@ fn insert_anthropic_reasoning(
 	let support_adaptive = supports_anthropic_adaptive_thinking(model_name);
 	let support_xhigh = supports_anthropic_reasoning_xhigh(model_name);
 
+	// `Zero` means "no reasoning": emit no `output_config.effort` and no adaptive/legacy
+	// thinking payload. Models where thinking is on by default need an explicit opt-out;
+	// for all others, omitting the `thinking` field already means "off".
+	if matches!(effort, ReasoningEffort::Zero) {
+		if anthropic_thinking_on_by_default(model_name) {
+			payload.x_insert("thinking", json!({"type": "disabled"}))?;
+		}
+		return Ok(());
+	}
+
 	// Models that support effort use it as the primary reasoning control.
 	if support_effort {
 		let effort = match effort {
@@ -747,7 +756,8 @@ fn insert_anthropic_reasoning(
 				budget = Some(*val);
 				""
 			}
-			ReasoningEffort::None => "",
+			// Handled by the early return above; kept for exhaustiveness.
+			ReasoningEffort::Zero => "",
 		};
 
 		// Emit the effort into the shared output_config map when present.
@@ -774,7 +784,7 @@ fn insert_anthropic_reasoning(
 	// Older models still use the legacy `thinking.enabled + budget_tokens` shape.
 	if !support_effort {
 		let thinking_budget = match effort {
-			ReasoningEffort::None => None,
+			ReasoningEffort::Zero => None,
 			ReasoningEffort::Budget(budget) => Some(*budget),
 			ReasoningEffort::Low | ReasoningEffort::Minimal => Some(REASONING_LOW),
 			ReasoningEffort::Medium => Some(REASONING_MEDIUM),
@@ -815,6 +825,16 @@ fn supports_anthropic_reasoning_max(model_name: &str) -> bool {
 
 fn supports_anthropic_reasoning_xhigh(model_name: &str) -> bool {
 	is_opus_4_7_or_higher(model_name) || model_name.contains("claude-sonnet-5")
+}
+
+/// Models where Anthropic enables adaptive thinking by default when the request omits the
+/// `thinking` field (currently the Claude Sonnet 5 family). These need an explicit
+/// `{"type": "disabled"}` to turn reasoning off.
+///
+/// NOTE: Fable/Mythos thinking is always-on and cannot be disabled (an explicit "disabled"
+/// is rejected), so they are intentionally not listed — for them, `Zero` omits `thinking`.
+fn anthropic_thinking_on_by_default(model_name: &str) -> bool {
+	model_name.contains("claude-sonnet-5")
 }
 
 fn supports_anthropic_adaptive_thinking(model_name: &str) -> bool {
@@ -1085,6 +1105,126 @@ mod tests {
 
 		assert_eq!(web_req.payload["thinking"], json!({"type": "adaptive"}));
 		assert_eq!(web_req.payload["output_config"]["effort"], json!("high"));
+	}
+
+	/// `Zero` on a thinking-off-by-default model (Opus 4.7+) must emit no reasoning
+	/// fields at all — omitting `thinking` already means "off". See issue #251.
+	#[test]
+	fn test_opus_4_7_reasoning_zero_omits_thinking() {
+		let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Zero);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-opus-4-7"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			options_set,
+		)
+		.expect("to_web_request_data should succeed");
+
+		assert_eq!(web_req.payload.get("thinking"), None, "thinking must be omitted");
+		assert_eq!(
+			web_req.payload.get("output_config"),
+			None,
+			"output_config.effort must be omitted"
+		);
+	}
+
+	/// `Zero` on a thinking-on-by-default model (Sonnet 5) must send the explicit
+	/// opt-out, since omitting the field would leave adaptive thinking on. See issue #251.
+	#[test]
+	fn test_sonnet_5_reasoning_zero_disables_thinking() {
+		let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Zero);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-sonnet-5"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			options_set,
+		)
+		.expect("to_web_request_data should succeed");
+
+		assert_eq!(web_req.payload["thinking"], json!({"type": "disabled"}));
+		assert_eq!(
+			web_req.payload.get("output_config"),
+			None,
+			"output_config.effort must be omitted"
+		);
+	}
+
+	/// The `-none`/`-zero` model-name suffixes must parse to `Zero` and be stripped
+	/// from the model name sent to the API.
+	#[test]
+	fn test_reasoning_zero_model_name_suffix() {
+		for suffix in ["none", "zero"] {
+			let target = ServiceTarget {
+				endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+				auth: AuthData::from_single("test-key"),
+				model: ModelIden::new(AdapterKind::Anthropic, format!("claude-sonnet-5-{suffix}")),
+			};
+
+			let web_req = AnthropicAdapter::to_web_request_data(
+				target,
+				ServiceType::Chat,
+				ChatRequest::from_user("hello"),
+				ChatOptionsSet::default(),
+			)
+			.expect("to_web_request_data should succeed");
+
+			assert_eq!(
+				web_req.payload["model"],
+				json!("claude-sonnet-5"),
+				"suffix -{suffix} must be stripped"
+			);
+			assert_eq!(web_req.payload["thinking"], json!({"type": "disabled"}));
+		}
+	}
+
+	/// `Zero` on every other family must emit no reasoning fields: legacy models
+	/// (claude-sonnet-4-5), adaptive-but-off-by-default models (claude-opus-4-6), and
+	/// Fable/Mythos — where thinking is always-on and an explicit "disabled" is rejected,
+	/// so omission is the only valid payload (see `anthropic_thinking_on_by_default`).
+	#[test]
+	fn test_reasoning_zero_other_models_omit_thinking() {
+		for model in ["claude-sonnet-4-5", "claude-opus-4-6", "claude-fable-5"] {
+			let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Zero);
+			let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+			let target = ServiceTarget {
+				endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+				auth: AuthData::from_single("test-key"),
+				model: ModelIden::new(AdapterKind::Anthropic, model),
+			};
+
+			let web_req = AnthropicAdapter::to_web_request_data(
+				target,
+				ServiceType::Chat,
+				ChatRequest::from_user("hello"),
+				options_set,
+			)
+			.expect("to_web_request_data should succeed");
+
+			assert_eq!(
+				web_req.payload.get("thinking"),
+				None,
+				"thinking must be omitted for {model}"
+			);
+			assert_eq!(
+				web_req.payload.get("output_config"),
+				None,
+				"output_config.effort must be omitted for {model}"
+			);
+		}
 	}
 
 	#[test]

--- a/src/adapter/adapters/bedrock/converse.rs
+++ b/src/adapter/adapters/bedrock/converse.rs
@@ -229,7 +229,7 @@ fn publisher_additional_fields(publisher: BedrockPublisher, effort: &ReasoningEf
 	match publisher {
 		BedrockPublisher::Anthropic => {
 			let budget = match effort {
-				ReasoningEffort::None => return None,
+				ReasoningEffort::Zero => return None,
 				ReasoningEffort::Budget(n) => *n,
 				ReasoningEffort::Minimal | ReasoningEffort::Low => 1024,
 				ReasoningEffort::Medium => 8000,
@@ -246,7 +246,7 @@ fn publisher_additional_fields(publisher: BedrockPublisher, effort: &ReasoningEf
 			// Nova surfaces reasoning via inferenceConfig.reasoningConfig today; when a user explicitly sets
 			// ReasoningEffort, opt in.
 			match effort {
-				ReasoningEffort::None => None,
+				ReasoningEffort::Zero => None,
 				_ => Some(json!({
 					"inferenceConfig": { "reasoningConfig": { "type": "enabled" } }
 				})),

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -27,7 +27,7 @@ pub(in crate::adapter) const REASONING_HIGH: u32 = 24000;
 fn insert_gemini_thinking_budget_value(payload: &mut Value, effort: &ReasoningEffort) -> Result<()> {
 	// -- for now, match minimal to Low (because zero is not supported by 2.5 pro)
 	let budget = match effort {
-		ReasoningEffort::None => None,
+		ReasoningEffort::Zero => None,
 		ReasoningEffort::Low | ReasoningEffort::Minimal => Some(REASONING_LOW),
 		ReasoningEffort::Medium => Some(REASONING_MEDIUM),
 		ReasoningEffort::High | ReasoningEffort::Max | ReasoningEffort::XHigh => Some(REASONING_HIGH),
@@ -399,7 +399,7 @@ impl GeminiAdapter {
 					let reasoning = match last {
 						// 'zero' is a gemini special
 						"zero" => Some(ReasoningEffort::Budget(REASONING_ZERO)),
-						"none" => Some(ReasoningEffort::None),
+						"none" => Some(ReasoningEffort::Zero),
 						"low" | "minimal" => Some(ReasoningEffort::Low),
 						"medium" => Some(ReasoningEffort::Medium),
 						"high" => Some(ReasoningEffort::High),
@@ -433,7 +433,7 @@ impl GeminiAdapter {
 			let models = ["gemini-3", "gemma-4"];
 			if models.iter().any(|m| provider_model_name.contains(m)) {
 				let thinking_level = match computed_reasoning_effort {
-					ReasoningEffort::None => None,
+					ReasoningEffort::Zero => None,
 					ReasoningEffort::Budget(_) => None,
 					ReasoningEffort::Minimal => Some("MINIMAL"),
 					ReasoningEffort::Low => Some("LOW"),

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -18,7 +18,7 @@ use value_ext::JsonValueExt;
 
 fn insert_openai_reasoning_effort(payload: &mut Value, effort: &ReasoningEffort) -> Result<()> {
 	let keyword = match effort {
-		ReasoningEffort::None => "none",
+		ReasoningEffort::Zero => "none",
 		ReasoningEffort::Low => "low",
 		ReasoningEffort::Medium => "medium",
 		ReasoningEffort::High => "high",

--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -237,7 +237,15 @@ impl ChatOptions {
 /// Provider-specific hint for reasoning intensity/budget.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ReasoningEffort {
-	None,
+	/// Explicitly request no reasoning.
+	///
+	/// Note: Distinct from leaving `ChatOptions::reasoning_effort` unset (`Option::None`),
+	/// which means "no preference, don't touch anything". The keyword remains `none`
+	/// (e.g., the `-none` model-name suffix). Adapters map this to the provider's explicit
+	/// opt-out where one exists (e.g., Anthropic models that think by default) and
+	/// otherwise omit the reasoning configuration.
+	#[serde(alias = "None")]
+	Zero,
 	Low,
 	Medium,
 	High,
@@ -253,7 +261,7 @@ impl ReasoningEffort {
 	/// Returns the lowercase variant name.
 	pub fn variant_name(&self) -> &'static str {
 		match self {
-			ReasoningEffort::None => "none",
+			ReasoningEffort::Zero => "zero",
 			ReasoningEffort::Low => "low",
 			ReasoningEffort::Medium => "medium",
 			ReasoningEffort::High => "high",
@@ -268,7 +276,7 @@ impl ReasoningEffort {
 	/// Returns a keyword for non-`Budget` variants; `None` for `Budget(_)`.
 	pub fn as_keyword(&self) -> Option<&'static str> {
 		match self {
-			ReasoningEffort::None => Some("none"),
+			ReasoningEffort::Zero => Some("none"),
 			ReasoningEffort::Low => Some("low"),
 			ReasoningEffort::Medium => Some("medium"),
 			ReasoningEffort::High => Some("high"),
@@ -283,7 +291,7 @@ impl ReasoningEffort {
 	/// Parses a verbosity keyword.
 	pub fn from_keyword(name: &str) -> Option<Self> {
 		match name {
-			"none" => Some(ReasoningEffort::None),
+			"none" => Some(ReasoningEffort::Zero),
 			"low" => Some(ReasoningEffort::Low),
 			"medium" => Some(ReasoningEffort::Medium),
 			"high" => Some(ReasoningEffort::High),
@@ -311,7 +319,7 @@ impl ReasoningEffort {
 impl std::fmt::Display for ReasoningEffort {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			ReasoningEffort::None => write!(f, "none"),
+			ReasoningEffort::Zero => write!(f, "none"),
 			ReasoningEffort::Low => write!(f, "low"),
 			ReasoningEffort::Medium => write!(f, "medium"),
 			ReasoningEffort::High => write!(f, "high"),


### PR DESCRIPTION
Fixes #251 — implements the rename agreed there.

## Problem

`Some(ReasoningEffort::None)` suppressed `output_config.effort` but still fell through to the adaptive-thinking branch, so an explicit "no reasoning" request emitted `thinking: {"type": "adaptive"}` on adaptive-capable models. On Claude Sonnet 5 — where adaptive thinking is on by default when the `thinking` field is omitted — there was no way to turn thinking off at all.

## Change

**1. `ReasoningEffort::None` → `ReasoningEffort::Zero`** (as proposed in #251), so the variant no longer reads like `Option::None`. The keyword surface is unchanged: `as_keyword()`/`Display` still produce `"none"`, `from_keyword()` still parses `"none"`, so the `-none` model suffix keeps working everywhere. `variant_name()` returns `"zero"` (its contract is the variant name; the keyword-vs-variant split is intentional). `#[serde(alias = "None")]` keeps previously serialized values deserializable — note the serialize side now emits `"Zero"`.

**2. Anthropic: `Zero` now positively disables reasoning.** `insert_anthropic_reasoning` handles it before the effort/adaptive/legacy branches:

| Model family | Payload for `Zero` | Why |
|---|---|---|
| Claude Sonnet 5 | `thinking: {"type": "disabled"}` | adaptive thinking is on by default; omitting the field would leave it on |
| Opus 4.7 / 4.8, Opus 4.6 / Sonnet 4.6, legacy | *(no `thinking`, no `output_config.effort`)* | thinking is off unless requested |
| Fable / Mythos | *(no `thinking`)* | thinking is always-on and an explicit `"disabled"` is rejected — omitting is "as zero as possible" |

The "on by default" set lives in a named helper (`anthropic_thinking_on_by_default`) per the suggestion in #251, ready for future models that adopt the same default.

**3. Anthropic model-suffix table:** `-zero` and `-none` now both map to `Zero` and are stripped from the model name. Two behavior deltas worth calling out explicitly:
- previously `"zero" => None` matched but didn't strip (the literal `claude-sonnet-5-zero` was sent to the API);
- the `"None" => Some(Low)` entry (capital N, mapping a "disable"-looking suffix to *low reasoning*) is removed rather than renamed — it looked like a leftover; shout if it was intentional.

This is scoped to the Anthropic adapter's own table — the shared `from_keyword()` deliberately does **not** learn `"zero"`, since it feeds `from_model_name()` in the OpenAI-family adapters where real model ids end in `-zero` (e.g. `deepseek-r1-zero`) and would be silently rewritten.

Other adapters (bedrock, gemini, openai) are mechanical renames; their existing behavior for this variant is unchanged (openai already maps it to OpenAI's native `reasoning_effort: "none"`).

## Not addressed here (pre-existing, happy to file/follow up)

- **Gemini**: `Zero` still emits no `thinkingConfig`, so thinking-by-default Gemini models keep thinking. Gemini has a positive off (`thinkingBudget: 0` — what the Gemini `-zero` suffix already maps to via `Budget(0)`); mapping `Zero` to it would mirror this fix but is beyond #251's scope.
- **Bedrock**: `Zero` emits no fields (unchanged), and the Anthropic-on-Bedrock path still uses the legacy `thinking.enabled + budget_tokens` shape for non-Zero efforts, which newer models reject.

## Tests

The two regression tests suggested in #251, plus suffix and other-model pins:

- `test_opus_4_7_reasoning_zero_omits_thinking` — no `thinking`, no `output_config`
- `test_sonnet_5_reasoning_zero_disables_thinking` — `thinking: {"type":"disabled"}`, no `output_config`
- `test_reasoning_zero_model_name_suffix` — `claude-sonnet-5-none` / `-zero` strip the suffix and disable thinking
- `test_reasoning_zero_other_models_omit_thinking` — legacy (`claude-sonnet-4-5`), off-by-default adaptive (`claude-opus-4-6`), and `claude-fable-5` (pins the "never send disabled to Fable" invariant from the helper's NOTE)

`cargo test --lib`: 117 passed; clippy clean. (The two doctest failures in `tool_base.rs` / `zai/mod.rs` are pre-existing on main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
