### PR TITLE
Capture Anthropic reasoning content (for -5 family)

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -484,7 +484,14 @@ impl AnthropicAdapter {
 		let mut output_config: Map<String, Value> = Map::new();
 
 		if let Some(computed_reasoning_effort) = computed_reasoning_effort {
-			insert_anthropic_reasoning(&mut payload, &mut output_config, model_name, &computed_reasoning_effort)?;
+			let capture_reasoning_content = options_set.capture_reasoning_content().unwrap_or_default();
+			insert_anthropic_reasoning(
+				&mut payload,
+				&mut output_config,
+				model_name,
+				&computed_reasoning_effort,
+				capture_reasoning_content,
+			)?;
 		}
 
 		// -- Add supported ChatOptions
@@ -748,6 +755,7 @@ fn insert_anthropic_reasoning(
 	output_config: &mut Map<String, Value>,
 	model_name: &str,
 	effort: &ReasoningEffort,
+	capture_reasoning_content: bool,
 ) -> Result<()> {
 	let mut budget: Option<u32> = None;
 	let support_effort = supports_anthropic_effort(model_name);
@@ -794,7 +802,7 @@ fn insert_anthropic_reasoning(
 
 	// Adaptive-thinking models use a `thinking` object, optionally with budget tokens.
 	if support_adaptive {
-		let thinking = match budget {
+		let mut thinking = match budget {
 			Some(budget) => json!({
 						"type": "adaptive",
 						"budget_tokens": budget // if None, should be ok.
@@ -802,6 +810,9 @@ fn insert_anthropic_reasoning(
 			None => json!({
 				"type": "adaptive"}),
 		};
+		if capture_reasoning_content {
+			thinking.x_insert("display", "summarized")?;
+		}
 
 		// Let the model choose adaptive thinking behavior, honoring an explicit budget when set.
 		payload.x_insert("thinking", thinking)?;

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -73,7 +73,9 @@ pub async fn common_test_chat_reasoning_ok(
 		ChatMessage::system("Answer in one sentence. But make think hard to make sure it is not a trick question."),
 		ChatMessage::user("Why is the sky red?"),
 	]);
-	let options = ChatOptions::default().with_reasoning_effort(reasoning_effort);
+	let options = ChatOptions::default()
+		.with_reasoning_effort(reasoning_effort)
+		.with_capture_reasoning_content(true);
 
 	// -- Exec
 	let chat_res = client.exec_chat(model, chat_req, Some(&options)).await?;

--- a/tests/tests_p_anthropic.rs
+++ b/tests/tests_p_anthropic.rs
@@ -11,9 +11,8 @@ use serial_test::serial;
 // "claude-sonnet-4-20250514" (fail on test_chat_json_mode_ok)
 //
 const MODEL: &str = "claude-haiku-4-5";
-// const MODEL_THINKING: &str = "claude-sonnet-4-5-20250929";
-// const MODEL_SONNET: &str = "claude-sonnet-4-6";
-const MODEL_THINKING: &str = "claude-sonnet-4-6";
+// const MODEL_THINKING: &str = "claude-sonnet-4-6";
+const MODEL_THINKING: &str = "claude-sonnet-5";
 const MODEL_NS: &str = "anthropic::claude-haiku-4-5";
 
 // region:    --- Chat
@@ -28,7 +27,7 @@ async fn test_chat_simple_ok() -> TestResult<()> {
 #[serial(anthropic)]
 async fn test_chat_reasoning_ok() -> TestResult<()> {
 	// NOTE: Does not test REASONING_USAGE as Anthropic does not report it
-	common_tests::common_test_chat_reasoning_ok(MODEL_THINKING, ReasoningEffort::Medium, Some(Check::REASONING_CONTENT))
+	common_tests::common_test_chat_reasoning_ok(MODEL_THINKING, ReasoningEffort::High, Some(Check::REASONING_CONTENT))
 		.await
 }
 


### PR DESCRIPTION
# Capture Anthropic reasoning content

## Problem

- `capture_reasoning_content` could not capture reasoning from Anthropic adaptive-thinking models because requests did not ask Anthropic to return summarized thinking blocks.
- The existing response and streaming parsers can expose those blocks once returned, but the request payload omitted the required `thinking.display` setting.

## Fix

- Add `thinking.display: "summarized"` only when reasoning capture is enabled for adaptive-thinking models.
- Preserve legacy Anthropic thinking payloads and leave requests unchanged when capture is disabled.
- Enable capture in the shared reasoning test helper and exercise the adaptive path with Claude Sonnet 5 at high effort.

