### PR TITLE
OpenAI Explicit cache only for openai.com endpoint (issue 273)

### DIFF
--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -1,7 +1,7 @@
 //! This is support implementation of the OpenAI Adapter which can also be called by other OpenAI Adapter Variants
 
 use super::cache_policy::{
-	OpenAiPromptCacheMode, OpenAiPromptCachePolicy, OpenAiProtocol, is_gpt_5_6_or_later, openai_prompt_cache_policy,
+	OpenAiPromptCachePolicy, OpenAiProtocol, is_gpt_5_6_or_later, openai_prompt_cache_policy,
 };
 use super::schema::{OpenAiResponseFormatPlan, response_format_plan, tool_parameters_schema};
 use crate::adapter::adapters::openai::OpenAIAdapter;
@@ -87,13 +87,9 @@ impl OpenAIAdapter {
 	) -> Result<WebRequestData> {
 		let ServiceTarget { model, auth, endpoint } = target;
 		let (_, model_name) = model.model_name.namespace_and_name();
-		let prompt_cache_policy = openai_prompt_cache_policy(
-			model.adapter_kind,
-			model_name,
-			&chat_req,
-			&options_set,
-			OpenAiProtocol::ChatCompletions,
-		);
+		let protocol = OpenAiProtocol::ChatCompletions;
+		let prompt_cache_policy =
+			openai_prompt_cache_policy(model.adapter_kind, model_name, &chat_req, &options_set, protocol);
 		let response_format_plan = response_format_plan(&options_set);
 
 		// -- url
@@ -134,11 +130,7 @@ impl OpenAIAdapter {
 		});
 
 		if let Some(policy) = prompt_cache_policy.as_ref() {
-			let mode = match policy.mode {
-				OpenAiPromptCacheMode::Implicit => "implicit",
-				OpenAiPromptCacheMode::Explicit => "explicit",
-			};
-			let mut prompt_cache_options = json!({"mode": mode});
+			let mut prompt_cache_options = json!({"mode": "explicit"});
 			if let Some(ttl) = policy.ttl {
 				prompt_cache_options["ttl"] = json!(ttl);
 			}
@@ -744,7 +736,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_gpt_5_6_chat_completion_cache_key_uses_implicit_mode() {
+	fn test_gpt_5_6_chat_completion_cache_key_uses_api_default_mode() {
 		let target = ServiceTarget {
 			model: ModelIden::new(AdapterKind::OpenAI, "gpt-5.6-mini"),
 			auth: AuthData::from_single("test-key"),
@@ -762,7 +754,7 @@ mod tests {
 		)
 		.expect("to_web_request_data should succeed");
 
-		assert_eq!(web_req.payload["prompt_cache_options"]["mode"], "implicit");
+		assert!(web_req.payload.get("prompt_cache_options").is_none());
 		assert!(web_req.payload["messages"][0]["content"]["prompt_cache_breakpoint"].is_null());
 	}
 

--- a/src/adapter/adapters/openai/cache_policy.rs
+++ b/src/adapter/adapters/openai/cache_policy.rs
@@ -1,5 +1,6 @@
 use crate::adapter::AdapterKind;
 use crate::chat::{CacheControl, ChatOptionsSet, ChatRequest};
+use crate::resolver::Endpoint;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OpenAiProtocol {
@@ -8,14 +9,7 @@ pub(crate) enum OpenAiProtocol {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum OpenAiPromptCacheMode {
-	Implicit,
-	Explicit,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct OpenAiPromptCachePolicy {
-	pub(crate) mode: OpenAiPromptCacheMode,
 	pub(crate) ttl: Option<&'static str>,
 	pub(crate) controlled_message_count: usize,
 }
@@ -44,6 +38,16 @@ pub(crate) fn openai_prompt_cache_ttl(_cache_control: &CacheControl) -> &'static
 	"30m"
 }
 
+pub(crate) fn supports_openai_responses_prompt_cache_options(endpoint: &Endpoint) -> bool {
+	const SUPPORTED_ORIGINS: [&str; 2] = ["https://api.openai.com", "http://api.openai.com"];
+
+	SUPPORTED_ORIGINS.iter().any(|origin| {
+		endpoint.base_url().strip_prefix(origin).is_some_and(|suffix| {
+			suffix.is_empty() || suffix.starts_with('/') || suffix.starts_with('?') || suffix.starts_with('#')
+		})
+	})
+}
+
 pub(crate) fn openai_prompt_cache_policy(
 	adapter_kind: AdapterKind,
 	model_name: &str,
@@ -70,17 +74,14 @@ pub(crate) fn openai_prompt_cache_policy(
 	let has_explicit_placement = controlled_message_count > 0;
 	let has_general_cache_intent = options.prompt_cache_key().is_some() || options.cache_control().is_some();
 
-	let mode = if has_explicit_placement || !has_general_cache_intent {
-		OpenAiPromptCacheMode::Explicit
-	} else {
-		OpenAiPromptCacheMode::Implicit
-	};
+	if !has_explicit_placement && has_general_cache_intent {
+		return None;
+	}
 
 	let has_cache_control = has_explicit_placement || options.cache_control().is_some();
 	let ttl = has_cache_control.then(|| openai_prompt_cache_ttl_from_request(chat_req, options));
 
 	Some(OpenAiPromptCachePolicy {
-		mode,
 		ttl,
 		controlled_message_count,
 	})
@@ -149,6 +150,43 @@ mod tests {
 	}
 
 	#[test]
+	fn test_adapter_adapters_openai_supports_prompt_cache_options_for_official_endpoint() -> Result<()> {
+		let endpoint = Endpoint::from_static("https://api.openai.com/v1/");
+
+		assert!(supports_openai_responses_prompt_cache_options(&endpoint));
+		Ok(())
+	}
+
+	#[test]
+	fn test_adapter_adapters_openai_rejects_prompt_cache_options_for_codex_responses_endpoint() -> Result<()> {
+		let endpoints = [
+			Endpoint::from_static("https://chatgpt.com/backend-api/codex"),
+			Endpoint::from_static("https://chatgpt.com/backend-api/codex/"),
+			Endpoint::from_static("https://chatgpt.com/backend-api/codex/responses"),
+		];
+
+		for endpoint in &endpoints {
+			assert!(!supports_openai_responses_prompt_cache_options(endpoint));
+		}
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_adapter_adapters_openai_prompt_cache_endpoint_check_uses_supported_domain_allowlist() -> Result<()> {
+		let host_lookalike = Endpoint::from_static("https://chatgpt.com.example/backend-api/codex/");
+		let path_lookalike = Endpoint::from_static("https://chatgpt.com/backend-api/codex-other/");
+		let openai_host_lookalike = Endpoint::from_static("https://api.openai.com.example/v1/");
+		let openai_path = Endpoint::from_static("https://api.openai.com/custom/v1/");
+
+		assert!(!supports_openai_responses_prompt_cache_options(&host_lookalike));
+		assert!(!supports_openai_responses_prompt_cache_options(&path_lookalike));
+		assert!(!supports_openai_responses_prompt_cache_options(&openai_host_lookalike));
+		assert!(supports_openai_responses_prompt_cache_options(&openai_path));
+		Ok(())
+	}
+
+	#[test]
 	fn test_adapter_adapters_openai_prompt_cache_policy_no_configuration_is_explicit() -> Result<()> {
 		let request = ChatRequest::from_user("hello");
 		let options = ChatOptionsSet::default();
@@ -161,14 +199,13 @@ mod tests {
 		)
 		.ok_or("supported OpenAI model should have a cache policy")?;
 
-		assert_eq!(policy.mode, OpenAiPromptCacheMode::Explicit);
 		assert_eq!(policy.ttl, None);
 		assert_eq!(policy.controlled_message_count, 0);
 		Ok(())
 	}
 
 	#[test]
-	fn test_adapter_adapters_openai_prompt_cache_policy_general_intent_is_implicit() -> Result<()> {
+	fn test_adapter_adapters_openai_prompt_cache_policy_general_intent_uses_api_default() -> Result<()> {
 		let request = ChatRequest::from_user("hello");
 		let chat_options = ChatOptions::default().with_prompt_cache_key("stable-key");
 		let options = ChatOptionsSet::default().with_chat_options(Some(&chat_options));
@@ -178,11 +215,9 @@ mod tests {
 			&request,
 			&options,
 			OpenAiProtocol::ChatCompletions,
-		)
-		.ok_or("supported OpenAI model should have a cache policy")?;
+		);
 
-		assert_eq!(policy.mode, OpenAiPromptCacheMode::Implicit);
-		assert_eq!(policy.ttl, None);
+		assert!(policy.is_none());
 		Ok(())
 	}
 
@@ -201,7 +236,6 @@ mod tests {
 		)
 		.ok_or("supported OpenAI model should have a cache policy")?;
 
-		assert_eq!(policy.mode, OpenAiPromptCacheMode::Explicit);
 		assert_eq!(policy.ttl, Some("30m"));
 		assert_eq!(policy.controlled_message_count, 1);
 		Ok(())
@@ -219,12 +253,9 @@ mod tests {
 			&request,
 			&options,
 			OpenAiProtocol::Responses,
-		)
-		.ok_or("supported OpenAI model should have a cache policy")?;
+		);
 
-		assert_eq!(policy.mode, OpenAiPromptCacheMode::Implicit);
-		assert_eq!(policy.ttl, None);
-		assert_eq!(policy.controlled_message_count, 0);
+		assert!(policy.is_none());
 		Ok(())
 	}
 

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -1,7 +1,8 @@
 use super::{OpenAIRespStreamer, RespResponse};
 use crate::adapter::adapters::openai::OpenAIAdapter;
 use crate::adapter::adapters::openai::cache_policy::{
-	OpenAiPromptCacheMode, OpenAiPromptCachePolicy, OpenAiProtocol, is_gpt_5_6_or_later, openai_prompt_cache_policy,
+	OpenAiPromptCachePolicy, OpenAiProtocol, is_gpt_5_6_or_later, openai_prompt_cache_policy,
+	supports_openai_responses_prompt_cache_options,
 };
 use crate::adapter::adapters::openai::schema::{
 	OpenAiResponseFormatPlan, response_format_plan, tool_parameters_schema,
@@ -86,13 +87,12 @@ impl Adapter for OpenAIRespAdapter {
 		let ServiceTarget { model, auth, endpoint } = target;
 		let (_, model_name) = model.model_name.namespace_and_name();
 		let adapter_kind = model.adapter_kind;
-		let prompt_cache_policy = openai_prompt_cache_policy(
-			adapter_kind,
-			model_name,
-			&chat_req,
-			&chat_options,
-			OpenAiProtocol::Responses,
-		);
+		let protocol = OpenAiProtocol::Responses;
+		let prompt_cache_policy = if supports_openai_responses_prompt_cache_options(&endpoint) {
+			openai_prompt_cache_policy(adapter_kind, model_name, &chat_req, &chat_options, protocol)
+		} else {
+			None
+		};
 		let response_format_plan = response_format_plan(&chat_options);
 
 		// -- api_key
@@ -159,11 +159,7 @@ impl Adapter for OpenAIRespAdapter {
 		});
 
 		if let Some(policy) = prompt_cache_policy.as_ref() {
-			let mode = match policy.mode {
-				OpenAiPromptCacheMode::Implicit => "implicit",
-				OpenAiPromptCacheMode::Explicit => "explicit",
-			};
-			let mut prompt_cache_options = json!({"mode": mode});
+			let mut prompt_cache_options = json!({"mode": "explicit"});
 			if let Some(ttl) = policy.ttl {
 				prompt_cache_options.x_insert("ttl", ttl)?;
 			}
@@ -755,6 +751,8 @@ fn apply_resp_cache_breakpoint(_model_iden: &ModelIden, content: &mut [Value], _
 
 #[cfg(test)]
 mod tests {
+	type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>;
+
 	use super::*;
 	use crate::adapter::AdapterKind;
 	use crate::chat::{ChatMessage, ChatOptions, JsonSpec, Tool, ToolCall, ToolChoice, ToolResponse};
@@ -1029,7 +1027,26 @@ mod tests {
 	}
 
 	#[test]
-	fn test_gpt_5_6_responses_cache_key_uses_implicit_cache_mode() {
+	fn test_gpt_5_6_codex_responses_endpoint_omits_prompt_cache_options() -> Result<()> {
+		let target = ServiceTarget {
+			model: ModelIden::new(AdapterKind::OpenAIResp, "gpt-5.6"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: Endpoint::from_static("https://chatgpt.com/backend-api/codex/"),
+		};
+
+		let web_req = OpenAIRespAdapter::to_web_request_data(
+			target,
+			ServiceType::Chat,
+			ChatRequest::from_user("hello"),
+			ChatOptionsSet::default(),
+		)?;
+
+		assert!(web_req.payload.get("prompt_cache_options").is_none());
+		Ok(())
+	}
+
+	#[test]
+	fn test_gpt_5_6_responses_cache_key_uses_api_default_cache_mode() {
 		let target = ServiceTarget {
 			model: ModelIden::new(AdapterKind::OpenAIResp, "gpt-5.6-mini"),
 			auth: AuthData::from_single("test-key"),
@@ -1046,7 +1063,7 @@ mod tests {
 		)
 		.expect("to_web_request_data should succeed");
 
-		assert_eq!(web_req.payload["prompt_cache_options"]["mode"], "implicit");
+		assert!(web_req.payload.get("prompt_cache_options").is_none());
 		assert!(
 			web_req.payload["input"][0]["content"][0]
 				.get("prompt_cache_breakpoint")


### PR DESCRIPTION
# OpenAI Explicit cache only for openai.com endpoint

This respond to the #273 issue (which is related to a previous PR #260 about the new openai caching cost)

### Problem

For GPT-5.6 and later, this library sends `prompt_cache_options: {"mode": "explicit"}` when callers have not expressed cache intent. 

OpenAI's new default on 5.6 implicit caching can add cache-related cost, so the library uses explicit mode to turn off automatic caching by default. This ensures callers must deliberately opt into caching, either through general cache intent or message-level cache control, before accepting its cost and behavior tradeoffs.

However, other providers, ChatGPT/Codex Responses endpoints do not support this OpenAI-specific parameter. Requests to endpoints such as `https://chatgpt.com/backend-api/codex/responses` fail with `Unsupported parameter: prompt_cache_options`, even when the caller has not configured prompt caching.

The issue is endpoint compatibility, not the explicit-cache strategy itself. The fix preserves the cost safeguard for the official OpenAI Responses API while omitting the unsupported field elsewhere.

## Solution

- Restrict `prompt_cache_options` serialization in the Responses adapter to the official `api.openai.com` origin.
- Omit the unsupported field for ChatGPT/Codex and other non-allowlisted Responses endpoints.
- Preserve explicit mode for supported endpoints when callers have no cache intent or use message-level cache control.
- Preserve OpenAI's default implicit caching when callers provide a cache key or request-level cache control.
- Keep Chat Completions behavior unchanged.

### What changed

- GPT-5.6 Responses requests send `prompt_cache_options` only to `api.openai.com`.
- Cache key or request-level cache control omits the field, preserving API-default implicit caching.
- No-cache-intent and per-message cache control use explicit mode on supported endpoints.

### Risk

- Compatible custom Responses gateways no longer receive explicit cache options unless added to the allowlist.
- API-default implicit caching may differ from the previously explicit request behavior.
- Chat Completions behavior is unchanged.
