### PR TITLE
fix(otel): cover CacheBreakpointNoEligibleContent in error.type derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Cross-provider adapters:
   - `^` Move messages after tools in JSON payloads for better prompt cache utilization. (PR #262)
 - OpenTelemetry:
+  - `-` Fix `otel` feature compilation, by covering the `CacheBreakpointNoEligibleContent` error variant in the `error.type` derivation (broken since v0.7.0-beta.18).
   - `+` Add optional OpenTelemetry GenAI semantic-convention instrumentation behind the new `otel` feature, off by default, using a pure `tracing` bridge with no extra dependencies.
     - Auto-instruments `exec_chat`, `exec_chat_stream`, and `exec_embed` as `gen_ai.*` spans, including operation, provider, request params, server address/port, usage tokens, finish reasons, response id/model, streaming time-to-first-chunk, and `error.type`. Prompt and response content capture is opt-in via `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Adds opt-in `genai::otel` helpers for agent, workflow, and tool spans, plus the evaluation-result event. Export by wiring `tracing-opentelemetry` in the application. See `docs/otel.md` and `examples/c12-otel.rs`.
 

--- a/src/otel/error.rs
+++ b/src/otel/error.rs
@@ -49,6 +49,7 @@ pub fn error_type(error: &Error) -> String {
 		// -- Adapter support
 		Error::AdapterNotSupported { .. } => "adapter_not_supported".to_string(),
 		Error::AdapterKindMismatch { .. } => "adapter_kind_mismatch".to_string(),
+		Error::CacheBreakpointNoEligibleContent { .. } => "cache_breakpoint_no_eligible_content".to_string(),
 
 		// -- Internals / externals
 		Error::Internal(_) => "internal".to_string(),


### PR DESCRIPTION
Following up on #277 — splitting it into small, single-purpose PRs as you asked. This is the first: the smallest, lowest-level piece, a bug fix.

## Problem

The `otel` feature has not compiled since v0.7.0-beta.18. `error_type()` in `src/otel/error.rs` matches `Error` exhaustively with no wildcard arm, and the `CacheBreakpointNoEligibleContent` variant added in beta.18 was never mapped, so `cargo check --features otel` fails with E0004 (non-exhaustive patterns).

## Change

- `src/otel/error.rs`: map `Error::CacheBreakpointNoEligibleContent { .. }` → `"cache_breakpoint_no_eligible_content"`.
- `CHANGELOG.md`: one OpenTelemetry fix line.

## Testing

`cargo build`, `cargo test --lib` (198 pass), `cargo test --lib --features otel` (220 pass — previously did not compile at all), `cargo fmt --check`, `cargo clippy` clean.

Depends on nothing. The remaining pieces from #277 will follow one at a time, low-level first, once this lands.
