### PR TITLE
feat(anthropic): preserve signed thinking blocks for replay

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -7,7 +7,7 @@ use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	Binary, BinarySource, CacheControl, CacheCreationDetails, ChatOptionsSet, ChatRequest, ChatResponse,
 	ChatResponseFormat, ChatRole, ContentPart, JsonSchemaDialect, MessageContent, PromptTokensDetails, ReasoningEffort,
-	StopReason, Tool, ToolCall, ToolChoice, ToolConfig, ToolName, Usage, sanitize_json_schema,
+	StopReason, ThinkingBlock, Tool, ToolCall, ToolChoice, ToolConfig, ToolName, Usage, sanitize_json_schema,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebClient, WebResponse};
@@ -235,6 +235,7 @@ impl AnthropicAdapter {
 								}
 								ContentPart::ThoughtSignature(_) => {}
 								ContentPart::ReasoningContent(_) => {}
+								ContentPart::Thinking(_) => {}
 								ContentPart::Custom(custom_part) => values.push(custom_part.data),
 							}
 						}
@@ -272,6 +273,16 @@ impl AnthropicAdapter {
 									"name": tool_call.fn_name,
 									"input": input,
 								}));
+							}
+							ContentPart::Thinking(block) => {
+								let mut value = json!({
+									"type": "thinking",
+									"thinking": block.thinking,
+								});
+								if let Some(signature) = block.signature {
+									value.x_insert("signature", signature)?;
+								}
+								values.push(value);
 							}
 							// Unsupported for assistant role in Anthropic message content
 							ContentPart::Binary(_) => {}
@@ -311,6 +322,7 @@ impl AnthropicAdapter {
 								}));
 							}
 							ContentPart::Custom(custom_part) => values.push(custom_part.data),
+							ContentPart::Thinking(_) => {}
 							_ => {}
 						}
 					}
@@ -556,7 +568,12 @@ impl AnthropicAdapter {
 					let part = ContentPart::from_text(item.x_take::<String>("text")?);
 					content.push(part);
 				}
-				"thinking" => reasoning_content.push(item.x_take("thinking")?),
+				"thinking" => {
+					let thinking: String = item.x_take("thinking")?;
+					let signature = item.x_take::<String>("signature").ok();
+					reasoning_content.push(thinking.clone());
+					content.push(ContentPart::Thinking(ThinkingBlock::new(thinking, signature)));
+				}
 				"tool_use" => {
 					let call_id = item.x_take::<String>("id")?;
 					let fn_name = item.x_take::<String>("name")?;

--- a/src/adapter/adapters/anthropic/adapter_shared_tests.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared_tests.rs
@@ -4,8 +4,90 @@ use super::*;
 use crate::ServiceTarget;
 use crate::adapter::adapters::anthropic::ant_reasoning::REASONING_HIGH;
 use crate::adapter::{Adapter, ServiceType};
-use crate::chat::{ChatMessage, ChatOptions, ChatRequest, JsonSpec, Tool, ToolChoice};
+use crate::chat::{
+	ChatMessage, ChatOptions, ChatRequest, ContentPart, JsonSpec, MessageContent, ThinkingBlock, Tool, ToolCall,
+	ToolChoice,
+};
 use crate::resolver::AuthData;
+use reqwest::StatusCode;
+
+#[test]
+fn test_anthropic_signed_thinking_round_trip_preserves_block_order() {
+	// Cause/effect graph: C1 an assistant turn contains signed Thinking; C2
+	// public Text follows; C3 ToolCall follows. Effects: E1 request serialization
+	// preserves the exact three-block order and signature; E2 response parsing
+	// reconstructs the same typed order; E3 the legacy normalized reasoning view
+	// remains available. Decision rule R1=C1&C2&C3 => E1+E2+E3.
+	let model = ModelIden::new(AdapterKind::Anthropic, "deepseek-v4-pro");
+	let tool_call = ToolCall {
+		call_id: "toolu_1".into(),
+		fn_name: "read_fixture".into(),
+		fn_arguments: json!({"marker":"anthropic"}),
+		thought_signatures: None,
+	};
+	let assistant = ChatMessage::assistant(MessageContent::from_parts(vec![
+		ContentPart::Thinking(ThinkingBlock::new("choose the fixture", Some("sig-123".into()))),
+		ContentPart::Text("Checking the fixture.".into()),
+		ContentPart::ToolCall(tool_call.clone()),
+	]));
+	let target = ServiceTarget {
+		endpoint: AnthropicAdapter::default_endpoint(AdapterKind::Anthropic),
+		auth: AuthData::from_single("test-key"),
+		model: model.clone(),
+	};
+	let web_req = AnthropicAdapter::to_web_request_data(
+		target,
+		ServiceType::Chat,
+		ChatRequest::new(vec![assistant]),
+		ChatOptionsSet::default(),
+	)
+	.expect("R1/E1 serialize signed thinking");
+	assert_eq!(
+		web_req.payload["messages"][0]["content"],
+		json!([
+			{"type":"thinking", "thinking":"choose the fixture", "signature":"sig-123"},
+			{"type":"text", "text":"Checking the fixture."},
+			{"type":"tool_use", "id":"toolu_1", "name":"read_fixture", "input":{"marker":"anthropic"}}
+		]),
+		"R1/E1"
+	);
+
+	let response = AnthropicAdapter::build_chat_response(
+		model,
+		WebResponse {
+			status: StatusCode::OK,
+			body: json!({
+				"model":"deepseek-v4-pro",
+				"stop_reason":"tool_use",
+				"usage":{"input_tokens":10,"output_tokens":5},
+				"content":[
+					{"type":"thinking", "thinking":"choose the fixture", "signature":"sig-123"},
+					{"type":"text", "text":"Checking the fixture."},
+					{"type":"tool_use", "id":"toolu_1", "name":"read_fixture", "input":{"marker":"anthropic"}}
+				]
+			}),
+		},
+	)
+	.expect("R1/E2 parse signed thinking");
+	let parts = response.content.parts();
+	assert!(
+		matches!(&parts[0], ContentPart::Thinking(block) if block.thinking == "choose the fixture" && block.signature.as_deref() == Some("sig-123")),
+		"R1/E2 thinking"
+	);
+	assert!(
+		matches!(&parts[1], ContentPart::Text(text) if text == "Checking the fixture."),
+		"R1/E2 text"
+	);
+	assert!(
+		matches!(&parts[2], ContentPart::ToolCall(call) if call.call_id == "toolu_1"),
+		"R1/E2 tool"
+	);
+	assert_eq!(
+		response.reasoning_content.as_deref(),
+		Some("choose the fixture"),
+		"R1/E3"
+	);
+}
 
 /// Regression guard: when both `reasoning_effort` and `JsonSpec` response format are set
 /// on a model that uses the `output_config` effort API (e.g. `claude-sonnet-4-6`), both

--- a/src/adapter/adapters/anthropic/streamer.rs
+++ b/src/adapter/adapters/anthropic/streamer.rs
@@ -1,7 +1,9 @@
 use super::parse_cache_creation_details;
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatOptionsSet, PromptTokensDetails, StopReason, ToolCall, Usage};
+use crate::chat::{
+	ChatOptionsSet, ContentPart, MessageContent, PromptTokensDetails, StopReason, ThinkingBlock, ToolCall, Usage,
+};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
 use serde_json::{Map, Value};
