### PR TITLE
fix(anthropic): correct reasoning routing for current model names

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -850,7 +850,7 @@ fn supports_anthropic_reasoning_max(model_name: &str) -> bool {
 }
 
 fn supports_anthropic_reasoning_xhigh(model_name: &str) -> bool {
-	is_opus_4_7_or_higher(model_name) || model_name.contains("claude-sonnet-5")
+	is_opus_4_7_or_higher(model_name) || is_fable_or_mythos(model_name) || model_name.contains("claude-sonnet-5")
 }
 
 /// Models where Anthropic enables adaptive thinking by default when the request omits the
@@ -885,6 +885,12 @@ fn supports_anthropic_adaptive_thinking(model_name: &str) -> bool {
 /// and a missing one reads as `0`. Any parse or regex failure is treated as a
 /// conservative `false`.
 fn is_opus_4_7_or_higher(model_name: &str) -> bool {
+	/// A minor version is one or two digits; a longer run is a date stamp, not a
+	/// minor. Without this, `claude-opus-4-20250514` (Opus 4.0) would read as
+	/// version 4.20250514 and be promoted. Lookaround would express it in the
+	/// pattern, but the `regex` crate has none.
+	const MAX_MINOR_DIGITS: usize = 2;
+
 	static RE: OnceLock<Option<regex::Regex>> = OnceLock::new();
 	let re = RE.get_or_init(|| regex::Regex::new(r"claude-opus-(\d+)(?:-(\d+))?").ok());
 	let Some(re) = re.as_ref() else {
@@ -894,7 +900,11 @@ fn is_opus_4_7_or_higher(model_name: &str) -> bool {
 		return false;
 	};
 	let major = caps.get(1).and_then(|m| m.as_str().parse::<u32>().ok());
-	let minor = caps.get(2).map_or(Some(0), |m| m.as_str().parse::<u32>().ok());
+	let minor = match caps.get(2) {
+		Some(m) if m.as_str().len() > MAX_MINOR_DIGITS => Some(0),
+		Some(m) => m.as_str().parse::<u32>().ok(),
+		None => Some(0),
+	};
 	match (major, minor) {
 		(Some(major), Some(minor)) => (major, minor) >= (4, 7),
 		_ => false,
@@ -1368,7 +1378,7 @@ mod tests {
 	/// A future Opus release must work without a table update, in either naming shape.
 	#[test]
 	fn test_future_opus_generation_uses_effort() {
-		for model in ["claude-opus-6", "claude-opus-5-1"] {
+		for model in ["claude-opus-6", "claude-opus-5-1", "claude-opus-5-20260101"] {
 			let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Medium);
 			let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
 			let target = ServiceTarget {
@@ -1394,10 +1404,16 @@ mod tests {
 		}
 	}
 
-	/// The optional minor segment must not promote pre-4.7 models: an absent minor reads as `0`.
+	/// The optional minor segment must not promote pre-4.7 models: an absent minor reads as `0`,
+	/// and a date stamp (`claude-opus-4-20250514`, Opus 4.0) is not a minor version.
 	#[test]
 	fn test_pre_4_7_models_still_use_budget_tokens() {
-		for model in ["claude-opus-4-0", "claude-opus-4-1", "claude-sonnet-4-5"] {
+		for model in [
+			"claude-opus-4-0",
+			"claude-opus-4-1",
+			"claude-opus-4-20250514",
+			"claude-sonnet-4-5",
+		] {
 			let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::High);
 			let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
 			let target = ServiceTarget {
@@ -1420,6 +1436,35 @@ mod tests {
 				"for {model}"
 			);
 			assert_eq!(web_req.payload.get("output_config"), None, "for {model}");
+		}
+	}
+
+	/// Fable/Mythos expose `xhigh`. Omitted from the predicate, `XHigh` fell through to the
+	/// `max` arm and silently bought a more expensive level than the caller asked for.
+	#[test]
+	fn test_fable_and_mythos_support_xhigh() {
+		for model in ["claude-fable-5", "claude-mythos-5"] {
+			let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::XHigh);
+			let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+			let target = ServiceTarget {
+				endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+				auth: AuthData::from_single("test-key"),
+				model: ModelIden::new(AdapterKind::Anthropic, model),
+			};
+
+			let web_req = AnthropicAdapter::to_web_request_data(
+				target,
+				ServiceType::Chat,
+				ChatRequest::from_user("hello"),
+				options_set,
+			)
+			.expect("to_web_request_data should succeed");
+
+			assert_eq!(
+				web_req.payload["output_config"]["effort"],
+				json!("xhigh"),
+				"for {model}"
+			);
 		}
 	}
 

--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -854,13 +854,15 @@ fn supports_anthropic_reasoning_xhigh(model_name: &str) -> bool {
 }
 
 /// Models where Anthropic enables adaptive thinking by default when the request omits the
-/// `thinking` field (currently the Claude Sonnet 5 family). These need an explicit
-/// `{"type": "disabled"}` to turn reasoning off.
+/// `thinking` field (currently the Claude Sonnet 5 and Claude Opus 5 families). These need an
+/// explicit `{"type": "disabled"}` to turn reasoning off.
+///
+/// NOTE: not derivable from `is_opus_4_7_or_higher` — Opus 4.7 and 4.8 are off by default, 5 is on.
 ///
 /// NOTE: Fable/Mythos thinking is always-on and cannot be disabled (an explicit "disabled"
 /// is rejected), so they are intentionally not listed — for them, `Zero` omits `thinking`.
 fn anthropic_thinking_on_by_default(model_name: &str) -> bool {
-	model_name.contains("claude-sonnet-5")
+	model_name.contains("claude-sonnet-5") || model_name.contains("claude-opus-5")
 }
 
 fn supports_anthropic_adaptive_thinking(model_name: &str) -> bool {
@@ -876,14 +878,15 @@ fn supports_anthropic_adaptive_thinking(model_name: &str) -> bool {
 // region:    --- Model Name Support
 
 /// Returns true when the given model name looks like a Claude Opus model with
-/// version >= 4.7 (e.g. `claude-opus-4-7`, `claude-opus-5-0`, ...).
+/// version >= 4.7 (e.g. `claude-opus-4-7`, `claude-opus-5`, ...).
 ///
 /// The regex is unanchored and tolerates arbitrary prefixes/suffixes around the
-/// core `claude-opus-<major>-<minor>` portion. Any parse or regex failure is
-/// treated as a conservative `false`.
+/// core `claude-opus-<major>[-<minor>]` portion. The minor segment is optional
+/// and a missing one reads as `0`. Any parse or regex failure is treated as a
+/// conservative `false`.
 fn is_opus_4_7_or_higher(model_name: &str) -> bool {
 	static RE: OnceLock<Option<regex::Regex>> = OnceLock::new();
-	let re = RE.get_or_init(|| regex::Regex::new(r"claude-opus-(\d+)-(\d+)").ok());
+	let re = RE.get_or_init(|| regex::Regex::new(r"claude-opus-(\d+)(?:-(\d+))?").ok());
 	let Some(re) = re.as_ref() else {
 		return false;
 	};
@@ -891,7 +894,7 @@ fn is_opus_4_7_or_higher(model_name: &str) -> bool {
 		return false;
 	};
 	let major = caps.get(1).and_then(|m| m.as_str().parse::<u32>().ok());
-	let minor = caps.get(2).and_then(|m| m.as_str().parse::<u32>().ok());
+	let minor = caps.get(2).map_or(Some(0), |m| m.as_str().parse::<u32>().ok());
 	match (major, minor) {
 		(Some(major), Some(minor)) => (major, minor) >= (4, 7),
 		_ => false,
@@ -1336,6 +1339,116 @@ mod tests {
 				"output_config.effort must be omitted for {model}"
 			);
 		}
+	}
+
+	/// `claude-opus-5` carries no minor version segment. If the version comparison misses it, the
+	/// request falls to the legacy branch and emits `thinking.budget_tokens`, removed on this model.
+	#[test]
+	fn test_opus_5_uses_effort_not_legacy_budget_tokens() {
+		let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::High);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-opus-5"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			options_set,
+		)
+		.expect("to_web_request_data should succeed");
+
+		assert_eq!(web_req.payload["output_config"]["effort"], json!("high"));
+		assert_eq!(web_req.payload["thinking"], json!({"type": "adaptive"}));
+	}
+
+	/// A future Opus release must work without a table update, in either naming shape.
+	#[test]
+	fn test_future_opus_generation_uses_effort() {
+		for model in ["claude-opus-6", "claude-opus-5-1"] {
+			let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Medium);
+			let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+			let target = ServiceTarget {
+				endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+				auth: AuthData::from_single("test-key"),
+				model: ModelIden::new(AdapterKind::Anthropic, model),
+			};
+
+			let web_req = AnthropicAdapter::to_web_request_data(
+				target,
+				ServiceType::Chat,
+				ChatRequest::from_user("hello"),
+				options_set,
+			)
+			.expect("to_web_request_data should succeed");
+
+			assert_eq!(
+				web_req.payload["output_config"]["effort"],
+				json!("medium"),
+				"for {model}"
+			);
+			assert_eq!(web_req.payload["thinking"], json!({"type": "adaptive"}), "for {model}");
+		}
+	}
+
+	/// The optional minor segment must not promote pre-4.7 models: an absent minor reads as `0`.
+	#[test]
+	fn test_pre_4_7_models_still_use_budget_tokens() {
+		for model in ["claude-opus-4-0", "claude-opus-4-1", "claude-sonnet-4-5"] {
+			let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::High);
+			let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+			let target = ServiceTarget {
+				endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+				auth: AuthData::from_single("test-key"),
+				model: ModelIden::new(AdapterKind::Anthropic, model),
+			};
+
+			let web_req = AnthropicAdapter::to_web_request_data(
+				target,
+				ServiceType::Chat,
+				ChatRequest::from_user("hello"),
+				options_set,
+			)
+			.expect("to_web_request_data should succeed");
+
+			assert_eq!(
+				web_req.payload["thinking"],
+				json!({"type": "enabled", "budget_tokens": REASONING_HIGH}),
+				"for {model}"
+			);
+			assert_eq!(web_req.payload.get("output_config"), None, "for {model}");
+		}
+	}
+
+	/// `Zero` on Opus 5 must send the explicit opt-out: thinking is on by default there (unlike
+	/// Opus 4.7/4.8), so omitting the field would leave adaptive thinking running.
+	#[test]
+	fn test_opus_5_reasoning_zero_disables_thinking() {
+		let chat_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Zero);
+		let options_set = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
+		let target = ServiceTarget {
+			endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+			auth: AuthData::from_single("test-key"),
+			model: ModelIden::new(AdapterKind::Anthropic, "claude-opus-5"),
+		};
+
+		let web_req = AnthropicAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			options_set,
+		)
+		.expect("to_web_request_data should succeed");
+
+		assert_eq!(web_req.payload["thinking"], json!({"type": "disabled"}));
+		assert_eq!(
+			web_req.payload.get("output_config"),
+			None,
+			"output_config.effort must be omitted"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Three misroutings in the Anthropic adapter's model-name predicates. They share a
cause — the predicates were written against an older naming shape and an older
model set — so they are here together rather than as three PRs. Each is
independently revertable.

## 1. `claude-opus-5` gets the legacy payload (400s)

The adapter sends:

```json
{"thinking": {"type": "enabled", "budget_tokens": 24000}}
```

`budget_tokens` was removed on that model, so the request fails.

The cause is the version comparison in `is_opus_4_7_or_higher`:

```rust
regex::Regex::new(r"claude-opus-(\d+)-(\d+)")
```

It requires two numeric segments. Current model names drop the minor version, so
`claude-opus-5` never matches — nor would `claude-opus-6`. `SUPPORT_EFFORT_MODELS`
does not list it either, so `supports_anthropic_effort` returns `false` and the
request falls through to the legacy branch.

Because `supports_anthropic_effort`, `supports_anthropic_reasoning_max`,
`supports_anthropic_reasoning_xhigh` and `supports_anthropic_adaptive_thinking`
all route through that same comparison, `claude-opus-5` additionally loses `max`,
`xhigh`, and the adaptive-thinking payload.

**Fix:** make the minor segment optional, reading a missing one as `0`. So
`claude-opus-5` is `(5, 0)` while `claude-opus-4-0` stays `(4, 0)` and remains
below the threshold. That restores the forward-compatibility the comparison was
written for — a future `claude-opus-6` works on release rather than after a table
patch.

A second, smaller change belongs to the same model: `claude-opus-5` is added to
`anthropic_thinking_on_by_default`, so `ReasoningEffort::Zero` sends the explicit
`{"type": "disabled"}`. Thinking is on by default there, so omitting the field
leaves it running. This one cannot be folded into the version comparison — Opus
4.7 and 4.8 are thinking-off by default while Opus 5 is on, so the distinction
does not follow the version ordering.

## 2. A date stamp is read as a minor version

`claude-opus-4-20250514` — the dated form of `claude-opus-4-0` — parses as version
**4.20250514** and is promoted to the modern effort path. The regex is unanchored,
so the date is captured as the minor segment. This one predates the PR; making the
minor optional does not introduce it and does not fix it.

**Fix:** a minor version is one or two digits; a longer run is a date, and the
version reads as `<major>.0`. Lookaround would express this in the pattern, but
the `regex` crate has none, so the check is in code. This also keeps a future
dated modern name correct — `claude-opus-5-20260101` reads as 5.0 and stays on the
effort path.

## 3. `xhigh` on Fable/Mythos silently becomes `max`

`supports_anthropic_reasoning_xhigh` omits Fable/Mythos, so `ReasoningEffort::XHigh`
on `claude-fable-5` falls through to the `Max | XHigh if support_reasoning_max` arm
and sends `"max"` — a more expensive level than the caller asked for, with no error.

Fable/Mythos are already listed in every sibling predicate
(`supports_anthropic_effort`, `_reasoning_max`, `_adaptive_thinking`); `xhigh` was
the only one missing them, which is what suggests an oversight rather than intent.

**Fix:** add them.

## Tests

Six, covering both directions:

- `claude-opus-5` gets `output_config.effort` and adaptive thinking
- `claude-opus-6`, `claude-opus-5-1` and `claude-opus-5-20260101` get the modern shape
- `claude-opus-4-0`, `claude-opus-4-1`, `claude-opus-4-20250514` and
  `claude-sonnet-4-5` still get `thinking.budget_tokens` — this is the guard
  against the optional minor over-promoting pre-4.7 names
- `Zero` on `claude-opus-5` sends `{"type": "disabled"}`
- `xhigh` on `claude-fable-5` and `claude-mythos-5` stays `"xhigh"`

Each fix was verified by reverting it alone and confirming the matching test goes
red — including the two additions, where the failures are
`{"type":"adaptive"}` vs `budget_tokens` for the dated name and `"max"` vs
`"xhigh"` for Fable.

`cargo test --lib` (163 passing), `cargo clippy --all-targets -- -D warnings`, and
`cargo fmt --check` are all clean.

I left `CHANGELOG.md` alone, since the history suggests you add those entries
yourself after merging. Happy to split any of the three out if you would rather
take them separately.
