### PR TITLE
Add error handling for tool-call input JSON parsing in AnthropicStreamer, avoid stream crash

### DIFF
--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -180,7 +180,13 @@ impl futures::Stream for AnthropicStreamer {
 									let fn_arguments = if input.is_empty() {
 										Value::Object(Map::new())
 									} else {
-										serde_json::from_str(&input)?
+										serde_json::from_str(&input).unwrap_or_else(|e| {
+											tracing::warn!(
+												"Anthropic streamer: failed to parse tool-call input JSON ({} bytes): {e}",
+												input.len()
+											);
+											Value::String(input)
+										})
 									};
 
 									let tc = ToolCall {


### PR DESCRIPTION
In case of claude generate invalid json, I actually encountered this.