### PR TITLE
anthropic: merge extra request body fields

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -507,6 +507,10 @@ impl AnthropicAdapter {
 			payload.x_insert("top_p", top_p)?;
 		}
 
+		if let Some(extra_body) = options_set.extra_body() {
+			payload.x_merge(extra_body.clone())?;
+		}
+
 		Ok(WebRequestData { url, headers, payload })
 	}
 


### PR DESCRIPTION
We support extra request body in our API for other adapters, we can pass it through for Anthropic.