### PR TITLE
feat: map Anthropic ping events to ChatStreamEvent::Heartbeat (#252)

### DIFF
--- a/examples/c21-tooluse-streaming.rs
+++ b/examples/c21-tooluse-streaming.rs
@@ -118,6 +118,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 					}
 				}
 			}
+			ChatStreamEvent::Heartbeat => {
+				println!("  Heartbeat");
+			}
 		}
 	}
 

--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -244,7 +244,10 @@ impl futures::Stream for AnthropicStreamer {
 							return Poll::Ready(Some(Ok(InterStreamEvent::End(inter_stream_end))));
 						}
 
-						"ping" => continue, // Loop to the next event
+						"ping" => {
+							// Map ping events to Heartbeat events to indicate the stream is still active
+							return Poll::Ready(Some(Ok(InterStreamEvent::Heartbeat)));
+						}
 						"error" => {
 							// Anthropic may emit an `event: error` mid-stream (e.g. overloaded_error,
 							// rate_limit, internal_server_error). Propagate it as a typed error so the

--- a/src/adapter/inter_stream.rs
+++ b/src/adapter/inter_stream.rs
@@ -40,4 +40,5 @@ pub enum InterStreamEvent {
 	ThoughtSignatureChunk(String),
 	ToolCallChunk(crate::chat::ToolCall),
 	End(InterStreamEnd),
+	Heartbeat,
 }

--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -80,6 +80,7 @@ impl Stream for ChatStream {
 						ChatStreamEvent::ToolCallChunk(ToolChunk { tool_call })
 					}
 					InterStreamEvent::End(inter_end) => ChatStreamEvent::End(inter_end.into()),
+					InterStreamEvent::Heartbeat => ChatStreamEvent::Heartbeat,
 				};
 
 				// -- OTel: record time-to-first-chunk on the first content chunk, and the
@@ -141,6 +142,9 @@ pub enum ChatStreamEvent {
 	/// End of stream.
 	/// May include captured usage and/or content when enabled via `ChatOptions`.
 	End(StreamEnd),
+
+	/// Ping emitted periodically to indicate the stream is still active.
+	Heartbeat,
 }
 
 /// Content of `ChatStreamEvent::Chunk`.

--- a/src/chat/printer.rs
+++ b/src/chat/printer.rs
@@ -151,6 +151,11 @@ async fn print_chat_stream_inner(
 							(None, None, false)
 						}
 					}
+
+					ChatStreamEvent::Heartbeat => {
+						// Liveness only — not user-facing content.
+						(None, None, false)
+					}
 				}
 			}
 			Err(e) => return Err(e.into()),

--- a/tests/data/yakbak/anthropic/ping_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/ping_stream/response_000.txt
@@ -1,0 +1,26 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01PingStreamTest000000000","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":25,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -81,6 +81,9 @@ pub struct StreamExtract {
 
 	/// All ToolCallChunk events received during streaming, in order.
 	pub tool_call_chunks: Vec<ToolCall>,
+
+	/// Number of Heartbeat events received during streaming.
+	pub heartbeat_count: usize,
 }
 
 pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<StreamExtract> {
@@ -89,6 +92,7 @@ pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<Strea
 	let mut content: Vec<String> = Vec::new();
 	let mut reasoning_content: Vec<String> = Vec::new();
 	let mut tool_call_chunks: Vec<ToolCall> = Vec::new();
+	let mut heartbeat_count: usize = 0;
 
 	while let Some(Ok(stream_event)) = chat_stream.next().await {
 		match stream_event {
@@ -101,6 +105,7 @@ pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<Strea
 				stream_end = Some(s_end);
 				break;
 			}
+			ChatStreamEvent::Heartbeat => heartbeat_count += 1,
 		}
 	}
 
@@ -113,6 +118,7 @@ pub async fn extract_stream_end(mut chat_stream: ChatStream) -> TestResult<Strea
 		content,
 		reasoning_content,
 		tool_call_chunks,
+		heartbeat_count,
 	})
 }
 

--- a/tests/tests_yakbak_anthropic.rs
+++ b/tests/tests_yakbak_anthropic.rs
@@ -90,3 +90,76 @@ async fn test_yakbak_anthropic_tool_stream() -> TestResult<()> {
 
 	Ok(())
 }
+
+/// Verify that Anthropic SSE `event: ping` maps to public `ChatStreamEvent::Heartbeat`,
+/// and that heartbeats do not affect content, reasoning, tools, usage, or stop reason.
+#[tokio::test]
+async fn test_yakbak_anthropic_ping_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("anthropic", "ping_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Hello"),
+	]);
+
+	let options = ChatOptions::default()
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_tool_calls(true)
+		.with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("anthropic::claude-haiku-4-5", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	// -- Heartbeats (cassette has two `event: ping` messages)
+	assert_eq!(
+		extract.heartbeat_count, 2,
+		"Should yield one Heartbeat per Anthropic ping event"
+	);
+
+	// -- Content unchanged by pings
+	assert_eq!(
+		extract.content.as_deref(),
+		Some("Hello!"),
+		"Streamed content should be the text deltas only"
+	);
+	assert_eq!(
+		extract.stream_end.captured_first_text(),
+		Some("Hello!"),
+		"Captured content should match streamed text"
+	);
+
+	// -- Reasoning / tools unchanged (none in this cassette)
+	assert!(
+		extract.reasoning_content.is_none(),
+		"Should not invent reasoning content"
+	);
+	assert!(
+		extract.stream_end.captured_reasoning_content.is_none(),
+		"Should not capture reasoning content"
+	);
+	assert!(
+		extract.tool_call_chunks.is_empty(),
+		"Should not invent tool-call chunks"
+	);
+	assert!(
+		extract.stream_end.captured_tool_calls().is_none_or(|t| t.is_empty()),
+		"Should not capture tool calls"
+	);
+
+	// -- Usage and stop reason still captured
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	// message_start input_tokens (25) + message_delta output_tokens (15)
+	assert_eq!(usage.prompt_tokens, Some(25));
+	assert_eq!(usage.completion_tokens, Some(15));
+
+	assert_eq!(
+		extract.stream_end.captured_stop_reason,
+		Some(StopReason::Completed("end_turn".to_string())),
+		"Stop reason should come from message_delta, not pings"
+	);
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #252

Expose Anthropic SSE `event: ping` as a provider-neutral `ChatStreamEvent::Heartbeat` so callers can tell a long-running stream is still alive (e.g. during extended thinking) instead of treating silence as a stall.

### Changes

- Add `InterStreamEvent::Heartbeat` and `ChatStreamEvent::Heartbeat`
- Anthropic streamer: map `"ping"` → `Heartbeat` (was previously discarded with `continue`)
- Keep the design adapter-agnostic so other providers can emit `Heartbeat` later if they add a similar signal
- Add yakbak cassette `tests/data/yakbak/anthropic/ping_stream/` and regression test

Heartbeats do not affect content, reasoning, tool calls, usage, or stop reason.

## Notes

- Focused single-feature PR, single commit (as requested)
- Draft PR for initial review

cc @lambdabetaeta for review if you have time

## Test plan

- [x] `cargo test --test tests_yakbak_anthropic`
- [x] `cargo test --lib`
- [ ] Maintainer review