### PR TITLE
feat(tool): ToolResponse binary parts (images in tool results across adapters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 - `!` API CHANGE - `Error::HttpError` adds a `headers: Box<HeaderMap>` field carrying the response headers of failed streaming HTTP calls.
 - `!` API CHANGE - `Tool` adds the public `custom_format: Option<Value>` field for provider-native freeform custom-tool formats. Downstream `Tool` struct literals must add `custom_format: None`, or preferably migrate to `Tool::new(...)` and builder methods. `Tool::with_custom_format(...)` is the new builder API.
+- `!` API CHANGE - `ToolResponse` adds the public `parts: Option<Vec<Binary>>` field for binary tool-result attachments (e.g., screenshots produced by agentic tools). Downstream `ToolResponse` struct literals must add `parts: None`, or preferably migrate to `ToolResponse::new(...)` and the new `ToolResponse::with_parts(...)` / `ToolResponse::append_binary(...)` builders. Image parts serialize natively where the wire supports them (Anthropic `tool_result`, Bedrock Converse `toolResult`, OpenAI Responses `function_call_output`) and ride in a follow-up user message elsewhere (OpenAI Chat Completions-compatible providers, Gemini, Ollama). Non-image parts are skipped with a warning, and text-only tool responses keep their exact previous serialization on every adapter.
 - `+` New Providers:
   - AtlasCloud - default env: `ATLASCLOUD_API_KEY`, Adapter: OpenAI, endpoint: `https://api.atlascloud.ai/v1/` (activated on the `atlascloud::` namespace) (PR #259)
   - Qwen Cloud - default env: `QWEN_CLOUD_API_KEY`, Adapter: OpenAI, endpoint: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1/` (activated on the `qwen_cloud::` namespace)
   - Kimi - default env: `KIMI_API_KEY`, Adapter: OpenAI, endpoint: `https://api.moonshot.ai/v1/` (activated on the `kimi::` namespace or `kimi` model prefix, moonshot.ai)
 - Anthropic:
+  - `+` Serialize `ToolResponse.parts` image attachments as base64 `image` blocks inside the `tool_result` content array (after the text block). Text-only tool responses keep the legacy plain-string `content`. Non-image and URL-based parts are skipped with a warning, since Anthropic `tool_result` content only accepts text and image blocks.
   - `+` Expose streaming SSE ping messages as provider-neutral `ChatStreamEvent::Heartbeat` events, allowing callers to distinguish a live long-running stream from a stall. (PR #271)
   - `+` Add prompt caching on tools via `Tool::with_cache_control`, and make request-level `ChatOptions::with_cache_control` automatically apply a cache breakpoint to the static (tools+system) prefix, which was previously ignored. `Ephemeral24h` is documented as clamped to Anthropic's max `1h` TTL.
   - `+` Support the `extra_body` `ChatOptions` field, merging extra request body fields. ([#255](https://github.com/jeremychone/rust-genai/pull/255))
@@ -23,6 +25,8 @@
     - Fable and Mythos omit `thinking`, because it is always on and cannot be explicitly disabled.
     - The Anthropic `-zero` model suffix is canonical, while `-none` remains a backward-compatible alias. Both map to `Zero` and are stripped.
 - OpenAI:
+  - `+` Chat Completions: `ToolResponse.parts` images ride in a follow-up `user` message (`image_url` blocks), batched across a run of consecutive tool messages; the `tool` message keeps its text, or the `"(see attached image)"` placeholder when the result is image-only. Applies to all OpenAI-compatible providers sharing this serializer.
+  - `+` Responses: `ToolResponse.parts` images serialize natively as `input_image` items in the `function_call_output` `output` array (after the `input_text` item). Custom tool-call outputs stay raw strings (with the `"(see attached image)"` / `"(no tool output)"` placeholder rules); their images ride in a follow-up `user` message input item, batched across a run of consecutive tool messages.
   - `+` Support OpenAI Responses freeform custom tools with grammar-constrained raw-string input. Custom tools serialize as `type: "custom"`, custom tool-call input streams incrementally, and round-trips as `custom_tool_call` / `custom_tool_call_output` items. (PR #266)
   - `^` Capture `cache_write_tokens` from prompt-cache usage and normalize it to `Usage.prompt_tokens_details.cache_creation_tokens` for Chat Completions and Responses API payloads.
   - `^` GPT-5.6 and later now use cache opt-in only. Here is how to opt in: (see [PR #260](https://github.com/jeremychone/rust-genai/pull/260))
@@ -36,11 +40,15 @@
   - `+` Sanitize JSON Schema for structured responses and strict tools. (PR #263)
   - `!` Apply the `ReasoningEffort::None` to `ReasoningEffort::Zero` rename mechanically, while preserving provider-specific keyword mappings.
 - Gemini:
+  - `+` `ToolResponse.parts` images ride in a follow-up `user` turn (`inline_data` / `file_data`) emitted after the merged `functionResponse` turn; the `functionResponse` keeps its text, or the `"(see attached image)"` placeholder when the result is image-only. Also applies to Vertex (Google publisher).
   - `^` Forward JSON Schema raw via `responseJsonSchema` and `parametersJsonSchema`. (PR #257)
   - `!` Map `ReasoningEffort::Zero` to a budget of `0`, which might be rejected by the provider on some models.
   - `-` Protect known model names such as `deepseek-r1-zero` from reasoning suffix stripping by using a whitelist in `from_model_name()`.
 - Bedrock:
+  - `+` `ToolResponse.parts` images serialize natively as `image` blocks inside the Converse `toolResult` content array (after the text block).
   - `!` Apply the `ReasoningEffort::None` to `ReasoningEffort::Zero` rename mechanically, with behavior unchanged.
+- Ollama:
+  - `+` `ToolResponse.parts` images (base64 only) ride in a follow-up `user` message via the native `images` array; the `tool` message keeps its text, or the `"(see attached image)"` placeholder when the result is image-only.
 - Cross-provider adapters:
   - `^` Move messages after tools in JSON payloads for better prompt cache utilization. (PR #262)
 - OpenTelemetry:

--- a/dev/specs/spec-chat.md
+++ b/dev/specs/spec-chat.md
@@ -34,7 +34,7 @@ The module exports the following key data structures:
 - **Tooling:**
   - `Tool`: Metadata and schema defining a function the model can call.
   - `ToolCall`: The model's invocation request for a specific tool.
-  - `ToolResponse`: The output returned from executing a tool, matched by call ID.
+  - `ToolResponse`: The output returned from executing a tool, matched by call ID. Carries text `content` plus optional binary `parts` (e.g., screenshots); see `spec-tool.md` for the per-adapter image serialization matrix.
 
 - **Metadata:**
   - `Usage`, `PromptTokensDetails`, `CompletionTokensDetails`: Normalized token usage statistics.

--- a/dev/specs/spec-tool.md
+++ b/dev/specs/spec-tool.md
@@ -60,11 +60,29 @@ pub struct ToolCall {
 ```rust
 pub struct ToolResponse {
     pub call_id: String,
+    pub fn_name: Option<String>,
     pub content: String,
+    pub parts: Option<Vec<Binary>>,
 }
 ```
 
 - `ToolResponse::new(call_id, content)`: Links the execution output back to the original call.
+- `ToolResponse::from_tool_call(&tool_call, content)`: Convenience constructor that also captures `fn_name` (needed by Gemini's `functionResponse.name`).
+- `with_fn_name(name)`: Builder-style method to set the function/tool name.
+- `with_parts(parts)` / `append_binary(binary)`: Builder-style methods to attach binary parts (e.g., screenshots) to the tool result.
+
+Adapter behavior for `parts` (image parts only; non-image parts are skipped with a warning on every adapter, and a `ToolResponse` without `parts` keeps its exact legacy serialization everywhere):
+
+- **Anthropic**: image parts serialize natively as base64 `image` blocks inside the `tool_result` content array, after the text block (text block omitted when the text is empty). URL-based image sources are skipped with a warning (matching user-message image handling).
+- **Bedrock (Converse)**: image parts serialize natively as `image` blocks inside the `toolResult` content array, after the text block. Base64 only (Converse binary handling does not support URLs).
+- **OpenAI Responses**: image parts serialize natively: `function_call_output.output` becomes an array of `input_text` (when text is non-empty) plus `input_image` items (`detail: "auto"`, `image_url` as data URL or plain URL). `custom_tool_call_output` stays a raw string with the same placeholder rules as Chat Completions (`"(see attached image)"` / `"(no tool output)"`); its images are rescued into a follow-up `user` message input item (`input_text` label + `input_image` items), batched across a run of consecutive Tool messages and emitted after the run.
+- **OpenAI Chat Completions** (shared by all OpenAI-compatible providers: Groq, Together, Fireworks, DeepSeek, etc.): the `tool` message stays text-only. When parts are present, its content is the text, or `"(see attached image)"` when the result has images but no text, or `"(no tool output)"` when it has neither. The images then ride in a follow-up `user` message with content `[{type: "text", text: "Attached image(s) from tool result:"}, ...image_url blocks]`. Images from a run of consecutive Tool messages are batched into ONE follow-up user message, emitted before the next non-tool message.
+- **Gemini** (also Vertex/Google): the `functionResponse` content stays text-only with the same placeholder rules as Chat Completions. Images from Tool-role messages ride in a follow-up `user` turn (label text part + `inline_data` for base64 / `file_data` for URLs), batched across the run of Tool messages and emitted after them, so the `functionResponse` turns can still be merged into the single user turn the Gemini FC protocol requires. For a `ToolResponse` embedded in a User-role message, the images are appended inline in that same user turn instead.
+- **Ollama (native)**: the `tool` message stays text-only with the same placeholder rules. Base64 images ride in a follow-up `user` message using the native `images` array (one follow-up per tool message); URL sources are skipped with a warning.
+
+Notes:
+
+- genai has no model-capability catalog, so the fallback is emitted whenever parts exist — attaching parts is the caller's opt-in that the target model accepts image input. No interstitial-assistant compatibility message is inserted, and Gemini is not version-gated for multimodal `functionResponse` nesting (the universal follow-up-user-turn form is used instead).
 
 ### Integration Points
 

--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -7,7 +7,7 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	Binary, BinarySource, CacheControl, CacheCreationDetails, ChatOptionsSet, ChatRequest, ChatResponse,
 	ChatResponseFormat, ChatRole, ContentPart, JsonSchemaDialect, MessageContent, PromptTokensDetails, ReasoningEffort,
-	StopReason, Tool, ToolCall, ToolChoice, ToolConfig, ToolName, Usage, sanitize_json_schema,
+	StopReason, Tool, ToolCall, ToolChoice, ToolConfig, ToolName, ToolResponse, Usage, sanitize_json_schema,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebClient, WebResponse};
@@ -227,11 +227,7 @@ impl AnthropicAdapter {
 								// ToolCall is not valid in user content for Anthropic; skip gracefully.
 								ContentPart::ToolCall(_tc) => {}
 								ContentPart::ToolResponse(tool_response) => {
-									values.push(json!({
-										"type": "tool_result",
-										"content": tool_response.content,
-										"tool_use_id": tool_response.call_id,
-									}));
+									values.push(tool_response_to_tool_result(tool_response));
 								}
 								ContentPart::ThoughtSignature(_) => {}
 								ContentPart::ReasoningContent(_) => {}
@@ -304,11 +300,7 @@ impl AnthropicAdapter {
 					for part in msg.content {
 						match part {
 							ContentPart::ToolResponse(tool_response) => {
-								values.push(json!({
-									"type": "tool_result",
-									"content": tool_response.content,
-									"tool_use_id": tool_response.call_id,
-								}));
+								values.push(tool_response_to_tool_result(tool_response));
 							}
 							ContentPart::Custom(custom_part) => values.push(custom_part.data),
 							_ => {}
@@ -807,6 +799,83 @@ fn apply_cache_control_to_parts(cache_control: Option<&CacheControl>, parts: Vec
 		}
 	}
 	parts
+}
+
+/// Serialize a `ToolResponse` into an Anthropic `tool_result` content item.
+///
+/// - Without binary parts, `content` remains a plain string (legacy shape, unchanged).
+/// - With parts, `content` becomes an array of a `text` block (when the text is non-empty)
+///   followed by `image` blocks for base64 image parts.
+///
+/// NOTE: Anthropic `tool_result` content only accepts `text` and `image` blocks,
+///       so non-image parts are skipped with a warning. URL-based image sources are
+///       skipped as well, matching the user-message image handling above.
+fn tool_response_to_tool_result(tool_response: ToolResponse) -> Value {
+	let ToolResponse {
+		call_id,
+		content,
+		parts,
+		..
+	} = tool_response;
+
+	let parts = parts.unwrap_or_default();
+
+	if parts.is_empty() {
+		return json!({
+			"type": "tool_result",
+			"content": content,
+			"tool_use_id": call_id,
+		});
+	}
+
+	let mut values: Vec<Value> = Vec::new();
+	if !content.is_empty() {
+		values.push(json!({"type": "text", "text": content}));
+	}
+
+	for binary in parts {
+		if !binary.is_image() {
+			warn!(
+				"Anthropic tool_result only supports text and image blocks; skipping non-image part '{}'",
+				binary.content_type
+			);
+			continue;
+		}
+		let Binary {
+			content_type, source, ..
+		} = binary;
+		match source {
+			BinarySource::Base64(data) => {
+				values.push(json!({
+					"type": "image",
+					"source": {
+						"type": "base64",
+						"media_type": content_type,
+						"data": data,
+					}
+				}));
+			}
+			BinarySource::Url(_) => {
+				// As of this API version, Anthropic doesn't support images by URL directly in messages.
+				warn!("Anthropic doesn't support images from URL, need to handle it gracefully");
+			}
+		}
+	}
+
+	// If all parts were skipped and there is no text, fall back to the legacy string shape.
+	if values.is_empty() {
+		return json!({
+			"type": "tool_result",
+			"content": content,
+			"tool_use_id": call_id,
+		});
+	}
+
+	json!({
+		"type": "tool_result",
+		"content": values,
+		"tool_use_id": call_id,
+	})
 }
 
 fn anthropic_tool_choice(tool_choice: Option<&ToolChoice>) -> Option<Value> {

--- a/src/adapter/adapters/anthropic/adapter_shared_tests.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared_tests.rs
@@ -658,6 +658,127 @@ fn test_anthropic_adapter_protected_reasoning_suffix_is_retained() -> Result<()>
 	Ok(())
 }
 
+/// A `ToolResponse` with an image part must serialize the Anthropic `tool_result`
+/// content as an array of a text block followed by a base64 `image` block.
+#[test]
+fn test_anthropic_tool_response_image_part_serializes_tool_result_blocks() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_call = ToolCall {
+		call_id: "call_1".to_string(),
+		fn_name: "take_screenshot".to_string(),
+		fn_arguments: json!({}),
+		thought_signatures: None,
+	};
+	let tool_response = ToolResponse::new("call_1", "screenshot taken").with_parts([Binary::from_base64(
+		"image/png",
+		"iVBORw0KBASE64",
+		None,
+	)]);
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::user("Take a screenshot"),
+		ChatMessage::from(vec![tool_call]),
+		ChatMessage::from(tool_response),
+	]);
+	let target = ServiceTarget {
+		endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+		auth: AuthData::from_single("test-key"),
+		model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+	};
+
+	// -- Exec
+	let web_req =
+		AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, ChatOptionsSet::default())?;
+
+	// -- Check
+	let messages = web_req.payload["messages"].as_array().ok_or("messages must be an array")?;
+	assert_eq!(messages.len(), 3, "user, assistant tool_use, and tool_result messages");
+	let tool_result_msg = &messages[2];
+	assert_eq!(tool_result_msg["role"], json!("user"));
+	assert_eq!(
+		tool_result_msg["content"][0],
+		json!({
+			"type": "tool_result",
+			"tool_use_id": "call_1",
+			"content": [
+				{"type": "text", "text": "screenshot taken"},
+				{
+					"type": "image",
+					"source": {
+						"type": "base64",
+						"media_type": "image/png",
+						"data": "iVBORw0KBASE64",
+					}
+				}
+			]
+		})
+	);
+
+	Ok(())
+}
+
+/// Regression guard: a text-only `ToolResponse` must keep the legacy `tool_result`
+/// shape with a plain string `content` (no content array).
+#[test]
+fn test_anthropic_tool_response_text_only_serializes_as_before() -> Result<()> {
+	// -- Setup & Fixtures
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(ToolResponse::new("call_1", "42"))]);
+	let target = ServiceTarget {
+		endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+		auth: AuthData::from_single("test-key"),
+		model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+	};
+
+	// -- Exec
+	let web_req =
+		AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, ChatOptionsSet::default())?;
+
+	// -- Check
+	assert_eq!(
+		web_req.payload["messages"][0]["content"][0],
+		json!({
+			"type": "tool_result",
+			"content": "42",
+			"tool_use_id": "call_1",
+		})
+	);
+
+	Ok(())
+}
+
+/// Non-image and URL-based parts are not valid inside an Anthropic `tool_result`;
+/// they must be skipped while the text block is preserved.
+#[test]
+fn test_anthropic_tool_response_non_image_parts_are_skipped() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_response = ToolResponse::new("call_1", "text kept").with_parts([
+		Binary::from_base64("application/pdf", "PDFDATA", Some("doc.pdf".to_string())),
+		Binary::from_url("image/png", "https://example.com/shot.png", None),
+	]);
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(tool_response)]);
+	let target = ServiceTarget {
+		endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+		auth: AuthData::from_single("test-key"),
+		model: ModelIden::new(AdapterKind::Anthropic, "claude-haiku-4-5"),
+	};
+
+	// -- Exec
+	let web_req =
+		AnthropicAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, ChatOptionsSet::default())?;
+
+	// -- Check
+	assert_eq!(
+		web_req.payload["messages"][0]["content"][0],
+		json!({
+			"type": "tool_result",
+			"tool_use_id": "call_1",
+			"content": [{"type": "text", "text": "text kept"}],
+		}),
+		"non-image and URL parts must be skipped, keeping only the text block"
+	);
+
+	Ok(())
+}
+
 // region:    --- Support
 
 fn build_characterization_payload(model_name: &str, reasoning_effort: Option<ReasoningEffort>) -> Result<Value> {

--- a/src/adapter/adapters/bedrock/converse.rs
+++ b/src/adapter/adapters/bedrock/converse.rs
@@ -6,7 +6,7 @@
 
 use crate::chat::{
 	Binary, BinarySource, ChatOptionsSet, ChatRequest, ChatResponse, ChatRole, ContentPart, MessageContent,
-	ReasoningEffort, StopReason, Tool, ToolCall, ToolName, Usage,
+	ReasoningEffort, StopReason, Tool, ToolCall, ToolName, ToolResponse, Usage,
 };
 use crate::webc::WebResponse;
 use crate::{Error, ModelIden, Result};
@@ -335,12 +335,7 @@ fn user_content_to_converse_blocks(content: MessageContent) -> Vec<Value> {
 				}
 			}
 			ContentPart::ToolResponse(tool_response) => {
-				blocks.push(json!({
-					"toolResult": {
-						"toolUseId": tool_response.call_id,
-						"content": [{ "text": tool_response.content }],
-					}
-				}));
+				blocks.push(tool_response_to_converse_block(tool_response));
 			}
 			// Not valid in user role for Converse — skip.
 			ContentPart::ToolCall(_) => {}
@@ -386,15 +381,57 @@ fn tool_content_to_converse_blocks(content: MessageContent) -> Vec<Value> {
 	let mut blocks = Vec::new();
 	for part in content {
 		if let ContentPart::ToolResponse(tool_response) = part {
-			blocks.push(json!({
-				"toolResult": {
-					"toolUseId": tool_response.call_id,
-					"content": [{ "text": tool_response.content }],
-				}
-			}));
+			blocks.push(tool_response_to_converse_block(tool_response));
 		}
 	}
 	blocks
+}
+
+/// Serialize a `ToolResponse` into a Converse `toolResult` block.
+///
+/// Converse natively supports image blocks inside `toolResult.content`, so image
+/// parts (base64 only) are emitted after the text block. Non-image parts are
+/// skipped with a warning, matching the other adapters' image-only contract.
+fn tool_response_to_converse_block(tool_response: ToolResponse) -> Value {
+	let ToolResponse {
+		call_id,
+		content,
+		parts,
+		..
+	} = tool_response;
+	let parts = parts.unwrap_or_default();
+
+	let mut content_blocks: Vec<Value> = Vec::new();
+	if parts.is_empty() {
+		content_blocks.push(json!({ "text": content }));
+	} else {
+		if !content.is_empty() {
+			content_blocks.push(json!({ "text": content }));
+		}
+		for binary in parts {
+			if !binary.is_image() {
+				warn!(
+					"ToolResponse binary parts only support images for the Bedrock Converse adapter; skipping non-image part '{}'",
+					binary.content_type
+				);
+				continue;
+			}
+			if let Some(block) = binary_to_converse_block(binary) {
+				content_blocks.push(block);
+			}
+		}
+		// If all parts were skipped, fall back to the legacy text block.
+		if content_blocks.is_empty() {
+			content_blocks.push(json!({ "text": content }));
+		}
+	}
+
+	json!({
+		"toolResult": {
+			"toolUseId": call_id,
+			"content": content_blocks,
+		}
+	})
 }
 
 fn binary_to_converse_block(binary: Binary) -> Option<Value> {
@@ -493,3 +530,11 @@ fn tool_to_converse_tool(tool: Tool) -> Result<Value> {
 
 	Ok(json!({ "toolSpec": tool_spec }))
 }
+
+// region:    --- Tests
+
+#[cfg(test)]
+#[path = "converse_tests.rs"]
+mod tests;
+
+// endregion: --- Tests

--- a/src/adapter/adapters/bedrock/converse_tests.rs
+++ b/src/adapter/adapters/bedrock/converse_tests.rs
@@ -1,0 +1,62 @@
+type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
+
+use super::*;
+use crate::chat::ChatMessage;
+
+/// Converse natively supports image blocks inside `toolResult.content`, so a
+/// `ToolResponse` with an image part emits the text block followed by the image block.
+#[test]
+fn test_bedrock_tool_response_image_part_serializes_tool_result_blocks() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_response =
+		ToolResponse::new("call_1", "screenshot taken").with_parts([Binary::from_base64("image/png", "PNG64", None)]);
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(tool_response)]);
+
+	// -- Exec
+	let ConverseRequestParts { messages, .. } = into_converse_request_parts(chat_req)?;
+
+	// -- Check
+	assert_eq!(
+		messages,
+		vec![json!({
+			"role": "user",
+			"content": [{
+				"toolResult": {
+					"toolUseId": "call_1",
+					"content": [
+						{ "text": "screenshot taken" },
+						{ "image": { "format": "png", "source": { "bytes": "PNG64" } } },
+					],
+				}
+			}]
+		})]
+	);
+
+	Ok(())
+}
+
+/// Regression guard: a text-only `ToolResponse` keeps the legacy single text block.
+#[test]
+fn test_bedrock_tool_response_text_only_serializes_as_before() -> Result<()> {
+	// -- Setup & Fixtures
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(ToolResponse::new("call_1", "42"))]);
+
+	// -- Exec
+	let ConverseRequestParts { messages, .. } = into_converse_request_parts(chat_req)?;
+
+	// -- Check
+	assert_eq!(
+		messages,
+		vec![json!({
+			"role": "user",
+			"content": [{
+				"toolResult": {
+					"toolUseId": "call_1",
+					"content": [{ "text": "42" }],
+				}
+			}]
+		})]
+	);
+
+	Ok(())
+}

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -1,5 +1,5 @@
 use crate::adapter::adapters::gemini::GeminiStreamer;
