### PR TITLE
feat(openai): serialize video Binary as video_url content part

### DIFF
--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -372,6 +372,11 @@ impl OpenAIAdapter {
 									} else if is_image {
 										let image_url = binary.into_url();
 										values.push(json!({"type": "image_url", "image_url": {"url": image_url}}));
+									} else if binary.is_video() {
+										// OpenAI-compatible providers that support video (e.g. Alibaba qwen)
+										// accept it as a `video_url` content part, symmetric to `image_url`.
+										let video_url = binary.into_url();
+										values.push(json!({"type": "video_url", "video_url": {"url": video_url}}));
 									} else if matches!(&binary.source, BinarySource::Url(_)) {
 										// TODO: Need to return error
 										warn!("OpenAI doesn't support file from URL, need to handle it gracefully");

--- a/src/chat/binary.rs
+++ b/src/chat/binary.rs
@@ -100,6 +100,11 @@ impl Binary {
 		self.content_type.trim().eq_ignore_ascii_case("application/pdf")
 	}
 
+	/// Returns true if this binary is a video (content_type starts with "video/").
+	pub fn is_video(&self) -> bool {
+		self.content_type.trim().to_ascii_lowercase().starts_with("video/")
+	}
+
 	/// Generate the web or data url from this binary
 	pub fn into_url(self) -> String {
 		match self.source {

--- a/src/chat/content_part/common.rs
+++ b/src/chat/content_part/common.rs
@@ -273,6 +273,14 @@ impl ContentPart {
 		}
 	}
 
+	/// Returns true if this part is a binary video (content_type starts with "video/").
+	pub fn is_video(&self) -> bool {
+		match self {
+			ContentPart::Binary(binary) => binary.content_type.trim().to_ascii_lowercase().starts_with("video/"),
+			_ => false,
+		}
+	}
+
 	/// Returns true if this part contains a tool call.
 	pub fn is_tool_call(&self) -> bool {
 		matches!(self, ContentPart::ToolCall(_))


### PR DESCRIPTION
## Problem

OpenAI-compatible providers that support video (e.g. Alibaba qwen, Moonshot Kimi) reject `file`-typed content parts with HTTP 400:

```
Invalid value: file. Supported values are: text, image_url, video_url, video.
```

The OpenAI adapter currently handles:
- image Binary → `image_url`
- audio Binary → `input_audio`

…but falls through to the generic `{type: "file"}` branch for everything else — including video. Any video attachment sent to a provider that exposes video via the OpenAI Chat Completions protocol fails at the API boundary.

## Fix

Add an explicit `binary.is_video()` branch between `is_image` and the generic file fallback, emitting `video_url` — symmetric to how `image_url` is constructed today.

## Changes

- `Binary::is_video()` — `content_type` starts with `video/`
- `ContentPart::is_video()` — delegates to `Binary::is_video()`
- `openai/adapter_shared.rs` — video branch in `ContentPart::Binary` match

```diff
} else if is_image {
    let image_url = binary.into_url();
    values.push(json!({"type": "image_url", "image_url": {"url": image_url}}));
+} else if binary.is_video() {
+    let video_url = binary.into_url();
+    values.push(json!({"type": "video_url", "video_url": {"url": video_url}}));
} else if matches!(&binary.source, BinarySource::Url(_)) {
```

## Verification

- `cargo check` passes
- Tested against Alibaba qwen3.6-plus (DashScope OpenAI-compatible endpoint): video attachments no longer return 400, model receives the video content.

Built on top of `v0.7.0-beta.12`. Happy to rebase onto `main` if preferred.
