### PR TITLE
feat(webc): expose response headers on streaming HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.7.0-beta.x (see [genai versions](https://crates.io/crates/genai/versions))
 
+- `!` API CHANGE - `Error::HttpError` adds a `headers: Box<HeaderMap>` field carrying the response headers of failed streaming HTTP calls (e.g., `retry-after`, `retry-after-ms`, `x-should-retry`), matching the non-streaming `webc::Error::ResponseFailedStatus`, so downstream retry layers can honor provider-requested retry delays. Exhaustive matchers/constructors of `Error::HttpError` must add the `headers` field (or match with `..`).
 - `!` API CHANGE - `Tool` adds the public `custom_format: Option<Value>` field for provider-native freeform custom-tool formats. Downstream `Tool` struct literals must add `custom_format: None`, or preferably migrate to `Tool::new(...)` and builder methods. `Tool::with_custom_format(...)` is the new builder API.
 - `+` New Providers:
   - AtlasCloud - default env: `ATLASCLOUD_API_KEY`, Adapter: OpenAI, endpoint: `https://api.atlascloud.ai/v1/` (activated on the `atlascloud::` namespace) (PR #259)

--- a/dev/specs/spec-webc.md
+++ b/dev/specs/spec-webc.md
@@ -31,6 +31,6 @@ The module consists of three main internal components:
 
 - **Generic JSON Response Handling:** `WebResponse` abstracts successful non-streaming responses by immediately parsing the body into `serde_json::Value`. This allows adapter modules to deserialize into their specific structures subsequently.
 
-- **Error Richness:** The `Error::ResponseFailedStatus` variant includes the `StatusCode`, full `body`, and `HeaderMap` to provide comprehensive debugging information upon API failure.
+- **Error Richness:** The `Error::ResponseFailedStatus` variant includes the `StatusCode`, full `body`, and `HeaderMap` to provide comprehensive debugging information upon API failure. On the streaming path, `WebStream` mirrors this: when the lazy request send resolves to a non-success status, it surfaces a crate-level `genai::Error::HttpError` carrying the status, canonical reason, body, and response `HeaderMap` (captured while the `reqwest::Response` is still in hand), so retry-relevant headers such as `retry-after`, `retry-after-ms`, and `x-should-retry` remain visible to downstream retry layers.
 
 - **Async Implementation:** All network operations rely on `tokio` and `reqwest`, ensuring non-blocking execution throughout the I/O layer. `WebStream` leverages `futures::Stream` traits for integration with standard Rust async infrastructure.

--- a/docs/for-llm/api-reference-for-llm.md
+++ b/docs/for-llm/api-reference-for-llm.md
@@ -727,7 +727,7 @@ let chat_res = client.exec_chat("genai_1::some-model", chat_req, None).await?;
   - `ChatResponse { model_iden, body }`: Error event in stream.
   - `StreamParse { model_iden, serde_error }`: Stream data parse failure.
   - `WebStream { model_iden, cause, error }`: Web stream error.
-  - `HttpError { status, canonical_reason, body }`: HTTP error.
+  - `HttpError { status, canonical_reason, body, headers }`: HTTP error (streaming path); `headers` carries the failed response headers (e.g., `retry-after`).
   - `Resolver { model_iden, resolver_error }`: Resolver error wrapper.
   - `AdapterNotSupported { adapter_kind, feature }`: Feature not supported by adapter.
   - `AdapterKindMismatch { bound, requested, model }`: A client bound to one adapter received a namespaced model or `ModelIden` targeting another adapter. Since v0.6.0.

--- a/src/adapter/adapters/bedrock/shared.rs
+++ b/src/adapter/adapters/bedrock/shared.rs
@@ -93,11 +93,15 @@ fn async_stream_once(
 			.map_err(|e| Box::new(e) as crate::error::BoxError)?;
 		let status = resp.status();
 		if !status.is_success() {
+			// Capture the headers while the response is still in hand
+			// (e.g., `retry-after`, `retry-after-ms`, `x-should-retry` for retry layers)
+			let headers = resp.headers().clone();
 			let body = resp.text().await.unwrap_or_default();
 			let err = crate::Error::HttpError {
 				status,
 				canonical_reason: status.canonical_reason().unwrap_or("Unknown").to_string(),
 				body,
+				headers: Box::new(headers),
 			};
 			return Err(Box::new(err) as crate::error::BoxError);
 		}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use crate::chat::ChatRole;
 use crate::{ModelIden, resolver, webc};
 use derive_more::{Display, From};
 use reqwest::StatusCode;
+use reqwest::header::HeaderMap;
 use value_ext::JsonValueExtError;
 
 /// Type alias for boxed errors that are Send + Sync
@@ -123,6 +124,9 @@ Cause:\n{cause}
 		status: StatusCode,
 		canonical_reason: String,
 		body: String,
+		/// Response headers of the failed HTTP call (e.g., `retry-after`, `retry-after-ms`, `x-should-retry`),
+		/// so that downstream retry layers can honor provider-requested retry delays.
+		headers: Box<HeaderMap>,
 	},
 
 	// -- Modules

--- a/src/otel/error.rs
+++ b/src/otel/error.rs
@@ -98,6 +98,7 @@ mod tests {
 			status: StatusCode::TOO_MANY_REQUESTS,
 			canonical_reason: "Too Many Requests".to_string(),
 			body: String::new(),
+			headers: Box::new(HeaderMap::new()),
 		};
 		assert_eq!(error_type(&error), "429");
 	}

--- a/src/webc/web_stream.rs
+++ b/src/webc/web_stream.rs
@@ -90,6 +90,9 @@ impl Stream for WebStream {
 							// For error responses, we need to read the body to get the error message
 							// Store a future that reads the body and returns an error
 							let error_future = async move {
+								// Capture the headers while the response is still in hand
+								// (e.g., `retry-after`, `retry-after-ms`, `x-should-retry` for retry layers)
+								let headers = response.headers().clone();
 								let body = response
 									.text()
 									.await
@@ -98,6 +101,7 @@ impl Stream for WebStream {
 									status,
 									canonical_reason: status.canonical_reason().unwrap_or("Unknown").to_string(),
 									body,
+									headers: Box::new(headers),
 								}))
 							};
 							this.response_future = Some(Box::pin(error_future));
@@ -264,3 +268,11 @@ fn process_buff_string_delimited(
 		candidate_message,
 	})
 }