-use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::adapters::support::{TOOL_RESULT_IMAGES_LABEL, get_api_key, tool_response_fallback_text};
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	Binary, BinarySource, ChatOptionsSet, ChatRequest, ChatResponse, ChatResponseFormat, ChatRole, ChatStream,
@@ -11,6 +11,7 @@ use crate::webc::{EventSourceStream, WebClient, WebResponse};
 use crate::{Error, Headers, ModelIden, Result, ServiceTarget};
 use reqwest::RequestBuilder;
 use serde_json::{Value, json};
+use tracing::warn;
 use value_ext::JsonValueExt;
 
 pub struct GeminiAdapter;
@@ -588,8 +589,19 @@ impl GeminiAdapter {
 			systems.push(system);
 		}
 
+		// Images attached to tool responses (`ToolResponse.parts`) of Tool-role messages
+		// ride in a follow-up "user" turn. They are batched across a run of consecutive
+		// Tool messages and flushed after it, so the functionResponse turns can still be
+		// merged into the single "user" turn that the Gemini FC protocol requires.
+		let mut pending_tool_images: Vec<Value> = Vec::new();
+
 		// -- Build
 		for msg in chat_req.messages {
+			if !matches!(msg.role, ChatRole::Tool) && !pending_tool_images.is_empty() {
+				contents.push(gemini_tool_images_user_content(std::mem::take(
+					&mut pending_tool_images,
+				)));
+			}
 			match msg.role {
 				// For now, system goes as "user" (later, we might have adapter_config.system_to_user_impl)
 				ChatRole::System => {
@@ -631,15 +643,26 @@ impl GeminiAdapter {
 							}
 							ContentPart::ToolResponse(tool_response) => {
 								let fn_name = gemini_function_response_name(&tool_response);
+								let ToolResponse { content, parts, .. } = tool_response;
+								let parts = parts.unwrap_or_default();
+								let has_parts = !parts.is_empty();
+								let image_values = gemini_tool_result_image_parts(parts);
+								let content = if has_parts {
+									tool_response_fallback_text(content, !image_values.is_empty())
+								} else {
+									content
+								};
 								parts_values.push(json!({
 									"functionResponse": {
 										"name": &fn_name,
 										"response": {
 											"name": &fn_name,
-											"content": tool_response.content,
+											"content": content,
 										}
 									}
 								}));
+								// Already a "user" turn: append the tool-result images inline.
+								parts_values.extend(image_values);
 							}
 							ContentPart::ThoughtSignature(thought) => {
 								parts_values.push(json!({
@@ -743,15 +766,28 @@ impl GeminiAdapter {
 							}
 							ContentPart::ToolResponse(tool_response) => {
 								let fn_name = gemini_function_response_name(&tool_response);
+								let ToolResponse { content, parts, .. } = tool_response;
+								let parts = parts.unwrap_or_default();
+								let has_parts = !parts.is_empty();
+								let image_values = gemini_tool_result_image_parts(parts);
+								let content = if has_parts {
+									tool_response_fallback_text(content, !image_values.is_empty())
+								} else {
+									content
+								};
 								parts_values.push(json!({
 									"functionResponse": {
 										"name": &fn_name,
 										"response": {
 											"name": &fn_name,
-											"content": tool_response.content,
+											"content": content,
 										}
 									}
 								}));
+								// Images ride in a follow-up "user" turn emitted after the run of
+								// Tool messages (post functionResponse-merge), since media nested
+								// inside functionResponse is not supported across Gemini versions.
+								pending_tool_images.extend(image_values);
 							}
 							ContentPart::ThoughtSignature(thought) => {
 								parts_values.push(json!({
@@ -771,6 +807,11 @@ impl GeminiAdapter {
 					contents.push(json!({"role": "user", "parts": parts_values}));
 				}
 			}
+		}
+
+		// Flush tool-result images from a trailing run of Tool messages.
+		if !pending_tool_images.is_empty() {
+			contents.push(gemini_tool_images_user_content(pending_tool_images));
 		}
 
 		let system = if !systems.is_empty() {
@@ -940,6 +981,48 @@ fn take_bool(v: &mut Value, key: &str) -> bool {
 		.unwrap_or(false)
 }
 
+/// Convert tool-result binary parts into Gemini user-content part values
+/// (`inline_data` for base64, `file_data` for URLs), skipping non-image parts
+/// with a warning.
+fn gemini_tool_result_image_parts(parts: Vec<Binary>) -> Vec<Value> {
+	let mut values: Vec<Value> = Vec::new();
+	for binary in parts {
+		if !binary.is_image() {
+			warn!(
+				"ToolResponse binary parts only support images for the Gemini adapter; skipping non-image part '{}'",
+				binary.content_type
+			);
+			continue;
+		}
+		let Binary {
+			content_type, source, ..
+		} = binary;
+		match source {
+			BinarySource::Url(url) => values.push(json!({
+				"file_data": {
+					"mime_type": content_type,
+					"file_uri": url
+				}
+			})),
+			BinarySource::Base64(data) => values.push(json!({
+				"inline_data": {
+					"mime_type": content_type,
+					"data": data
+				}
+			})),
+		}
+	}
+	values
+}
+
+/// Build the follow-up "user" turn that carries tool-result images.
+fn gemini_tool_images_user_content(image_parts: Vec<Value>) -> Value {
+	let mut parts: Vec<Value> = Vec::with_capacity(image_parts.len() + 1);
+	parts.push(json!({"text": TOOL_RESULT_IMAGES_LABEL}));
+	parts.extend(image_parts);
+	json!({"role": "user", "parts": parts})
+}
+
 fn gemini_function_response_name(tool_response: &ToolResponse) -> String {
 	tool_response
 		.fn_name
@@ -1024,6 +1107,73 @@ mod tests {
 
 		assert_eq!(function_response["name"], "get_weather");
 		assert_eq!(function_response["response"]["name"], "get_weather");
+	}
+
+	/// Tool-message `ToolResponse.parts` images ride in a follow-up "user" turn,
+	/// batched after the run of Tool messages so the functionResponse turns still
+	/// merge into the single "user" turn required by the Gemini FC protocol.
+	#[test]
+	fn tool_response_image_parts_ride_in_followup_user_turn() {
+		// -- Setup & Fixtures
+		let model_iden = ModelIden::new(AdapterKind::Gemini, "gemini-2.5-flash");
+		let tr1 = ToolResponse::new("call_1", "screenshot taken")
+			.with_fn_name("screenshot")
+			.with_parts([Binary::from_base64("image/png", "PNG64", None)]);
+		let tr2 = ToolResponse::new("call_2", "")
+			.with_fn_name("chart")
+			.with_parts([Binary::from_base64("image/jpeg", "JPEG64", None)]);
+		let chat_req = ChatRequest::new(vec![ChatMessage::from(tr1), ChatMessage::from(tr2)]);
+
+		// -- Exec
+		let parts = GeminiAdapter::into_gemini_request_parts(&model_iden, chat_req).unwrap();
+
+		// -- Check
+		// The two functionResponse turns merge into one, followed by the image turn.
+		assert_eq!(parts.contents.len(), 2);
+		let fn_parts = parts.contents[0]["parts"].as_array().unwrap();
+		assert_eq!(fn_parts.len(), 2);
+		assert_eq!(
+			fn_parts[0]["functionResponse"]["response"]["content"],
+			"screenshot taken"
+		);
+		assert_eq!(
+			fn_parts[1]["functionResponse"]["response"]["content"], "(see attached image)",
+			"image-only tool response must use the placeholder text"
+		);
+		assert_eq!(
+			parts.contents[1],
+			json!({
+				"role": "user",
+				"parts": [
+					{"text": "Attached image(s) from tool result:"},
+					{"inline_data": {"mime_type": "image/png", "data": "PNG64"}},
+					{"inline_data": {"mime_type": "image/jpeg", "data": "JPEG64"}},
+				]
+			})
+		);
+	}
+
+	/// Regression guard: a text-only `ToolResponse` keeps its legacy functionResponse
+	/// shape with no follow-up user turn.
+	#[test]
+	fn tool_response_text_only_serializes_as_before() {
+		// -- Setup & Fixtures
+		let model_iden = ModelIden::new(AdapterKind::Gemini, "gemini-2.5-flash");
+		let chat_req = ChatRequest::new(vec![ChatMessage::from(
+			ToolResponse::new("call_1", "42").with_fn_name("calc"),
+		)]);
+
+		// -- Exec
+		let parts = GeminiAdapter::into_gemini_request_parts(&model_iden, chat_req).unwrap();
+
+		// -- Check
+		assert_eq!(
+			parts.contents,
+			vec![json!({
+				"role": "user",
+				"parts": [{"functionResponse": {"name": "calc", "response": {"name": "calc", "content": "42"}}}]
+			})]
+		);
 	}
 
 	#[test]

--- a/src/adapter/adapters/ollama/adapter_shared.rs
+++ b/src/adapter/adapters/ollama/adapter_shared.rs
@@ -3,11 +3,13 @@
 use super::OllamaAdapter;
 use crate::Headers;
 use crate::adapter::AdapterKind;
-use crate::chat::{Binary, BinarySource, ChatRequest, ContentPart, Tool, ToolName, Usage};
+use crate::adapter::adapters::support::{TOOL_RESULT_IMAGES_LABEL, tool_response_fallback_text};
+use crate::chat::{Binary, BinarySource, ChatRequest, ContentPart, Tool, ToolName, ToolResponse, Usage};
 use crate::resolver::Endpoint;
 use crate::webc::WebClient;
 use crate::{Error, Result};
 use serde_json::{Value, json};
+use tracing::warn;
 use value_ext::JsonValueExt;
 
 /// Support functions for other adapters that share Ollama APIs
@@ -81,6 +83,9 @@ impl OllamaAdapter {
 			let mut content = String::new();
 			let mut images = Vec::new();
 			let mut tool_calls = Vec::new();
+			// Images attached to tool responses (`ToolResponse.parts`); they ride in a
+			// follow-up "user" message since tool messages carry only text content.
+			let mut tool_response_images = Vec::new();
 
 			for part in msg.content {
 				match part {
@@ -103,7 +108,43 @@ impl OllamaAdapter {
 					}
 					ContentPart::ToolResponse(tr) => {
 						// Note: Ollama native API expects role "tool" for tool response
-						ollama_msg.x_insert("content", tr.content)?;
+						let ToolResponse {
+							content: tr_content,
+							parts,
+							..
+						} = tr;
+						let parts = parts.unwrap_or_default();
+
+						if parts.is_empty() {
+							ollama_msg.x_insert("content", tr_content)?;
+						} else {
+							// Track whether THIS tool response contributed usable images, so the
+							// "(see attached image)" placeholder is not emitted for a response
+							// whose own parts were all skipped while an earlier response in the
+							// same message contributed images.
+							let images_count_before = tool_response_images.len();
+							for binary in parts {
+								if binary.is_image() {
+									match binary.source {
+										// Note: Ollama native API expects raw base64 (no data URL).
+										BinarySource::Base64(data) => tool_response_images.push(data),
+										BinarySource::Url(_) => {
+											warn!(
+												"Ollama native API doesn't support image URLs; skipping tool-result image part"
+											);
+										}
+									}
+								} else {
+									warn!(
+										"ToolResponse binary parts only support images for the Ollama adapter; skipping non-image part '{}'",
+										binary.content_type
+									);
+								}
+							}
+							let has_own_images = tool_response_images.len() > images_count_before;
+							let tr_content = tool_response_fallback_text(tr_content, has_own_images);
+							ollama_msg.x_insert("content", tr_content)?;
+						}
 					}
 					_ => {}
 				}
@@ -120,6 +161,15 @@ impl OllamaAdapter {
 			}
 
 			messages.push(ollama_msg);
+
+			// Follow-up user message carrying the tool-result images.
+			if !tool_response_images.is_empty() {
+				messages.push(json!({
+					"role": "user",
+					"content": TOOL_RESULT_IMAGES_LABEL,
+					"images": tool_response_images,
+				}));
+			}
 		}
 
 		// -- Tools
@@ -166,3 +216,11 @@ pub(in crate::adapter::adapters) struct OllamaRequestParts {
 	pub messages: Vec<Value>,
 	pub tools: Option<Vec<Value>>,
 }
+
+// region:    --- Tests
+
+#[cfg(test)]
+#[path = "adapter_shared_tests.rs"]
+mod tests;
+
+// endregion: --- Tests

--- a/src/adapter/adapters/ollama/adapter_shared_tests.rs
+++ b/src/adapter/adapters/ollama/adapter_shared_tests.rs
@@ -1,0 +1,96 @@
+type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
+
+use super::*;
+use crate::chat::{ChatMessage, MessageContent};
+
+/// Tool-result images cannot ride inside an Ollama `tool` message: the tool message
+/// keeps its text (or the placeholder), and the images are carried by a follow-up
+/// `user` message with the base64 `images` array.
+#[test]
+fn test_ollama_tool_response_image_parts_ride_in_followup_user_message() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_response = ToolResponse::new("call_1", "").with_parts([Binary::from_base64("image/png", "PNG64", None)]);
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(tool_response)]);
+
+	// -- Exec
+	let OllamaRequestParts { messages, .. } = OllamaAdapter::into_ollama_request_parts(chat_req)?;
+
+	// -- Check
+	assert_eq!(messages.len(), 2, "tool message + follow-up user image message");
+	assert_eq!(
+		messages[0],
+		json!({"role": "tool", "content": "(see attached image)"}),
+		"image-only tool response must use the placeholder text"
+	);
+	assert_eq!(
+		messages[1],
+		json!({
+			"role": "user",
+			"content": "Attached image(s) from tool result:",
+			"images": ["PNG64"],
+		})
+	);
+
+	Ok(())
+}
+
+/// The `"(see attached image)"` placeholder must track the images contributed by the
+/// CURRENT tool response only: with two responses in one message where the first
+/// contributes an image and the second is empty with only skipped parts, the second's
+/// text must be `"(no tool output)"` (not `"(see attached image)"`), even though the
+/// message-level image accumulator is non-empty from the first response.
+#[test]
+fn test_ollama_tool_response_placeholder_tracks_own_images_only() -> Result<()> {
+	// -- Setup & Fixtures
+	let first = ToolResponse::new("call_1", "").with_parts([Binary::from_base64("image/png", "PNG64", None)]);
+	// URL-based image parts are skipped by the Ollama native adapter, so this
+	// response contributes no usable image of its own.
+	let second = ToolResponse::new("call_2", "").with_parts([Binary::from_url(
+		"image/png",
+		"https://example.com/shot.png",
+		None,
+	)]);
+	let tool_msg = ChatMessage::tool(MessageContent::from_parts(vec![
+		ContentPart::ToolResponse(first),
+		ContentPart::ToolResponse(second),
+	]));
+	let chat_req = ChatRequest::new(vec![tool_msg]);
+
+	// -- Exec
+	let OllamaRequestParts { messages, .. } = OllamaAdapter::into_ollama_request_parts(chat_req)?;
+
+	// -- Check
+	assert_eq!(messages.len(), 2, "tool message + follow-up user image message");
+	assert_eq!(
+		messages[0]["content"],
+		json!("(no tool output)"),
+		"a response whose own parts were all skipped must not claim an attached image"
+	);
+	assert_eq!(
+		messages[1],
+		json!({
+			"role": "user",
+			"content": "Attached image(s) from tool result:",
+			"images": ["PNG64"],
+		}),
+		"the first response's image still rides in the follow-up user message"
+	);
+
+	Ok(())
+}
+
+/// Regression guard: a text-only `ToolResponse` keeps its legacy shape with no
+/// follow-up user message.
+#[test]
+fn test_ollama_tool_response_text_only_serializes_as_before() -> Result<()> {
+	// -- Setup & Fixtures
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(ToolResponse::new("call_1", "42"))]);
+
+	// -- Exec
+	let OllamaRequestParts { messages, .. } = OllamaAdapter::into_ollama_request_parts(chat_req)?;
+
+	// -- Check
+	assert_eq!(messages, vec![json!({"role": "tool", "content": "42"})]);
+
+	Ok(())
+}

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -3,10 +3,11 @@
 use super::cache_policy::{OpenAiPromptCachePolicy, OpenAiProtocol, is_gpt_5_6_or_later, openai_prompt_cache_policy};
 use super::schema::{OpenAiResponseFormatPlan, response_format_plan, tool_parameters_schema};
 use crate::adapter::adapters::openai::OpenAIAdapter;
-use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::adapters::support::{TOOL_RESULT_IMAGES_LABEL, get_api_key, tool_response_fallback_text};
 use crate::adapter::{AdapterDispatcher, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
-	BinarySource, CacheControl, ChatOptionsSet, ChatRequest, ChatRole, ContentPart, ReasoningEffort, ToolChoice, Usage,
+	BinarySource, CacheControl, ChatOptionsSet, ChatRequest, ChatRole, ContentPart, ReasoningEffort, ToolChoice,
+	ToolResponse, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebClient;
@@ -304,8 +305,18 @@ impl OpenAIAdapter {
 			messages.push(json!({"role": "system", "content": system_msg}));
 		}
 
+		// Images attached to tool responses (`ToolResponse.parts`) cannot ride inside a
+		// Chat Completions `tool` message, so they are carried by a follow-up `user`
+		// message. Images from a run of consecutive Tool messages are batched into one
+		// trailing user message, emitted before the next non-tool message.
+		let mut pending_tool_images: Vec<Value> = Vec::new();
+
 		// -- Process the messages
 		for msg in chat_req.messages {
+			if !matches!(msg.role, ChatRole::Tool) && !pending_tool_images.is_empty() {
+				messages.push(tool_images_user_message(std::mem::take(&mut pending_tool_images)));
+			}
+
 			let cache_controlled = cache_policy.is_some()
 				&& msg
 					.options
@@ -469,17 +480,53 @@ impl OpenAIAdapter {
 				ChatRole::Tool => {
 					for part in msg.content {
 						if let ContentPart::ToolResponse(tool_response) = part {
-							messages.push(json!({
-								"role": "tool",
-								"content": tool_response.content,
-								"tool_call_id": tool_response.call_id,
-							}))
+							let ToolResponse {
+								call_id,
+								content,
+								parts,
+								..
+							} = tool_response;
+							let parts = parts.unwrap_or_default();
+
+							if parts.is_empty() {
+								messages.push(json!({
+									"role": "tool",
+									"content": content,
+									"tool_call_id": call_id,
+								}));
+							} else {
+								let mut image_values: Vec<Value> = Vec::new();
+								for binary in parts {
+									if binary.is_image() {
+										let image_url = binary.into_url();
+										image_values
+											.push(json!({"type": "image_url", "image_url": {"url": image_url}}));
+									} else {
+										warn!(
+											"ToolResponse binary parts only support images for OpenAI-compatible adapters; skipping non-image part '{}'",
+											binary.content_type
+										);
+									}
+								}
+								let content = tool_response_fallback_text(content, !image_values.is_empty());
+								messages.push(json!({
+									"role": "tool",
+									"content": content,
+									"tool_call_id": call_id,
+								}));
+								pending_tool_images.extend(image_values);
+							}
 						}
 					}
 
 					// TODO: Probably need to trace/warn that this will be ignored
 				}
 			}
+		}
+
+		// Flush tool-result images from a trailing run of Tool messages.
+		if !pending_tool_images.is_empty() {
+			messages.push(tool_images_user_message(pending_tool_images));
 		}
 
 		// -- Process the tools
@@ -591,6 +638,16 @@ pub struct ToWebRequestDataOptions {
 struct OpenAIRequestParts {
 	messages: Vec<Value>,
 	tools: Option<Vec<Value>>,
+}
+
+/// Build the follow-up `user` message that carries tool-result images
+/// (`ToolResponse.parts`), since Chat Completions `tool` message content
+/// cannot include image blocks.
+fn tool_images_user_message(image_values: Vec<Value>) -> Value {
+	let mut values: Vec<Value> = Vec::with_capacity(image_values.len() + 1);
+	values.push(json!({"type": "text", "text": TOOL_RESULT_IMAGES_LABEL}));
+	values.extend(image_values);
+	json!({"role": "user", "content": values})
 }
 
 fn apply_chat_cache_breakpoint(_model_iden: &ModelIden, content: &mut [Value], _scope: &'static str) -> Result<()> {

--- a/src/adapter/adapters/openai/adapter_shared_tests.rs
+++ b/src/adapter/adapters/openai/adapter_shared_tests.rs
@@ -1,8 +1,8 @@
 use super::{OpenAIAdapter, ToWebRequestDataOptions};
 use crate::adapter::AdapterKind;
 use crate::chat::{
-	CacheControl, ChatMessage, ChatOptions, ChatOptionsSet, ChatRequest, ContentPart, MessageContent, Tool, ToolCall,
-	ToolChoice,
+	Binary, CacheControl, ChatMessage, ChatOptions, ChatOptionsSet, ChatRequest, ContentPart, MessageContent, Tool,
+	ToolCall, ToolChoice, ToolResponse,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::{ModelIden, ServiceTarget};
@@ -449,6 +449,119 @@ fn test_managed_body_thinking_uses_model_name_derived_effort() -> Result<()> {
 }
 
 // endregion: --- Managed Thinking
+
+/// Tool-result images cannot ride inside a Chat Completions `tool` message: the tool
+/// message keeps its text, and the images from a run of consecutive tool messages are
+/// batched into ONE follow-up `user` message, emitted before the next non-tool message.
+#[test]
+fn test_tool_response_image_parts_batched_into_followup_user_message() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_response_1 = ToolResponse::new("call_1", "screenshot taken").with_parts([Binary::from_base64(
+		"image/png",
+		"BASE64PNG",
+		None,
+	)]);
+	let tool_response_2 =
+		ToolResponse::new("call_2", "chart built").with_parts([Binary::from_base64("image/jpeg", "BASE64JPEG", None)]);
+	let chat_req = ChatRequest::new(vec![
+		ChatMessage::from(tool_response_1),
+		ChatMessage::from(tool_response_2),
+		ChatMessage::user("continue"),
+	]);
+
+	// -- Exec
+	let web_req = OpenAIAdapter::util_to_web_request_data(
+		target("gpt-4o-mini"),
+		crate::adapter::ServiceType::Chat,
+		chat_req,
+		ChatOptionsSet::default(),
+		None,
+	)?;
+
+	// -- Check
+	let messages = web_req.payload["messages"].as_array().ok_or("messages should be an array")?;
+	assert_eq!(messages.len(), 4, "2 tool + 1 batched image user + 1 user");
+	assert_eq!(
+		messages[0],
+		json!({"role": "tool", "content": "screenshot taken", "tool_call_id": "call_1"})
+	);
+	assert_eq!(
+		messages[1],
+		json!({"role": "tool", "content": "chart built", "tool_call_id": "call_2"})
+	);
+	assert_eq!(
+		messages[2],
+		json!({
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "Attached image(s) from tool result:"},
+				{"type": "image_url", "image_url": {"url": "data:image/png;base64,BASE64PNG"}},
+				{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,BASE64JPEG"}},
+			]
+		}),
+		"images from the run of tool messages must batch into one follow-up user message"
+	);
+	assert_eq!(messages[3], json!({"role": "user", "content": "continue"}));
+
+	Ok(())
+}
+
+/// An image-only tool response (no text) gets the "(see attached image)" placeholder
+/// as the tool message content.
+#[test]
+fn test_tool_response_image_only_uses_placeholder_text() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_response = ToolResponse::new("call_1", "").with_parts([Binary::from_base64("image/png", "PNG64", None)]);
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(tool_response)]);
+
+	// -- Exec
+	let web_req = OpenAIAdapter::util_to_web_request_data(
+		target("gpt-4o-mini"),
+		crate::adapter::ServiceType::Chat,
+		chat_req,
+		ChatOptionsSet::default(),
+		None,
+	)?;
+
+	// -- Check
+	assert_eq!(
+		web_req.payload["messages"][0],
+		json!({"role": "tool", "content": "(see attached image)", "tool_call_id": "call_1"})
+	);
+	assert_eq!(
+		web_req.payload["messages"][1]["content"][1]["image_url"]["url"],
+		json!("data:image/png;base64,PNG64")
+	);
+
+	Ok(())
+}
+
+/// Regression guard: a text-only `ToolResponse` must serialize exactly as before,
+/// with no follow-up user message.
+#[test]
+fn test_tool_response_text_only_serializes_as_before() -> Result<()> {
+	// -- Setup & Fixtures
+	let chat_req = ChatRequest::new(vec![ChatMessage::from(ToolResponse::new("call_1", "42"))]);
+
+	// -- Exec
+	let web_req = OpenAIAdapter::util_to_web_request_data(
+		target("gpt-4o-mini"),
+		crate::adapter::ServiceType::Chat,
+		chat_req,
+		ChatOptionsSet::default(),
+		None,
+	)?;
+
+	// -- Check
+	let messages = web_req.payload["messages"].as_array().ok_or("messages should be an array")?;
+	assert_eq!(messages.len(), 1, "no follow-up user message for text-only");
+	assert_eq!(
+		messages[0],
+		json!({"role": "tool", "content": "42", "tool_call_id": "call_1"})
+	);
+
+	Ok(())
+}
 
 // region:    --- Support
 

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -7,11 +7,11 @@ use crate::adapter::adapters::openai::cache_policy::{
 use crate::adapter::adapters::openai::schema::{
 	OpenAiResponseFormatPlan, response_format_plan, tool_parameters_schema,
 };
-use crate::adapter::adapters::support::get_api_key;
+use crate::adapter::adapters::support::{TOOL_RESULT_IMAGES_LABEL, get_api_key, tool_response_fallback_text};
 use crate::adapter::{Adapter, AdapterDispatcher, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	CacheControl, ChatOptionsSet, ChatRequest, ChatResponse, ChatRole, ChatStream, ChatStreamResponse, ContentPart,
-	MessageContent, ReasoningEffort, StopReason, Tool, ToolChoice, ToolConfig, ToolName, Usage,
+	MessageContent, ReasoningEffort, StopReason, Tool, ToolChoice, ToolConfig, ToolName, ToolResponse, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{EventSourceStream, WebClient, WebResponse};
@@ -20,6 +20,7 @@ use crate::{ModelIden, ServiceTarget};
 use reqwest::RequestBuilder;
 use serde_json::{Map, Value, json};
 use std::collections::BTreeSet;
+use tracing::warn;
 use value_ext::JsonValueExt;
 
 pub struct OpenAIRespAdapter;
@@ -430,8 +431,19 @@ impl OpenAIRespAdapter {
 
 		let mut unamed_file_count = 0;
 
+		// Images rescued from custom tool outputs (`custom_tool_call_output.output` is a
+		// raw string on the wire, so it cannot carry `input_image` blocks). They ride in a
+		// follow-up `user` message input item. Images from a run of consecutive Tool
+		// messages are batched into one trailing item, emitted before the next non-tool
+		// message (same batching as the Chat Completions serializer).
+		let mut pending_custom_tool_images: Vec<Value> = Vec::new();
+
 		// -- Process the messages
 		for msg in chat_req.messages {
+			if !matches!(msg.role, ChatRole::Tool) && !pending_custom_tool_images.is_empty() {
+				input_items.push(tool_images_user_item(std::mem::take(&mut pending_custom_tool_images)));
+			}
+
 			let cache_controlled = cache_policy.is_some()
 				&& msg
 					.options
@@ -638,22 +650,84 @@ impl OpenAIRespAdapter {
 				ChatRole::Tool => {
 					for part in msg.content {
 						if let ContentPart::ToolResponse(tool_response) = part {
-							let response_type = if custom_call_ids.contains(&tool_response.call_id) {
+							let is_custom = custom_call_ids.contains(&tool_response.call_id);
+							let response_type = if is_custom {
 								"custom_tool_call_output"
 							} else {
 								"function_call_output"
 							};
-							input_items.push(json!({
-								"type": response_type,
-								"call_id": tool_response.call_id,
-								"output": tool_response.content,
-							}));
+							let ToolResponse {
+								call_id,
+								content,
+								parts,
+								..
+							} = tool_response;
+							let parts = parts.unwrap_or_default();
+							let has_parts = !parts.is_empty();
+
+							// The Responses API natively supports `output` as an array of
+							// `input_text` / `input_image` items for function call outputs.
+							// Custom tool outputs are raw strings, so their images are
+							// rescued into a follow-up `user` message input item instead.
+							let mut image_values: Vec<Value> = Vec::new();
+							for binary in parts {
+								if binary.is_image() {
+									image_values.push(json!({
+										"type": "input_image",
+										"detail": "auto",
+										"image_url": binary.into_url(),
+									}));
+								} else {
+									warn!(
+										"ToolResponse binary parts only support images for the OpenAI Responses adapter; skipping non-image part '{}'",
+										binary.content_type
+									);
+								}
+							}
+
+							if is_custom {
+								// NOTE: The fallback text applies only when parts were present, so
+								//       plain text-only responses keep their exact legacy serialization.
+								let output = if has_parts {
+									tool_response_fallback_text(content, !image_values.is_empty())
+								} else {
+									content
+								};
+								input_items.push(json!({
+									"type": response_type,
+									"call_id": call_id,
+									"output": output,
+								}));
+								pending_custom_tool_images.extend(image_values);
+							} else if image_values.is_empty() {
+								input_items.push(json!({
+									"type": response_type,
+									"call_id": call_id,
+									"output": content,
+								}));
+							} else {
+								let mut output: Vec<Value> = Vec::new();
+								if !content.is_empty() {
+									output.push(json!({"type": "input_text", "text": content}));
+								}
+								output.extend(image_values);
+								input_items.push(json!({
+									"type": response_type,
+									"call_id": call_id,
+									"output": output,
+								}));
+							}
 						}
 					}
 
 					// TODO: Probably need to trace/warn that this will be ignored
 				}
 			}
+		}
+
+		// Flush custom-tool-result images from a trailing run of Tool messages.
+		if !pending_custom_tool_images.is_empty() {
+			input_items.push(tool_images_user_item(pending_custom_tool_images));
 		}
 
 		// -- Process the tools
@@ -731,6 +805,16 @@ struct OpenAIRespRequestParts {
 	tools: Option<Vec<Value>>,
 }
 
+/// Build the follow-up `user` message input item that carries tool-result images
+/// (`ToolResponse.parts`) rescued from custom tool outputs, since
+/// `custom_tool_call_output.output` is a raw string and cannot include image blocks.
+fn tool_images_user_item(image_values: Vec<Value>) -> Value {
+	let mut content: Vec<Value> = Vec::with_capacity(image_values.len() + 1);
+	content.push(json!({"type": "input_text", "text": TOOL_RESULT_IMAGES_LABEL}));
+	content.extend(image_values);
+	json!({"type": "message", "role": "user", "content": content})
+}
+
 fn apply_resp_cache_breakpoint(_model_iden: &ModelIden, content: &mut [Value], _scope: &'static str) -> Result<()> {
 	let Some(content_block) = content.iter_mut().rev().find(|value| {
 		matches!(
@@ -755,7 +839,7 @@ mod tests {
 
 	use super::*;
 	use crate::adapter::AdapterKind;
-	use crate::chat::{ChatMessage, ChatOptions, JsonSpec, Tool, ToolCall, ToolChoice, ToolResponse};
+	use crate::chat::{Binary, ChatMessage, ChatOptions, JsonSpec, Tool, ToolCall, ToolChoice};
 
 	#[test]
 	fn test_cache_control_without_eligible_content_does_not_fail_response_request() {
@@ -825,6 +909,177 @@ mod tests {
 		assert!(input.iter().any(|item| {
 			item["type"] == "custom_tool_call_output" && item["call_id"] == "call_patch" && item["output"] == "Done!"
 		}));
+	}
+
+	/// A `ToolResponse` with an image part must serialize natively as a
+	/// `function_call_output` whose `output` is an array of `input_text` / `input_image`
+	/// items (the Responses API supports image function-call outputs natively).
+	#[test]
+	fn test_tool_response_image_part_serializes_native_output_array() {
+		// -- Setup & Fixtures
+		let target = ServiceTarget {
+			model: ModelIden::new(AdapterKind::OpenAIResp, "gpt-5.6"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: OpenAIRespAdapter::default_endpoint(AdapterKind::OpenAIResp),
+		};
+		let tool_response = ToolResponse::new("call_1", "screenshot taken").with_parts([Binary::from_base64(
+			"image/png",
+			"PNG64",
+			None,
+		)]);
+		let chat_req = ChatRequest::new(vec![ChatMessage::from(tool_response)]);
+
+		// -- Exec
+		let web_req =
+			OpenAIRespAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, ChatOptionsSet::default())
+				.expect("to_web_request_data should succeed");
+
+		// -- Check
+		let input = web_req.payload["input"].as_array().expect("input array");
+		let item = input
+			.iter()
+			.find(|item| item["type"] == "function_call_output")
+			.expect("function_call_output item must be present");
+		assert_eq!(item["call_id"], "call_1");
+		assert_eq!(
+			item["output"],
+			json!([
+				{"type": "input_text", "text": "screenshot taken"},
+				{"type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,PNG64"},
+			])
+		);
+	}
+
+	/// Regression guard: a text-only `ToolResponse` must keep `output` as a plain string.
+	#[test]
+	fn test_tool_response_text_only_output_stays_string() {
+		// -- Setup & Fixtures
+		let target = ServiceTarget {
+			model: ModelIden::new(AdapterKind::OpenAIResp, "gpt-5.6"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: OpenAIRespAdapter::default_endpoint(AdapterKind::OpenAIResp),
+		};
+		let chat_req = ChatRequest::new(vec![ChatMessage::from(ToolResponse::new("call_1", "42"))]);
+
+		// -- Exec
+		let web_req =
+			OpenAIRespAdapter::to_web_request_data(target, ServiceType::Chat, chat_req, ChatOptionsSet::default())
+				.expect("to_web_request_data should succeed");
+
+		// -- Check
+		let input = web_req.payload["input"].as_array().expect("input array");
+		let item = input
+			.iter()
+			.find(|item| item["type"] == "function_call_output")
+			.expect("function_call_output item must be present");
+		assert_eq!(
+			item["output"],
+			json!("42"),
+			"text-only output must remain a plain string"
+		);
+	}
+
+	/// A `ToolResponse` whose `call_id` belongs to a CUSTOM tool serializes as a
+	/// `custom_tool_call_output` with a raw string `output` (placeholder text when the
+	/// result is image-only), and its image parts are rescued into a follow-up `user`
+	/// message input item right after the output item.
+	#[test]
+	fn test_custom_tool_response_image_part_rides_in_followup_user_item() {
+		// -- Setup & Fixtures
+		let target = ServiceTarget {
+			model: ModelIden::new(AdapterKind::OpenAIResp, "gpt-5.6"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: OpenAIRespAdapter::default_endpoint(AdapterKind::OpenAIResp),
+		};
+		let assistant = ChatMessage::assistant(vec![ToolCall {
+			call_id: "call_patch".to_string(),
+			fn_name: "apply_patch".to_string(),
+			fn_arguments: Value::String("some patch".to_string()),
+			thought_signatures: None,
+		}]);
+		let response = ChatMessage::from(ToolResponse::new("call_patch", "").with_parts([Binary::from_base64(
+			"image/png",
+			"PNG64",
+			None,
+		)]));
+		let request = ChatRequest::new(vec![ChatMessage::user("patch it"), assistant, response]).with_tools(vec![
+			Tool::new("apply_patch").with_custom_format(json!({"type": "text"})),
+		]);
+
+		// -- Exec
+		let web_req =
+			OpenAIRespAdapter::to_web_request_data(target, ServiceType::Chat, request, ChatOptionsSet::default())
+				.expect("to_web_request_data should succeed");
+
+		// -- Check
+		let input = web_req.payload["input"].as_array().expect("input array");
+		let output_idx = input
+			.iter()
+			.position(|item| item["type"] == "custom_tool_call_output")
+			.expect("custom_tool_call_output item must be present");
+		assert_eq!(input[output_idx]["call_id"], "call_patch");
+		assert_eq!(
+			input[output_idx]["output"],
+			json!("(see attached image)"),
+			"custom output must stay a raw string with the image placeholder"
+		);
+		let followup = input
+			.get(output_idx + 1)
+			.expect("follow-up user message item must come right after the custom output");
+		assert_eq!(
+			*followup,
+			json!({
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": TOOL_RESULT_IMAGES_LABEL},
+					{"type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,PNG64"},
+				]
+			})
+		);
+	}
+
+	/// Regression guard: a text-only custom tool output keeps its raw-string `output`
+	/// and does NOT get a follow-up user message item.
+	#[test]
+	fn test_custom_tool_response_text_only_has_no_followup_item() {
+		// -- Setup & Fixtures
+		let target = ServiceTarget {
+			model: ModelIden::new(AdapterKind::OpenAIResp, "gpt-5.6"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: OpenAIRespAdapter::default_endpoint(AdapterKind::OpenAIResp),
+		};
+		let assistant = ChatMessage::assistant(vec![ToolCall {
+			call_id: "call_patch".to_string(),
+			fn_name: "apply_patch".to_string(),
+			fn_arguments: Value::String("some patch".to_string()),
+			thought_signatures: None,
+		}]);
+		let response = ChatMessage::from(ToolResponse::new("call_patch", "Done!"));
+		let request = ChatRequest::new(vec![ChatMessage::user("patch it"), assistant, response]).with_tools(vec![
+			Tool::new("apply_patch").with_custom_format(json!({"type": "text"})),
+		]);
+
+		// -- Exec
+		let web_req =
+			OpenAIRespAdapter::to_web_request_data(target, ServiceType::Chat, request, ChatOptionsSet::default())
+				.expect("to_web_request_data should succeed");
+
+		// -- Check
+		let input = web_req.payload["input"].as_array().expect("input array");
+		let item = input
+			.iter()
+			.find(|item| item["type"] == "custom_tool_call_output")
+			.expect("custom_tool_call_output item must be present");
+		assert_eq!(
+			item["output"],
+			json!("Done!"),
+			"text-only output must remain the raw string"
+		);
+		assert!(
+			!input.iter().any(|item| item["content"][0]["text"] == TOOL_RESULT_IMAGES_LABEL),
+			"no follow-up tool-images user item must be emitted for a text-only custom output"
+		);
 	}
 
 	#[test]

--- a/src/adapter/adapters/support.rs
+++ b/src/adapter/adapters/support.rs
@@ -13,6 +13,35 @@ pub fn get_api_key(auth: AuthData, model: &ModelIden) -> Result<String> {
 	})
 }
 
+// region:    --- Tool Response Binary Parts
+
+/// Leading text of the follow-up `user` message that carries tool-result images on
+/// wire formats that cannot express images inside the tool-result item itself
+/// (e.g., OpenAI Chat Completions `tool` messages, Gemini `functionResponse`, Ollama).
+pub const TOOL_RESULT_IMAGES_LABEL: &str = "Attached image(s) from tool result:";
+
+/// Resolve the text content of a tool-result message when the `ToolResponse`
+/// carries binary parts.
+///
+/// - Non-empty text content is kept as-is.
+/// - Empty text with image parts becomes the `"(see attached image)"` placeholder,
+///   pointing the model at the follow-up user message that carries the images.
+/// - Empty text without any usable image part becomes `"(no tool output)"`.
+///
+/// NOTE: Only called when `ToolResponse.parts` is present, so plain text-only
+///       responses keep their exact legacy serialization.
+pub fn tool_response_fallback_text(content: String, has_images: bool) -> String {
+	if !content.is_empty() {
+		content
+	} else if has_images {
+		"(see attached image)".to_string()
+	} else {
+		"(no tool output)".to_string()
+	}
+}
+
+// endregion: --- Tool Response Binary Parts
+
 // region:    --- StreamerChatOptions
 
 #[derive(Debug)]

--- a/src/chat/tool/tool_response.rs
+++ b/src/chat/tool/tool_response.rs
@@ -1,4 +1,5 @@
 use super::ToolCall;
+use crate::chat::Binary;
 use serde::{Deserialize, Serialize};
 
 /// Response produced by a tool invocation, paired with the originating tool call ID.
@@ -15,6 +16,16 @@ pub struct ToolResponse {
 	/// Tool output payload as a string. Providers may use JSON-serialized content.
 	// For now, just a string (would probably be serialized JSON)
 	pub content: String,
+	/// Optional binary attachments produced by the tool (e.g., screenshots, file reads).
+	///
+	/// Image parts serialize natively where the wire supports them (Anthropic
+	/// `tool_result`, Bedrock Converse `toolResult`, OpenAI Responses
+	/// `function_call_output`) and ride in a follow-up user message elsewhere
+	/// (OpenAI Chat Completions-compatible providers, Gemini, Ollama).
+	/// Non-image parts are currently skipped with a warning.
+	/// Text-only responses (no `parts`) keep their exact legacy serialization.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub parts: Option<Vec<Binary>>,
 }
 
 /// Constructor
@@ -25,6 +36,7 @@ impl ToolResponse {
 			call_id: tool_call_id.into(),
 			fn_name: None,
 			content: content.into(),
+			parts: None,
 		}
 	}
 
@@ -34,12 +46,29 @@ impl ToolResponse {
 			call_id: tool_call.call_id.clone(),
 			fn_name: Some(tool_call.fn_name.clone()),
 			content: content.into(),
+			parts: None,
 		}
 	}
 
 	/// Attach the function/tool name to this response.
 	pub fn with_fn_name(mut self, fn_name: impl Into<String>) -> Self {
 		self.fn_name = Some(fn_name.into());
+		self
+	}
+
+	/// Set the binary attachments of this response. Returns self for chaining.
+	pub fn with_parts<I>(mut self, parts: I) -> Self
+	where
+		I: IntoIterator,
+		I::Item: Into<Binary>,
+	{
+		self.parts = Some(parts.into_iter().map(Into::into).collect());
+		self
+	}
+
+	/// Append a single binary attachment to this response. Returns self for chaining.
+	pub fn append_binary(mut self, binary: impl Into<Binary>) -> Self {
+		self.parts.get_or_insert_with(Vec::new).push(binary.into());
 		self
 	}
 }
@@ -49,9 +78,16 @@ impl ToolResponse {
 	/// Returns an approximate in-memory size of this `ToolResponse`, in bytes,
 	/// computed as the sum of the UTF-8 lengths of:
 	/// - `call_id`
+	/// - `fn_name` (if any)
 	/// - `content`
+	/// - plus the `Binary::size()` of each part (if any)
 	pub fn size(&self) -> usize {
-		self.call_id.len() + self.fn_name.as_ref().map(|name| name.len()).unwrap_or(0) + self.content.len()
+		let parts_size: usize = self
+			.parts
+			.as_ref()
+			.map(|parts| parts.iter().map(Binary::size).sum())
+			.unwrap_or_default();
+		self.call_id.len() + self.fn_name.as_ref().map(|name| name.len()).unwrap_or(0) + self.content.len() + parts_size
 	}
 }
 
@@ -69,4 +105,16 @@ impl ToolResponse {
 	fn content(&self) -> &str {
 		&self.content
 	}
+
+	fn parts(&self) -> Option<&[Binary]> {
+		self.parts.as_deref()
+	}
 }
+
+// region:    --- Tests
+
+#[cfg(test)]
+#[path = "tool_response_tests.rs"]
+mod tests;
+
+// endregion: --- Tests

--- a/src/chat/tool/tool_response_tests.rs
+++ b/src/chat/tool/tool_response_tests.rs
@@ -1,0 +1,60 @@
+type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
+
+use super::*;
+use serde_json::json;
+
+/// A text-only ToolResponse must serialize exactly as before the `parts` addition
+/// (no `parts` key), so persisted chat histories keep the same JSON shape.
+#[test]
+fn test_tool_response_text_only_serde_unchanged() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_response = ToolResponse::new("call_1", "42");
+
+	// -- Exec
+	let value = serde_json::to_value(&tool_response)?;
+
+	// -- Check
+	assert_eq!(value, json!({"call_id": "call_1", "content": "42"}));
+
+	Ok(())
+}
+
+/// Legacy JSON (without `parts`) must still deserialize.
+#[test]
+fn test_tool_response_deserialize_legacy_json() -> Result<()> {
+	// -- Setup & Fixtures
+	let legacy_json = json!({"call_id": "call_1", "content": "42"});
+
+	// -- Exec
+	let tool_response: ToolResponse = serde_json::from_value(legacy_json)?;
+
+	// -- Check
+	assert_eq!(tool_response.call_id, "call_1");
+	assert_eq!(tool_response.content, "42");
+	assert!(tool_response.parts.is_none());
+
+	Ok(())
+}
+
+/// `with_parts` and `append_binary` builders populate `parts`, and `parts`
+/// round-trips through serde.
+#[test]
+fn test_tool_response_with_parts_serde_roundtrip() -> Result<()> {
+	// -- Setup & Fixtures
+	let tool_response = ToolResponse::new("call_1", "screenshot taken")
+		.with_parts([Binary::from_base64("image/png", "AAA=", None)])
+		.append_binary(Binary::from_base64("image/jpeg", "BBB=", Some("shot.jpg".to_string())));
+
+	// -- Exec
+	let value = serde_json::to_value(&tool_response)?;
+	let back: ToolResponse = serde_json::from_value(value)?;
+
+	// -- Check
+	let parts = back.parts.ok_or("should have parts")?;
+	assert_eq!(parts.len(), 2);
+	assert_eq!(parts[0].content_type, "image/png");
+	assert_eq!(parts[1].content_type, "image/jpeg");
+	assert_eq!(parts[1].name.as_deref(), Some("shot.jpg"));
+
+	Ok(())
+}


### PR DESCRIPTION
Part of the #277 split (single-purpose PRs, low-level first, gated on merges). Its only prerequisite — the otel compile gate (#278) — is merged, so this sits as a single commit on current `main`.

`ToolResponse` was text-only, forcing agentic harnesses to degrade tool-produced images (screenshots, file reads) to text markers even though provider APIs can carry them. This adds an additive `parts: Option<Vec<Binary>>` field (serde-skipped when absent) with `with_parts` / `append_binary` builders, and serializes image parts on every adapter.

**Changed**
- `src/chat/tool/tool_response.rs`: `parts` field + builders.
- Native image serialization where the wire supports it: Anthropic `tool_result` image blocks, Bedrock Converse `toolResult` image blocks, OpenAI Responses `function_call_output` output arrays.
- Follow-up user-message carriage elsewhere: OpenAI Chat Completions-compatible providers (batched across a tool-message run), Gemini (after the merged `functionResponse` turn), Ollama (native `images` array); `"(see attached image)"` placeholder for image-only results.
- Shared helpers in `adapters/support.rs` (`TOOL_RESULT_IMAGES_LABEL`, `tool_response_fallback_text`). Non-image parts are skipped with a warning; text-only responses keep byte-identical previous output. CHANGELOG + `dev/specs/spec-tool.md` / `spec-chat.md`.

**Breaking**: downstream `ToolResponse` struct literals must add `parts: None` (or use the builders).

**Foundation for the rest of the split**: the next two PRs (embedded tool responses, Anthropic URL images) build on `ToolResponse.parts` and these helpers, and will follow after this.

**Tests**: build, `test --lib` (219), `test --lib --features otel` (241), `fmt`, `clippy` clean; the five yakbak replay suites pass.