### PR TITLE
- fix(anthropic): align stream usage capture with new anthropic api behaviour

### DIFF
--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -283,13 +283,12 @@ impl futures::Stream for AnthropicStreamer {
 impl AnthropicStreamer {
 	fn capture_usage(&mut self, message_type: &str, message_data: &str) -> Result<()> {
 		if self.options.capture_usage {
-			let data = self.parse_message_data(message_data)?;
-			// TODO: Might want to exit early if usage is not found
+			let mut data = self.parse_message_data(message_data)?;
 
-			let (input_path, output_path) = if message_type == "message_start" {
-				("/message/usage/input_tokens", "/message/usage/output_tokens")
+			let usage_path = if message_type == "message_start" {
+				"/message/usage"
 			} else if message_type == "message_delta" {
-				("/usage/input_tokens", "/usage/output_tokens")
+				"/usage"
 			} else {
 				// TODO: Use tracing
 				tracing::debug!(
@@ -298,82 +297,67 @@ impl AnthropicStreamer {
 				return Ok(()); // For now permissive
 			};
 
-			// -- Capture/Add the eventual input_tokens
-			// NOTE: Permissive on this one; if an error occurs, treat it as nonexistent (for now)
-			if let Ok(input_tokens) = data.x_get::<i32>(input_path) {
-				let val = self
-					.captured_data
-					.usage
-					.get_or_insert(Usage::default())
-					.prompt_tokens
-					.get_or_insert(0);
-				*val += input_tokens;
-			}
-
-			if let Ok(output_tokens) = data.x_get::<i32>(output_path) {
-				let val = self
-					.captured_data
-					.usage
-					.get_or_insert(Usage::default())
-					.completion_tokens
-					.get_or_insert(0);
-				*val += output_tokens;
-			}
-
-			// -- Capture cache tokens.
-			// Standard Anthropic reports them in `message_start` (`/message/usage`).
-			// Some Anthropic-compatible gateways (e.g. Alibaba DashScope / Qwen) instead report
-			// them in `message_delta` (`/usage`), so fall back to that location when `message_start`
-			// did not carry them.
-			// NOTE: Anthropic's input_tokens does NOT include cached tokens, so we must add them.
-			// See also: AnthropicAdapter::into_usage() for non-streaming equivalent.
-			let cache_base = match message_type {
-				"message_start" => Some("/message/usage"),
-				// Fall back to message_delta only if message_start did not already provide cache details.
-				"message_delta"
-					if self
-						.captured_data
-						.usage
-						.as_ref()
-						.and_then(|u| u.prompt_tokens_details.as_ref())
-						.is_none() =>
-				{
-					Some("/usage")
-				}
-				_ => None,
+			// NOTE: Permissive on this one; if the usage object is absent, treat it as nonexistent (for now)
+			let Ok(mut usage_value) = data.x_take::<Value>(usage_path) else {
+				return Ok(());
 			};
 
-			if let Some(base) = cache_base {
-				let cache_creation: i32 = data.x_get(&format!("{base}/cache_creation_input_tokens")).unwrap_or(0);
-				let cache_read: i32 = data.x_get(&format!("{base}/cache_read_input_tokens")).unwrap_or(0);
+			// -- Capture the eventual input/output tokens
+			let input_tokens = usage_value.x_take::<i32>("input_tokens").ok();
+			let output_tokens = usage_value.x_take::<i32>("output_tokens").ok();
 
-				// Parse cache_creation breakdown if present (TTL-specific breakdown)
-				let cache_creation_details = data
-					.x_get::<Value>(&format!("{base}/cache_creation"))
-					.ok()
-					.as_ref()
-					.and_then(parse_cache_creation_details);
+			// -- Capture cache tokens.
+			// Standard Anthropic reports them in `message_start` and repeats them in `message_delta`;
+			// some gateways (e.g. Alibaba DashScope / Qwen) report them only in `message_delta`.
+			// NOTE: Anthropic's input_tokens does NOT include cached tokens, so we must add them.
+			// See also: AnthropicAdapter::into_usage() for non-streaming equivalent.
+			let cache_creation: i32 = usage_value.x_get("cache_creation_input_tokens").unwrap_or(0);
+			let cache_read: i32 = usage_value.x_get("cache_read_input_tokens").unwrap_or(0);
 
-				if cache_creation > 0 || cache_read > 0 || cache_creation_details.is_some() {
-					let usage = self.captured_data.usage.get_or_insert(Usage::default());
+			// Parse cache_creation breakdown if present (TTL-specific breakdown)
+			let cache_creation_details = usage_value
+				.x_get::<Value>("cache_creation")
+				.ok()
+				.as_ref()
+				.and_then(parse_cache_creation_details);
 
-					// Add cache tokens to prompt_tokens only for message_start, where Anthropic's
-					// input_tokens excludes them. For the message_delta fallback the token accounting
-					// is gateway-specific, so we only surface the breakdown to avoid double counting.
-					if message_type == "message_start"
-						&& let Some(ref mut pt) = usage.prompt_tokens
-					{
-						*pt += cache_creation + cache_read;
-					}
+			let has_cache = cache_creation > 0 || cache_read > 0 || cache_creation_details.is_some();
 
-					// Set prompt_tokens_details (match into_usage behavior: always Some(value))
-					usage.prompt_tokens_details = Some(PromptTokensDetails {
-						cache_creation_tokens: Some(cache_creation),
-						cache_creation_details,
-						cached_tokens: Some(cache_read),
-						audio_tokens: None,
-					});
-				}
+			// Nothing to capture from this snapshot, leave `usage` as-is (possibly None).
+			if input_tokens.is_none() && output_tokens.is_none() && !has_cache {
+				return Ok(());
+			}
+
+			let usage = self.captured_data.usage.get_or_insert(Usage::default());
+
+			if let Some(input_tokens) = input_tokens {
+				usage.prompt_tokens = Some(input_tokens + cache_creation + cache_read);
+			}
+			// NOTE: Cache tokens without `input_tokens` (gateway shape) are deliberately NOT added
+			// to `prompt_tokens`, since gateway token accounting is provider-specific.
+
+			if let Some(output_tokens) = output_tokens {
+				usage.completion_tokens = Some(output_tokens);
+			}
+
+			if has_cache {
+				// Anthropic sends the `cache_creation` breakdown only in `message_start`, while
+				// `message_delta` repeats the totals without it. Keep the earlier breakdown so the
+				// later snapshot does not erase it.
+				let cache_creation_details = cache_creation_details.or_else(|| {
+					usage
+						.prompt_tokens_details
+						.as_ref()
+						.and_then(|details| details.cache_creation_details.clone())
+				});
+
+				// Set prompt_tokens_details (match into_usage behavior: always Some(value))
+				usage.prompt_tokens_details = Some(PromptTokensDetails {
+					cache_creation_tokens: Some(cache_creation),
+					cache_creation_details,
+					cached_tokens: Some(cache_read),
+					audio_tokens: None,
+				});
 			}
 		}
 

--- a/tests/data/yakbak/anthropic/ping_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/ping_stream/response_000.txt
@@ -1,5 +1,5 @@
 event: message_start
-data: {"type":"message_start","message":{"id":"msg_01PingStreamTest000000000","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":25,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+data: {"type":"message_start","message":{"id":"msg_01PingStreamTest000000000","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":25,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
@@ -24,3 +24,4 @@ data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":
 
 event: message_stop
 data: {"type":"message_stop"}
+

--- a/tests/data/yakbak/anthropic/tool_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/tool_stream/response_000.txt
@@ -1,5 +1,5 @@
 event: message_start
-data: {"type":"message_start","message":{"id":"msg_01XFDUFYzQKEhQN3M5vW7tTH","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":85,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+data: {"type":"message_start","message":{"id":"msg_01XFDUFYzQKEhQN3M5vW7tTH","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":85,"output_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01A2B3C4D5","name":"get_weather","input":{}}}

--- a/tests/data/yakbak/anthropic/usage_cache_creation_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/usage_cache_creation_stream/response_000.txt
@@ -1,0 +1,24 @@
+event: message_start
+data: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_011CdoBxyp9PbmAyLMootcEu","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":9,"cache_creation_input_tokens":4202,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":4202,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}        }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}         }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0      }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":9,"cache_creation_input_tokens":4202,"cache_read_input_tokens":0,"output_tokens":5}   }
+
+event: message_stop
+data: {"type":"message_stop"         }
+

--- a/tests/data/yakbak/anthropic/usage_cache_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/usage_cache_stream/response_000.txt
@@ -1,0 +1,24 @@
+event: message_start
+data: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_011CdoBy7hf5Rc9bbdE4nbDa","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":9,"cache_creation_input_tokens":0,"cache_read_input_tokens":4202,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}         }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}            }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}            }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0               }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":9,"cache_creation_input_tokens":0,"cache_read_input_tokens":4202,"output_tokens":5}        }
+
+event: message_stop
+data: {"type":"message_stop"        }
+

--- a/tests/data/yakbak/anthropic/usage_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/usage_stream/response_000.txt
@@ -1,0 +1,27 @@
+event: message_start
+data: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_011CdoBxEqVxeFdUGZtB1eB8","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":3,"service_tier":"standard","inference_geo":"not_available"}}   }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The sky is"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" blue because sunlight scatters off nitrogen and oxygen molecules in the atmosphere, and blue light scatters more efficiently"}            }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" than other colors."}       }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0               }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":34}               }
+
+event: message_stop
+data: {"type":"message_stop" }
+

--- a/tests/tests_yakbak_anthropic.rs
+++ b/tests/tests_yakbak_anthropic.rs
@@ -87,6 +87,7 @@ async fn test_yakbak_anthropic_tool_stream() -> TestResult<()> {
 	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
 	assert_eq!(usage.prompt_tokens, Some(85));
 	assert_eq!(usage.completion_tokens, Some(42));
+	assert_eq!(usage.total_tokens, Some(127));
 
 	Ok(())
 }
@@ -154,12 +155,128 @@ async fn test_yakbak_anthropic_ping_stream() -> TestResult<()> {
 	// message_start input_tokens (25) + message_delta output_tokens (15)
 	assert_eq!(usage.prompt_tokens, Some(25));
 	assert_eq!(usage.completion_tokens, Some(15));
+	assert_eq!(usage.total_tokens, Some(40));
 
 	assert_eq!(
 		extract.stream_end.captured_stop_reason,
 		Some(StopReason::Completed("end_turn".to_string())),
 		"Stop reason should come from message_delta, not pings"
 	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_yakbak_anthropic_usage_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("anthropic", "usage_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Hello"),
+	]);
+
+	let options = ChatOptions::default().with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("anthropic::claude-haiku-4-5", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(usage.prompt_tokens, Some(19));
+	assert_eq!(usage.completion_tokens, Some(34));
+	assert_eq!(usage.total_tokens, Some(53));
+
+	let details = usage
+		.prompt_tokens_details
+		.as_ref()
+		.ok_or("Real Anthropic sends cache_creation even when uncached, so details should be Some")?;
+	assert_eq!(details.cache_creation_tokens, Some(0));
+	assert_eq!(details.cached_tokens, Some(0));
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_yakbak_anthropic_usage_cache_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("anthropic", "usage_cache_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Hello"),
+	]);
+
+	let options = ChatOptions::default().with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("anthropic::claude-haiku-4-5", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(
+		usage.prompt_tokens,
+		Some(4211),
+		"prompt = input + cache_creation + cache_read"
+	);
+	assert_eq!(usage.completion_tokens, Some(5));
+	assert_eq!(usage.total_tokens, Some(4216));
+
+	let details = usage
+		.prompt_tokens_details
+		.as_ref()
+		.ok_or("Should have prompt_tokens_details")?;
+	assert_eq!(details.cache_creation_tokens, Some(0));
+	assert_eq!(details.cached_tokens, Some(4202));
+
+	let creation_details = details
+		.cache_creation_details
+		.as_ref()
+		.ok_or("message_start breakdown should survive message_delta")?;
+	assert_eq!(creation_details.ephemeral_5m_tokens, Some(0));
+	assert_eq!(creation_details.ephemeral_1h_tokens, Some(0));
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_yakbak_anthropic_usage_cache_creation_stream() -> TestResult<()> {
+	let (client, _server) = replay_client("anthropic", "usage_cache_creation_stream").await?;
+
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::system("Answer in one sentence."),
+		ChatMessage::user("Hello"),
+	]);
+
+	let options = ChatOptions::default().with_capture_usage(true);
+
+	let stream_res = client
+		.exec_chat_stream("anthropic::claude-haiku-4-5", chat_req, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream_res.stream).await?;
+
+	let usage = extract.stream_end.captured_usage.as_ref().ok_or("Should have usage")?;
+	assert_eq!(
+		usage.prompt_tokens,
+		Some(4211),
+		"prompt = input + cache_creation + cache_read"
+	);
+	assert_eq!(usage.completion_tokens, Some(5));
+	assert_eq!(usage.total_tokens, Some(4216));
+
+	let details = usage
+		.prompt_tokens_details
+		.as_ref()
+		.ok_or("Should have prompt_tokens_details")?;
+	assert_eq!(details.cache_creation_tokens, Some(4202));
+	assert_eq!(details.cached_tokens, Some(0));
+
+	let creation_details = details
+		.cache_creation_details
+		.as_ref()
+		.ok_or("message_start breakdown should survive message_delta")?;
+	assert_eq!(creation_details.ephemeral_5m_tokens, Some(4202));
+	assert_eq!(creation_details.ephemeral_1h_tokens, Some(0));
 
 	Ok(())
 }


### PR DESCRIPTION
Closes #272.

Fix for the Anthropic streaming usage over-count. `capture_usage` in `AnthropicStreamer` now treats each usage payload as a cumulative snapshot. Every event overwrites the token fields it actually carries, so the final capture holds the latest values instead of the sum of `message_start` + `message_delta`.

Also added replay tests and fixtures (recorded from the live API).