+
+// region:    --- Tests
+
+#[cfg(test)]
+#[path = "web_stream_tests.rs"]
+mod tests;
+
+// endregion: --- Tests

--- a/src/webc/web_stream_tests.rs
+++ b/src/webc/web_stream_tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+use crate::error::Error as GenaiError;
+use futures::StreamExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>;
+
+#[tokio::test]
+async fn test_web_stream_http_error_captures_headers() -> Result<()> {
+	// -- Setup & Fixtures
+	let body = r#"{"error":{"message":"rate limited"}}"#;
+	let raw_response = format!(
+		"HTTP/1.1 429 Too Many Requests\r\n\
+		content-type: application/json\r\n\
+		retry-after: 2\r\n\
+		retry-after-ms: 1500\r\n\
+		x-should-retry: true\r\n\
+		content-length: {}\r\n\
+		connection: close\r\n\
+		\r\n\
+		{body}",
+		body.len()
+	);
+	let url = support_spawn_one_shot_http_server(raw_response).await?;
+	let reqwest_builder = reqwest::Client::new().post(&url).json(&serde_json::json!({"stream": true}));
+	let mut web_stream = WebStream::new_with_sse(reqwest_builder);
+
+	// -- Exec
+	let first_item = web_stream.next().await.ok_or("Should have a first stream item")?;
+
+	// -- Check
+	let err = first_item.err().ok_or("First stream item should be an error")?;
+	let err = err
+		.downcast::<GenaiError>()
+		.map_err(|err| format!("Error should downcast to genai Error, but was: {err}"))?;
+	match *err {
+		GenaiError::HttpError {
+			status,
+			canonical_reason,
+			body: err_body,
+			headers,
+		} => {
+			assert_eq!(status.as_u16(), 429);
+			assert_eq!(canonical_reason, "Too Many Requests");
+			assert_eq!(err_body, body);
+			assert_eq!(headers.get("retry-after").and_then(|v| v.to_str().ok()), Some("2"));
+			assert_eq!(
+				headers.get("retry-after-ms").and_then(|v| v.to_str().ok()),
+				Some("1500")
+			);
+			assert_eq!(
+				headers.get("x-should-retry").and_then(|v| v.to_str().ok()),
+				Some("true")
+			);
+		}
+		other => return Err(format!("Should be an Error::HttpError, but was: {other}").into()),
+	}
+
+	Ok(())
+}
+
+// region:    --- Support
+
+/// Spawns a one-shot HTTP server that answers the first request with the given raw HTTP response.
+async fn support_spawn_one_shot_http_server(raw_response: String) -> Result<String> {
+	let listener = TcpListener::bind("127.0.0.1:0").await?;
+	let addr = listener.local_addr()?;
+	tokio::spawn(async move {
+		if let Ok((mut socket, _)) = listener.accept().await {
+			// Best effort: read the (small) request bytes before responding.
+			let mut buf = [0u8; 4096];
+			let _ = socket.read(&mut buf).await;
+			let _ = socket.write_all(raw_response.as_bytes()).await;
+			let _ = socket.shutdown().await;
+		}
+	});
+	Ok(format!("http://{addr}/"))
+}
+
+// endregion: --- Support


### PR DESCRIPTION
Part of the #277 split (single-purpose PRs, low-level first, gated on merges). The otel-compile prerequisite (#278) is now merged, so this is a single commit on top of current `main`.

Streaming HTTP failures (`WebStream` and the Bedrock byte stream) previously discarded the response headers, so downstream retry layers could not see `retry-after`, `retry-after-ms`, or `x-should-retry` on the streaming path — unlike the non-streaming `webc::Error::ResponseFailedStatus`, which already carries a `HeaderMap`. This adds a `headers: Box<HeaderMap>` field to `Error::HttpError`, captured while the `reqwest::Response` is still in hand.

**Changed**
- `src/error.rs`: `Error::HttpError` gains `headers: Box<HeaderMap>`.
- `src/webc/web_stream.rs` + `src/adapter/adapters/bedrock/shared.rs`: capture headers before reading the error body; new lib test `test_web_stream_http_error_captures_headers` (one-shot local TCP server asserting the header round-trip).
- `src/otel/error.rs`: add `headers` to the existing `HttpError` test constructor.
- CHANGELOG / `dev/specs/spec-webc.md` / `docs/for-llm/api-reference-for-llm.md`.

**Breaking**: exhaustive matchers/constructors of `Error::HttpError` must add `headers` (or match with `..`).

**Tests**: build, `test --lib` (199), `test --lib --features otel` (221), `fmt`, `clippy` clean; the five yakbak replay suites pass (touches the bedrock adapter).