### PR TITLE
fix(anthropic): capture streaming cache tokens from `message_delta` fallback

### DIFF
--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -311,17 +311,36 @@ impl AnthropicStreamer {
 				*val += output_tokens;
 			}
 
-			// -- Capture cache tokens (only present in message_start)
+			// -- Capture cache tokens.
+			// Standard Anthropic reports them in `message_start` (`/message/usage`).
+			// Some Anthropic-compatible gateways (e.g. Alibaba DashScope / Qwen) instead report
+			// them in `message_delta` (`/usage`), so fall back to that location when `message_start`
+			// did not carry them.
 			// NOTE: Anthropic's input_tokens does NOT include cached tokens, so we must add them.
 			// See also: AnthropicAdapter::into_usage() for non-streaming equivalent.
-			if message_type == "message_start" {
-				let cache_creation: i32 = data.x_get("/message/usage/cache_creation_input_tokens").unwrap_or(0);
-				let cache_read: i32 = data.x_get("/message/usage/cache_read_input_tokens").unwrap_or(0);
+			let cache_base = match message_type {
+				"message_start" => Some("/message/usage"),
+				// Fall back to message_delta only if message_start did not already provide cache details.
+				"message_delta"
+					if self
+						.captured_data
+						.usage
+						.as_ref()
+						.and_then(|u| u.prompt_tokens_details.as_ref())
+						.is_none() =>
+				{
+					Some("/usage")
+				}
+				_ => None,
+			};
+
+			if let Some(base) = cache_base {
+				let cache_creation: i32 = data.x_get(&format!("{base}/cache_creation_input_tokens")).unwrap_or(0);
+				let cache_read: i32 = data.x_get(&format!("{base}/cache_read_input_tokens")).unwrap_or(0);
 
 				// Parse cache_creation breakdown if present (TTL-specific breakdown)
-				// Use x_get with JSON pointer to navigate to /message/usage/cache_creation
 				let cache_creation_details = data
-					.x_get::<Value>("/message/usage/cache_creation")
+					.x_get::<Value>(&format!("{base}/cache_creation"))
 					.ok()
 					.as_ref()
 					.and_then(parse_cache_creation_details);
@@ -329,9 +348,13 @@ impl AnthropicStreamer {
 				if cache_creation > 0 || cache_read > 0 || cache_creation_details.is_some() {
 					let usage = self.captured_data.usage.get_or_insert(Usage::default());
 
-					// Add cache tokens to prompt_tokens (same as into_usage does)
-					if let Some(ref mut pt) = usage.prompt_tokens {
-						*pt += cache_creation + cache_read;
+					// Add cache tokens to prompt_tokens only for message_start, where Anthropic's
+					// input_tokens excludes them. For the message_delta fallback the token accounting
+					// is gateway-specific, so we only surface the breakdown to avoid double counting.
+					if message_type == "message_start" {
+						if let Some(ref mut pt) = usage.prompt_tokens {
+							*pt += cache_creation + cache_read;
+						}
 					}
 
 					// Set prompt_tokens_details (match into_usage behavior: always Some(value))


### PR DESCRIPTION
## Problem

`AnthropicStreamer::capture_usage` only reads cache tokens
(`cache_creation_input_tokens` / `cache_read_input_tokens`) from the
`message_start` event (`/message/usage/...`).

The official Anthropic API does report them there, but several
**Anthropic-compatible gateways** report them in the `message_delta` event
(`/usage/...`) instead. On those gateways, streaming responses silently return
`prompt_tokens_details.cached_tokens = 0` / `cache_creation_tokens = 0` even when
the request used `cache_control` and the server actually served/created a cache.

Concretely reproduced against **Alibaba DashScope / Qwen** Anthropic-compatible
endpoint (`.../apps/anthropic/v1`). Raw SSE from that gateway:

```
event:message_start
data:{"message":{...,"usage":{"input_tokens":3602,"output_tokens":0}}}   # no cache fields

event:message_delta
data:{"type":"message_delta","usage":{
  "cache_creation_input_tokens":0,
  "cache_read_input_tokens":3604,
  "prompt_tokens_details":{"cached_tokens":3604},
  "output_tokens":878}}                                                   # cache is here
```

Non-streaming (`into_usage`) works because it parses the final top-level `usage`
object; only the streaming path was affected.

## Fix

Fall back to `message_delta` (`/usage`) when `message_start` did not carry cache
details. `prompt_tokens` is only adjusted for `message_start` (where Anthropic's
`input_tokens` excludes cached tokens); for the `message_delta` fallback we only
surface the breakdown into `prompt_tokens_details` to avoid double counting under
gateway-specific accounting.

- Standard Anthropic: unchanged (still reads `message_start`).
- Compatible gateways reporting in `message_delta`: `cached_tokens` /
  `cache_creation_tokens` are now populated.

## Verification

Against the DashScope/Qwen Anthropic-compatible endpoint with a >1k-token
`cache_control` system prompt, streaming now reports
`prompt_tokens_details.cached_tokens = 2404` (was `0`), matching the raw SSE.
`cargo check` passes on `0.7.0-beta.11-WIP`.
