### PR TITLE
fix(chat): default ChatOptions.stop_sequences for partial deserialization

### DIFF
--- a/src/chat/chat_options.rs
+++ b/src/chat/chat_options.rs
@@ -26,6 +26,7 @@ pub struct ChatOptions {
 	pub top_p: Option<f64>,
 
 	/// Sequences that halt generation when encountered.
+	#[serde(default)]
 	pub stop_sequences: Vec<String>,
 
 	// -- Stream Options
@@ -759,6 +760,38 @@ mod tests {
 		// -- Check
 		assert!(matches!(effort, Some(ReasoningEffort::Zero)));
 		assert_eq!(trimmed, "some-model");
+		Ok(())
+	}
+
+	// -- Deserialization surface tests
+
+	#[test]
+	fn test_chat_options_deser_partial_without_stop_sequences() -> Result<()> {
+		// -- Setup & Fixtures
+		let json = serde_json::json!({"temperature": 0.4});
+
+		// -- Exec
+		let options: ChatOptions = serde_json::from_value(json)?;
+
+		// -- Check
+		assert_eq!(options.temperature, Some(0.4));
+		assert!(options.stop_sequences.is_empty());
+		assert_eq!(options.max_tokens, None);
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_chat_options_deser_empty_object() -> Result<()> {
+		// -- Setup & Fixtures
+		let json = serde_json::json!({});
+
+		// -- Exec
+		let options: ChatOptions = serde_json::from_value(json)?;
+
+		// -- Check
+		assert!(options.stop_sequences.is_empty());
+
 		Ok(())
 	}
 }


### PR DESCRIPTION
## Problem

Every field of `ChatOptions` is optional in practice, and serde treats the `Option<T>` ones as such automatically. `stop_sequences` is the one exception — a bare `Vec<String>` — so deserializing anything that omits it fails:

```rust
let options: ChatOptions = serde_json::from_value(json!({"temperature": 0.4}))?;
// Error("missing field `stop_sequences`")
```

This makes a partial `ChatOptions` impossible to deserialize from a config file, or from a language binding that accepts an options mapping — even though `ChatOptions::default()` fills the field with an empty `Vec` perfectly happily.

I hit this in Python bindings that accept either a typed options object or a plain dict: `{"temperature": 0.4}` had to be padded with `"stop_sequences": []` to deserialize at all.

## Change

Adds `#[serde(default)]` to the field, matching what `ChatRequest.messages` already does for the same reason, plus two regression tests.

## Verification

- Both new tests fail without the one-line change (`Error("missing field 'stop_sequences'")`) and pass with it.
- Full `cargo test --lib` suite passes (201 tests).
- `cargo fmt --check` clean.

No behaviour change for any input that already deserialized, and none for serialization.