@@ -18,13 +20,15 @@ pub struct AnthropicStreamer {
 	done: bool,
 
 	captured_data: StreamerCapturedData,
+	captured_parts: Vec<ContentPart>,
 	in_progress_block: InProgressBlock,
 }
 
 enum InProgressBlock {
-	Text,
+	Idle,
+	Text { content: String },
 	ToolUse { id: String, name: String, input: String },
-	Thinking,
+	Thinking(ThinkingBlock),
 }
 
 impl AnthropicStreamer {
@@ -34,7 +38,8 @@ impl AnthropicStreamer {
 			done: false,
 			options: StreamerOptions::new(model_iden, options_set),
 			captured_data: Default::default(),
-			in_progress_block: InProgressBlock::Text,
+			captured_parts: Vec::new(),
+			in_progress_block: InProgressBlock::Idle,
 		}
 	}
 }
@@ -77,8 +82,17 @@ impl futures::Stream for AnthropicStreamer {
 								})?;
 
 							match data.x_get_str("/content_block/type") {
-								Ok("text") => self.in_progress_block = InProgressBlock::Text,
-								Ok("thinking") => self.in_progress_block = InProgressBlock::Thinking,
+								Ok("text") => {
+									self.in_progress_block = InProgressBlock::Text {
+										content: data.x_take::<String>("/content_block/text").unwrap_or_default(),
+									}
+								}
+								Ok("thinking") => {
+									let thinking = data.x_take::<String>("/content_block/thinking").unwrap_or_default();
+									let signature = data.x_take::<String>("/content_block/signature").ok();
+									self.in_progress_block =
+										InProgressBlock::Thinking(ThinkingBlock::new(thinking, signature));
+								}
 								Ok("tool_use") => {
 									let id: String = data.x_take("/content_block/id")?;
 									let name: String = data.x_take("/content_block/name")?;
@@ -118,18 +132,12 @@ impl futures::Stream for AnthropicStreamer {
 								})?;
 
 							match &mut self.in_progress_block {
-								InProgressBlock::Text => {
-									let content: String = data.x_take("/delta/text")?;
+								InProgressBlock::Idle => continue,
+								InProgressBlock::Text { content } => {
+									let delta: String = data.x_take("/delta/text")?;
+									content.push_str(&delta);
 
-									// Add to the captured_content if chat options say so
-									if self.options.capture_content {
-										match self.captured_data.content {
-											Some(ref mut c) => c.push_str(&content),
-											None => self.captured_data.content = Some(content.clone()),
-										}
-									}
-
-									return Poll::Ready(Some(Ok(InterStreamEvent::Chunk(content))));
+									return Poll::Ready(Some(Ok(InterStreamEvent::Chunk(delta))));
 								}
 								InProgressBlock::ToolUse { id, name, input } => {
 									let partial = data.x_get_str("/delta/partial_json")?;
@@ -146,8 +154,9 @@ impl futures::Stream for AnthropicStreamer {
 
 									return Poll::Ready(Some(Ok(InterStreamEvent::ToolCallChunk(tc))));
 								}
-								InProgressBlock::Thinking => {
+								InProgressBlock::Thinking(block) => {
 									if let Ok(thinking) = data.x_take::<String>("/delta/thinking") {
+										block.thinking.push_str(&thinking);
 										// Add to the captured_thinking if chat options say so
 										if self.options.capture_reasoning_content {
 											match self.captured_data.reasoning_content {
@@ -158,6 +167,10 @@ impl futures::Stream for AnthropicStreamer {
 
 										return Poll::Ready(Some(Ok(InterStreamEvent::ReasoningChunk(thinking))));
 									} else if let Ok(signature) = data.x_take::<String>("/delta/signature") {
+										match &mut block.signature {
+											Some(captured) => captured.push_str(&signature),
+											None => block.signature = Some(signature.clone()),
+										}
 										return Poll::Ready(Some(Ok(InterStreamEvent::ThoughtSignatureChunk(
 											signature,
 										))));
@@ -172,7 +185,13 @@ impl futures::Stream for AnthropicStreamer {
 							}
 						}
 						"content_block_stop" => {
-							match std::mem::replace(&mut self.in_progress_block, InProgressBlock::Text) {
+							match std::mem::replace(&mut self.in_progress_block, InProgressBlock::Idle) {
+								InProgressBlock::Text { content } if self.options.capture_content => {
+									self.captured_parts.push(ContentPart::Text(content));
+								}
+								InProgressBlock::Thinking(block) if self.options.capture_reasoning_content => {
+									self.captured_parts.push(ContentPart::Thinking(block));
+								}
 								InProgressBlock::ToolUse { id, name, input } if self.options.capture_tool_calls => {
 									// ToolCallChunks were already emitted incrementally
 									// during content_block_start and content_block_delta.
@@ -196,10 +215,7 @@ impl futures::Stream for AnthropicStreamer {
 										thought_signatures: None,
 									};
 
-									match self.captured_data.tool_calls {
-										Some(ref mut t) => t.push(tc),
-										None => self.captured_data.tool_calls = Some(vec![tc]),
-									}
+									self.captured_parts.push(ContentPart::ToolCall(tc));
 								}
 								_ => {
 									// no-op for remaining block types
@@ -233,10 +249,9 @@ impl futures::Stream for AnthropicStreamer {
 							let inter_stream_end = InterStreamEnd {
 								captured_usage,
 								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-								captured_text_content: self.captured_data.content.take(),
+								captured_content: (!self.captured_parts.is_empty())
+									.then(|| MessageContent::from_parts(std::mem::take(&mut self.captured_parts))),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
-								captured_tool_calls: self.captured_data.tool_calls.take(),
-								captured_thought_signatures: None,
 								captured_response_id: None,
 							};
 

--- a/src/adapter/adapters/bedrock/converse.rs
+++ b/src/adapter/adapters/bedrock/converse.rs
@@ -346,6 +346,7 @@ fn user_content_to_converse_blocks(content: MessageContent) -> Vec<Value> {
 			ContentPart::ToolCall(_) => {}
 			ContentPart::ThoughtSignature(_) => {}
 			ContentPart::ReasoningContent(_) => {}
+			ContentPart::Thinking(_) => {}
 			ContentPart::Custom(_) => {}
 		}
 	}
@@ -376,6 +377,7 @@ fn assistant_content_to_converse_blocks(content: MessageContent) -> Vec<Value> {
 			ContentPart::ToolResponse(_) => {}
 			ContentPart::ThoughtSignature(_) => {}
 			ContentPart::ReasoningContent(_) => {}
+			ContentPart::Thinking(_) => {}
 			ContentPart::Custom(_) => {}
 		}
 	}

--- a/src/adapter/adapters/bedrock/streamer.rs
+++ b/src/adapter/adapters/bedrock/streamer.rs
@@ -16,7 +16,7 @@
 //! See: https://docs.aws.amazon.com/transcribe/latest/dg/event-stream.html
 
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
-use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
+use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent, assemble_captured_content};
 use crate::chat::{ChatOptionsSet, StopReason, ToolCall, Usage};
 use crate::{Error, ModelIden, Result};
 use bytes::{Buf, BytesMut};
@@ -251,10 +251,12 @@ impl BedrockStreamer {
 		let end = InterStreamEnd {
 			captured_usage,
 			captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-			captured_text_content: self.captured_data.content.take(),
+			captured_content: assemble_captured_content(
+				self.captured_data.content.take(),
+				self.captured_data.tool_calls.take(),
+				None,
+			),
 			captured_reasoning_content: self.captured_data.reasoning_content.take(),
-			captured_tool_calls: self.captured_data.tool_calls.take(),
-			captured_thought_signatures: None,
 			captured_response_id: None,
 		};
 		InterStreamEvent::End(end)

--- a/src/adapter/adapters/cohere/streamer.rs
+++ b/src/adapter/adapters/cohere/streamer.rs
@@ -1,6 +1,6 @@
 use crate::adapter::adapters::cohere::CohereAdapter;
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
-use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
+use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent, assemble_captured_content};
 use crate::chat::{ChatOptionsSet, StopReason};
 use crate::webc::WebStream;
 use crate::{Error, ModelIden, Result};
@@ -114,10 +114,12 @@ impl futures::Stream for CohereStreamer {
 											.stop_reason
 											.take()
 											.map(StopReason::from),
-										captured_text_content: self.captured_data.content.take(),
+										captured_content: assemble_captured_content(
+											self.captured_data.content.take(),
+											self.captured_data.tool_calls.take(),
+											None,
+										),
 										captured_reasoning_content: self.captured_data.reasoning_content.take(),
-										captured_tool_calls: self.captured_data.tool_calls.take(),
-										captured_thought_signatures: None,
 										captured_response_id: None,
 									};
 

--- a/src/adapter/adapters/gemini/adapter_impl.rs
+++ b/src/adapter/adapters/gemini/adapter_impl.rs
@@ -648,6 +648,7 @@ impl GeminiAdapter {
 							}
 
 							ContentPart::ReasoningContent(_) => {}
+							ContentPart::Thinking(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}
@@ -718,6 +719,7 @@ impl GeminiAdapter {
 								}
 							}
 							ContentPart::ReasoningContent(_) => {}
+							ContentPart::Thinking(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}

--- a/src/adapter/adapters/gemini/streamer.rs
+++ b/src/adapter/adapters/gemini/streamer.rs
@@ -1,6 +1,6 @@
 use super::{GeminiAdapter, GeminiChatResponse};
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
-use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
+use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent, assemble_captured_content};
 use crate::chat::{ChatOptionsSet, StopReason, ToolCall};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
@@ -41,10 +41,12 @@ impl GeminiStreamer {
 		let inter_stream_end = InterStreamEnd {
 			captured_usage: self.captured_data.usage.take(),
 			captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-			captured_text_content: self.captured_data.content.take(),
+			captured_content: assemble_captured_content(
+				self.captured_data.content.take(),
+				self.captured_data.tool_calls.take(),
+				self.captured_data.thought_signatures.take(),
+			),
 			captured_reasoning_content: self.captured_data.reasoning_content.take(),
-			captured_tool_calls: self.captured_data.tool_calls.take(),
-			captured_thought_signatures: self.captured_data.thought_signatures.take(),
 			captured_response_id: None,
 		};
 		self.pending_events.push_back(InterStreamEvent::End(inter_stream_end));

--- a/src/adapter/adapters/ollama/streamer.rs
+++ b/src/adapter/adapters/ollama/streamer.rs
@@ -1,5 +1,5 @@
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
-use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
+use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent, assemble_captured_content};
 use crate::chat::{ChatOptionsSet, StopReason, ToolCall, Usage};
 use crate::webc::WebStream;
 use crate::{Error, ModelIden, Result};
@@ -159,10 +159,12 @@ impl futures::Stream for OllamaStreamer {
 							let inter_stream_end = InterStreamEnd {
 								captured_usage: self.captured_data.usage.take(),
 								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-								captured_text_content: self.captured_data.content.take(),
+								captured_content: assemble_captured_content(
+									self.captured_data.content.take(),
+									self.captured_data.tool_calls.take(),
+									None,
+								),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
-								captured_tool_calls: self.captured_data.tool_calls.take(),
-								captured_thought_signatures: None,
 								captured_response_id: None,
 							};
 
@@ -183,10 +185,12 @@ impl futures::Stream for OllamaStreamer {
 						let inter_stream_end = InterStreamEnd {
 							captured_usage: self.captured_data.usage.take(),
 							captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-							captured_text_content: self.captured_data.content.take(),
+							captured_content: assemble_captured_content(
+								self.captured_data.content.take(),
+								self.captured_data.tool_calls.take(),
+								None,
+							),
 							captured_reasoning_content: self.captured_data.reasoning_content.take(),
-							captured_tool_calls: self.captured_data.tool_calls.take(),
-							captured_thought_signatures: None,
 							captured_response_id: None,
 						};
 						return Poll::Ready(Some(Ok(InterStreamEvent::End(inter_stream_end))));

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -401,6 +401,7 @@ impl OpenAIAdapter {
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
 								ContentPart::ReasoningContent(_) => (),
+								ContentPart::Thinking(_) => (),
 								// Custom are ignored for this logic
 								ContentPart::Custom(_) => {}
 							}
@@ -438,6 +439,7 @@ impl OpenAIAdapter {
 							ContentPart::Binary(_) => (),
 							ContentPart::ToolResponse(_) => (),
 							ContentPart::ThoughtSignature(_) => {}
+							ContentPart::Thinking(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}

--- a/src/adapter/adapters/openai/streamer.rs
+++ b/src/adapter/adapters/openai/streamer.rs
@@ -1,7 +1,7 @@
 use super::OpenAIAdapter;
 use crate::adapter::AdapterKind;
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
-use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
+use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent, assemble_captured_content};
 use crate::chat::{ChatOptionsSet, StopReason, ToolCall, Usage};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
@@ -194,10 +194,12 @@ impl futures::Stream for OpenAIStreamer {
 						let inter_stream_end = InterStreamEnd {
 							captured_usage,
 							captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-							captured_text_content: self.captured_data.content.take(),
+							captured_content: assemble_captured_content(
+								self.captured_data.content.take(),
+								captured_tool_calls,
+								None,
+							),
 							captured_reasoning_content: self.captured_data.reasoning_content.take(),
-							captured_tool_calls,
-							captured_thought_signatures: None,
 							captured_response_id: None,
 						};
 

--- a/src/adapter/adapters/openai_resp/adapter_impl.rs
+++ b/src/adapter/adapters/openai_resp/adapter_impl.rs
@@ -521,6 +521,7 @@ impl OpenAIRespAdapter {
 								ContentPart::ToolResponse(_) => (),
 								ContentPart::ThoughtSignature(_) => (),
 								ContentPart::ReasoningContent(_) => (),
+								ContentPart::Thinking(_) => (),
 								// Custom are ignored for this logic
 								ContentPart::Custom(_) => {}
 							}
@@ -619,6 +620,7 @@ impl OpenAIRespAdapter {
 							// top-level `type:reasoning` items in the pre-pass above.
 							ContentPart::ThoughtSignature(_) => {}
 							ContentPart::ReasoningContent(_) => {}
+							ContentPart::Thinking(_) => {}
 							// Custom are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}

--- a/src/adapter/adapters/openai_resp/streamer.rs
+++ b/src/adapter/adapters/openai_resp/streamer.rs
@@ -1,6 +1,6 @@
 use super::RespResponse;
 use crate::adapter::adapters::support::{StreamerCapturedData, StreamerOptions};
-use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
+use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent, assemble_captured_content};
 use crate::chat::{ChatOptionsSet, StopReason, ToolCall};
 use crate::webc::{Event, EventSourceStream};
 use crate::{Error, ModelIden, Result};
@@ -355,10 +355,12 @@ impl futures::Stream for OpenAIRespStreamer {
 							let inter_stream_end = InterStreamEnd {
 								captured_usage: self.captured_data.usage.take(),
 								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-								captured_text_content: self.captured_data.content.take(),
+								captured_content: assemble_captured_content(
+									self.captured_data.content.take(),
+									self.captured_data.tool_calls.take(),
+									self.captured_data.thought_signatures.take(),
+								),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
-								captured_tool_calls: self.captured_data.tool_calls.take(),
-								captured_thought_signatures: self.captured_data.thought_signatures.take(),
 								captured_response_id: Some(response.id),
 							};
 
@@ -388,10 +390,12 @@ impl futures::Stream for OpenAIRespStreamer {
 							let inter_stream_end = InterStreamEnd {
 								captured_usage: response.usage.map(Into::into),
 								captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-								captured_text_content: self.captured_data.content.take(),
+								captured_content: assemble_captured_content(
+									self.captured_data.content.take(),
+									self.captured_data.tool_calls.take(),
+									None,
+								),
 								captured_reasoning_content: self.captured_data.reasoning_content.take(),
-								captured_tool_calls: self.captured_data.tool_calls.take(),
-								captured_thought_signatures: None,
 								captured_response_id: Some(resp_id),
 							};
 
@@ -417,10 +421,12 @@ impl futures::Stream for OpenAIRespStreamer {
 						let inter_stream_end = InterStreamEnd {
 							captured_usage: self.captured_data.usage.take(),
 							captured_stop_reason: self.captured_data.stop_reason.take().map(StopReason::from),
-							captured_text_content: self.captured_data.content.take(),
+							captured_content: assemble_captured_content(
+								self.captured_data.content.take(),
+								self.captured_data.tool_calls.take(),
+								None,
+							),
 							captured_reasoning_content: self.captured_data.reasoning_content.take(),
-							captured_tool_calls: self.captured_data.tool_calls.take(),
-							captured_thought_signatures: None,
 							captured_response_id: None,
 						};
 						return Poll::Ready(Some(Ok(InterStreamEvent::End(inter_stream_end))));

--- a/src/adapter/inter_stream.rs
+++ b/src/adapter/inter_stream.rs
@@ -5,7 +5,7 @@
 //!
 //! NOTE: This might be removed at some point as it may not be needed, and we could go directly to the GenAI stream.
 
-use crate::chat::{StopReason, Usage};
+use crate::chat::{ContentPart, MessageContent, StopReason, ToolCall, Usage};
 
 #[derive(Debug, Default)]
 pub struct InterStreamEnd {
@@ -15,20 +15,38 @@ pub struct InterStreamEnd {
 	// Normalised stop reason.
 	pub captured_stop_reason: Option<StopReason>,
 
-	// When `ChatOptions..capture_content == true`
-	pub captured_text_content: Option<String>,
+	// Exact ordered assistant content captured by the provider streamer.
+	pub captured_content: Option<MessageContent>,
 
 	// When `ChatOptions..capture_reasoning_content == true`
 	pub captured_reasoning_content: Option<String>,
 
-	// When `ChatOptions..capture_tool_calls == true`
-	pub captured_tool_calls: Option<Vec<crate::chat::ToolCall>>,
-
-	// When `ChatOptions..capture_thought_signatures == true` (implied or explicit)
-	pub captured_thought_signatures: Option<Vec<String>>,
-
 	// Response ID for stateful sessions (OpenAI Responses API).
 	pub captured_response_id: Option<String>,
+}
+
+/// Assemble the legacy split capture accumulators into the one ordered terminal
+/// content representation. Provider streamers with native block ordering should
+/// construct `MessageContent` directly instead.
+pub(crate) fn assemble_captured_content(
+	text: Option<String>,
+	mut tool_calls: Option<Vec<ToolCall>>,
+	thought_signatures: Option<Vec<String>>,
+) -> Option<MessageContent> {
+	let mut parts = Vec::new();
+	if let Some(thought_signatures) = thought_signatures {
+		if let Some(first_call) = tool_calls.as_mut().and_then(|calls| calls.first_mut()) {
+			first_call.thought_signatures = Some(thought_signatures.clone());
+		}
+		parts.extend(thought_signatures.into_iter().map(ContentPart::ThoughtSignature));
+	}
+	if let Some(text) = text {
+		parts.push(ContentPart::Text(text));
+	}
+	if let Some(tool_calls) = tool_calls {
+		parts.extend(tool_calls.into_iter().map(ContentPart::ToolCall));
+	}
+	(!parts.is_empty()).then(|| MessageContent::from_parts(parts))
 }
 
 /// Intermediary StreamEvent

--- a/src/chat/chat_message.rs
+++ b/src/chat/chat_message.rs
@@ -1,4 +1,4 @@
-use crate::chat::{ContentPart, MessageContent, ToolCall, ToolResponse};
+use crate::chat::{ContentPart, MessageContent, ThinkingBlock, ToolCall, ToolResponse};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 
@@ -89,6 +89,12 @@ impl ChatMessage {
 		if let Some(reasoning) = reasoning {
 			self.content.push(ContentPart::ReasoningContent(reasoning));
 		}
+		self
+	}
+
+	/// Append one provider-issued signed thinking block to this message.
+	pub fn with_thinking(mut self, thinking: ThinkingBlock) -> Self {
+		self.content.push(ContentPart::Thinking(thinking));
 		self
 	}
 

--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -1,5 +1,5 @@
 use crate::adapter::inter_stream::{InterStreamEnd, InterStreamEvent};
-use crate::chat::{ChatMessage, ContentPart, MessageContent, StopReason, ToolCall, Usage};
+use crate::chat::{ChatMessage, MessageContent, StopReason, ToolCall, Usage};
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
@@ -186,58 +186,10 @@ pub struct StreamEnd {
 
 impl From<InterStreamEnd> for StreamEnd {
 	fn from(inter_end: InterStreamEnd) -> Self {
-		let captured_text_content = inter_end.captured_text_content;
-		let mut captured_tool_calls = inter_end.captured_tool_calls;
-
-		// -- create public captured_content
-		// Ordering policy: ThoughtSignature -> Text -> ToolCall
-		// This matches provider expectations (e.g., Gemini 3 requires thought first).
-		let mut captured_content: Option<MessageContent> = None;
-		if let Some(captured_thoughts) = inter_end.captured_thought_signatures {
-			let thoughts_content = captured_thoughts
-				.into_iter()
-				.map(ContentPart::ThoughtSignature)
-				.collect::<Vec<_>>();
-			// Also attach thoughts to the first tool call so that
-			// ChatMessage::from(Vec<ToolCall>) can auto-prepend them.
-			if let Some(tool_calls) = captured_tool_calls.as_mut()
-				&& let Some(first_call) = tool_calls.first_mut()
-			{
-				first_call.thought_signatures = Some(
-					thoughts_content
-						.iter()
-						.filter_map(|p| p.as_thought_signature().map(|s| s.to_string()))
-						.collect(),
-				);
-			}
-			if let Some(existing_content) = &mut captured_content {
-				existing_content.extend_front(thoughts_content);
-			} else {
-				captured_content = Some(MessageContent::from_parts(thoughts_content));
-			}
-		}
-		if let Some(captured_text_content) = captured_text_content {
-			// This `captured_text_content` is the concatenation of all text chunks received.
-			if let Some(existing_content) = &mut captured_content {
-				existing_content.extend(MessageContent::from_text(captured_text_content));
-			} else {
-				captured_content = Some(MessageContent::from_text(captured_text_content));
-			}
-		}
-		if let Some(captured_tool_calls) = captured_tool_calls {
-			if let Some(existing_content) = &mut captured_content {
-				existing_content.extend(MessageContent::from_tool_calls(captured_tool_calls));
-			} else {
-				// This `captured_tool_calls` is the concatenation of all tool call chunks received.
-				captured_content = Some(MessageContent::from_tool_calls(captured_tool_calls));
-			}
-		}
-
-		// -- Return result
 		StreamEnd {
 			captured_usage: inter_end.captured_usage,
 			captured_stop_reason: inter_end.captured_stop_reason,
-			captured_content,
+			captured_content: inter_end.captured_content,
 			captured_reasoning_content: inter_end.captured_reasoning_content,
 			captured_response_id: inter_end.captured_response_id,
 		}
@@ -313,22 +265,11 @@ impl StreamEnd {
 	/// were captured.
 	pub fn into_assistant_message_for_tool_use(self) -> Option<ChatMessage> {
 		let content = self.captured_content?;
-		let mut thought_signatures: Vec<String> = Vec::new();
-		let mut tool_calls: Vec<ToolCall> = Vec::new();
-		for part in content.into_parts() {
-			match part {
-				ContentPart::ThoughtSignature(t) => thought_signatures.push(t),
-				ContentPart::ToolCall(tc) => tool_calls.push(tc),
-				_ => {}
-			}
-		}
-		if tool_calls.is_empty() {
+		if !content.contains_tool_call() {
 			return None;
 		}
-		Some(
-			ChatMessage::assistant_tool_calls_with_thoughts(tool_calls, thought_signatures)
-				.with_reasoning_content(self.captured_reasoning_content),
-		)
+		let message = ChatMessage::assistant(content);
+		Some(message.with_reasoning_content(self.captured_reasoning_content))
 	}
 }
 

--- a/src/chat/content_part/common.rs
+++ b/src/chat/content_part/common.rs
@@ -1,4 +1,4 @@
-use crate::chat::{Binary, CustomPart, ToolCall, ToolResponse};
+use crate::chat::{Binary, CustomPart, ThinkingBlock, ToolCall, ToolResponse};
 use crate::{ModelIden, Result};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
@@ -32,6 +32,10 @@ pub enum ContentPart {
 	/// (e.g., sibling `reasoning_content` field for OpenAI-compatible providers).
 	#[from(ignore)]
 	ReasoningContent(String),
+	/// Anthropic-style signed thinking. Unlike `ReasoningContent`, the optional
+	/// signature is part of the block and must survive an assistant replay.
+	#[from]
+	Thinking(ThinkingBlock),
 
 	#[from]
 	Custom(CustomPart),
@@ -82,6 +86,10 @@ impl ContentPart {
 
 	pub fn from_custom(data: Value, model_iden: Option<ModelIden>) -> Self {
 		ContentPart::Custom(CustomPart { data, model_iden })
+	}
+
+	pub fn from_thinking(thinking: impl Into<String>, signature: Option<String>) -> Self {
+		ContentPart::Thinking(ThinkingBlock::new(thinking, signature))
 	}
 }
 
@@ -195,6 +203,22 @@ impl ContentPart {
 		}
 	}
 
+	pub fn as_thinking(&self) -> Option<&ThinkingBlock> {
+		if let ContentPart::Thinking(thinking) = self {
+			Some(thinking)
+		} else {
+			None
+		}
+	}
+
+	pub fn into_thinking(self) -> Option<ThinkingBlock> {
+		if let ContentPart::Thinking(thinking) = self {
+			Some(thinking)
+		} else {
+			None
+		}
+	}
+
 	/// Borrow the custom part if present.
 	pub fn as_custom(&self) -> Option<&CustomPart> {
 		if let ContentPart::Custom(custom_part) = self {
@@ -218,7 +242,7 @@ impl ContentPart {
 impl ContentPart {
 	/// Returns an approximate in-memory size of this `ContentPart`, in bytes.
 	///
-	/// - For `Text`, `ThoughtSignature`, and `ReasoningContent`: the UTF-8 length of the string.
+	/// - For textual and thinking parts: the UTF-8 length of their owned strings.
 	/// - For `Binary`: delegates to `Binary::size()`.
 	/// - For `ToolCall`: delegates to `ToolCall::size()`.
 	/// - For `ToolResponse`: delegates to `ToolResponse::size()`.
@@ -230,6 +254,9 @@ impl ContentPart {
 			ContentPart::ToolResponse(tool_response) => tool_response.size(),
 			ContentPart::ThoughtSignature(thought) => thought.len(),
 			ContentPart::ReasoningContent(reasoning) => reasoning.len(),
+			ContentPart::Thinking(thinking) => {
+				thinking.thinking.len() + thinking.signature.as_ref().map_or(0, String::len)
+			}
 			ContentPart::Custom(_value) => 0, // TODO: will need to compute this size
 		}
 	}
@@ -299,6 +326,10 @@ impl ContentPart {
 	/// Returns true if this part is reasoning content.
 	pub fn is_reasoning_content(&self) -> bool {
 		matches!(self, ContentPart::ReasoningContent(_))
+	}
+
+	pub fn is_thinking(&self) -> bool {
+		matches!(self, ContentPart::Thinking(_))
 	}
 
 	/// Returns true if this part is custom provider-specific content.

--- a/src/chat/content_part/mod.rs
+++ b/src/chat/content_part/mod.rs
@@ -2,8 +2,10 @@
 
 mod common;
 mod custom_part;
+mod thinking_block;
 
 pub use common::*;
 pub use custom_part::*;
+pub use thinking_block::*;
 
 // endregion: --- Modules

--- a/src/chat/content_part/thinking_block.rs
+++ b/src/chat/content_part/thinking_block.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+/// One provider-issued thinking block whose text and integrity signature must
+/// remain bound and ordered when the assistant turn is replayed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThinkingBlock {
+	pub thinking: String,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub signature: Option<String>,
+}
+
+impl ThinkingBlock {
+	pub fn new(thinking: impl Into<String>, signature: Option<String>) -> Self {
+		Self {
+			thinking: thinking.into(),
+			signature,
+		}
+	}
+
+	pub fn with_signature(mut self, signature: impl Into<String>) -> Self {
+		self.signature = Some(signature.into());
+		self
+	}
+}

--- a/src/chat/message_content.rs
+++ b/src/chat/message_content.rs
@@ -1,5 +1,5 @@
 /// Note: MessageContent is used for ChatRequest and ChatResponse.
-use crate::chat::{Binary, ContentPart, CustomPart, ToolCall, ToolResponse};
+use crate::chat::{Binary, ContentPart, CustomPart, ThinkingBlock, ToolCall, ToolResponse};
 use serde::{Deserialize, Serialize};
 
 /// Message content container used in ChatRequest and ChatResponse.
@@ -265,6 +265,16 @@ impl MessageContent {
 		self.parts.into_iter().filter_map(|p| p.into_reasoning_content()).collect()
 	}
 
+	/// Return Anthropic-style signed thinking blocks in message order.
+	pub fn thinking_blocks(&self) -> Vec<&ThinkingBlock> {
+		self.parts.iter().filter_map(ContentPart::as_thinking).collect()
+	}
+
+	/// Consume and return Anthropic-style signed thinking blocks in message order.
+	pub fn into_thinking_blocks(self) -> Vec<ThinkingBlock> {
+		self.parts.into_iter().filter_map(ContentPart::into_thinking).collect()
+	}
+
 	/// Join all reasoning content parts with a newline separator.
 	/// Returns None if there are no reasoning content parts.
 	pub fn joined_reasoning_content(&self) -> Option<String> {
@@ -408,6 +418,11 @@ impl MessageContent {
 	/// True if at least one part is ReasoningContent.
 	pub fn contains_reasoning_content(&self) -> bool {
 		self.parts.iter().any(|p| p.is_reasoning_content())
+	}
+
+	/// True if at least one Anthropic-style signed thinking block exists.
+	pub fn contains_thinking(&self) -> bool {
+		self.parts.iter().any(ContentPart::is_thinking)
 	}
 
 	/// True if at least one part is Custom.

--- a/src/otel/attrs.rs
+++ b/src/otel/attrs.rs
@@ -123,7 +123,7 @@ fn part_value(part: &ContentPart) -> Option<Value> {
 		ContentPart::ReasoningContent(text) => Some(json!({ "type": "reasoning", "content": text })),
 		// Opaque/internal parts: represented by type only (no content emitted).
 		ContentPart::Binary(_) => Some(json!({ "type": "blob" })),
-		ContentPart::ThoughtSignature(_) | ContentPart::Custom(_) => None,
+		ContentPart::ThoughtSignature(_) | ContentPart::Thinking(_) | ContentPart::Custom(_) => None,
 	}
 }
 

--- a/tests/data/yakbak/anthropic/thinking_tool_stream/response_000.txt
+++ b/tests/data/yakbak/anthropic/thinking_tool_stream/response_000.txt
@@ -1,0 +1,44 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_thinking_tool","type":"message","role":"assistant","content":[],"model":"deepseek-v4-pro","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":31,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"I should "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"use the fixture."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"123"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Checking."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: content_block_start
+data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_stream_1","name":"read_fixture","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"marker\":\"anthropic\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":27}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/tests_yakbak_anthropic.rs
+++ b/tests/tests_yakbak_anthropic.rs
@@ -10,6 +10,61 @@ use serde_json::{Value, json};
 use support::yakbak::replay_client;
 use support::{TestResult, extract_stream_end};
 
+#[tokio::test]
+async fn test_yakbak_anthropic_signed_thinking_stream_preserves_block_order() -> TestResult<()> {
+	// Cause/effect graph: C1 SSE emits a Thinking block in multiple reasoning and
+	// signature deltas; C2 Text is the next block; C3 ToolUse is last; C4 all
+	// capture switches are enabled. Effects: E1 streamed reasoning is complete;
+	// E2 terminal content binds signature to Thinking; E3 terminal block order is
+	// Thinking→Text→ToolCall. Rule R1=C1&C2&C3&C4 => E1+E2+E3.
+	let (client, _server) = replay_client("anthropic", "thinking_tool_stream").await?;
+	let options = ChatOptions::default()
+		.with_capture_content(true)
+		.with_capture_reasoning_content(true)
+		.with_capture_tool_calls(true)
+		.with_capture_usage(true);
+	let request = ChatRequest::from_user("Read the compatibility fixture").append_tool(
+		Tool::new("read_fixture").with_schema(json!({
+			"type":"object",
+			"properties":{"marker":{"type":"string"}},
+			"required":["marker"]
+		})),
+	);
+	let stream = client
+		.exec_chat_stream("anthropic::deepseek-v4-pro", request, Some(&options))
+		.await?;
+	let extract = extract_stream_end(stream.stream).await?;
+	assert_eq!(
+		extract.reasoning_content.as_deref(),
+		Some("I should use the fixture."),
+		"R1/E1"
+	);
+	assert_eq!(
+		extract.stream_end.captured_reasoning_content.as_deref(),
+		Some("I should use the fixture."),
+		"R1/E1 normalized capture"
+	);
+	let parts = extract
+		.stream_end
+		.captured_content
+		.as_ref()
+		.ok_or("R1 captured content")?
+		.parts();
+	assert!(
+		matches!(&parts[0], ContentPart::Thinking(block) if block.thinking == "I should use the fixture." && block.signature.as_deref() == Some("sig-123")),
+		"R1/E2"
+	);
+	assert!(
+		matches!(&parts[1], ContentPart::Text(text) if text == "Checking."),
+		"R1/E3 text"
+	);
+	assert!(
+		matches!(&parts[2], ContentPart::ToolCall(call) if call.call_id == "toolu_stream_1" && call.fn_name == "read_fixture"),
+		"R1/E3 tool"
+	);
+	Ok(())
+}
+
 /// Verify that the Anthropic adapter emits incremental ToolCallChunk events
 /// during streaming: one at content_block_start (name + empty args), then one
 /// per content_block_delta (accumulated args as Value::String).


### PR DESCRIPTION
## Summary

- add a replayable ThinkingBlock that keeps Anthropic thinking text bound to its optional signature
- parse signed thinking in non-streaming responses and accumulate split thinking/signature streaming deltas into the same block
- preserve the original Thinking, Text, and ToolCall block order in captured MessageContent
- serialize assistant Thinking blocks back onto the Anthropic Messages request wire
- consolidate stream terminal capture around one ordered MessageContent source of truth

## Test design

The regression cases cover both response modes and the replay boundary:

- non-streaming Thinking -> Text -> ToolCall parsing and assistant request round-trip
- streaming split thinking/signature deltas -> ordered terminal Thinking -> Text -> ToolCall capture
- legacy normalized reasoning_content remains available without replacing ordered content

## Validation

- cargo check --all-targets
- cargo test --lib: 200 passed
- all offline Yakbak suites: 25 passed, 10 ignored
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check

A downstream DeepSeek Anthropic Messages integration also completed a real signed-thinking tool continuation using the captured assistant turn.