### PR TITLE
adapter: AdapterKind::all() to enumerate the built-in adapters

### DIFF
--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -273,3 +273,47 @@ impl AdapterKind {
 		}
 	}
 }
+
+// region:    --- Tests
+
+#[cfg(test)]
+mod tests {
+	type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
+
+	use super::*;
+
+	#[test]
+	fn test_adapter_kind_all_round_trips_lower_str() -> Result<()> {
+		// -- Exec & Check
+		for kind in AdapterKind::all() {
+			let lower = kind.as_lower_str();
+			assert_eq!(AdapterKind::from_lower_str(lower), Some(*kind), "for '{lower}'");
+		}
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_adapter_kind_all_has_no_duplicates() -> Result<()> {
+		// -- Setup & Fixtures
+		let all = AdapterKind::all();
+
+		// -- Exec
+		let unique: std::collections::HashSet<_> = all.iter().collect();
+
+		// -- Check
+		assert_eq!(unique.len(), all.len());
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_adapter_kind_all_excludes_custom() -> Result<()> {
+		// -- Check
+		assert!(!AdapterKind::all().iter().any(|kind| matches!(kind, AdapterKind::Custom(_))));
+
+		Ok(())
+	}
+}
+
+// endregion: --- Tests

--- a/src/adapter/macros/adapter_kind_macros.rs
+++ b/src/adapter/macros/adapter_kind_macros.rs
@@ -1,9 +1,11 @@
-/// Generates the three 1:1 string-mapping methods (`as_str`, `as_lower_str`,
-/// `from_lower_str`) from a single canonical table of `Variant => "Name", "lower"`.
+/// Generates the 1:1 string-mapping methods (`as_str`, `as_lower_str`,
+/// `from_lower_str`) and the variant list (`all`) from a single canonical
+/// table of `Variant => "Name", "lower"`.
 ///
-/// This keeps the three tables impossible to desync (the same `"lower"` literal
-/// drives both `as_lower_str` and `from_lower_str`), and reduces adding a new
-/// adapter to a single line in the table below.
+/// This keeps them impossible to desync (the same `"lower"` literal drives
+/// both `as_lower_str` and `from_lower_str`, and the same variant drives
+/// `all`), and reduces adding a new adapter to a single line in the table
+/// below.
 ///
 /// NOTE: `Custom(_)` and the `genai_` parsing are handled inside the macro since
 ///       they are constant across all variants. The cfg-gated `BedrockSigv4` is
@@ -35,6 +37,22 @@ macro_rules! adapter_kind_str_maps {
 					AdapterKind::BedrockSigv4 => "bedrock_sigv4",
 					AdapterKind::Custom(_) => "custom",
 				}
+			}
+
+			/// All built-in adapter kinds, in table order.
+			///
+			/// `Custom(_)` is excluded: it is parameterized by an index
+			/// rather than a fixed variant, so it cannot be enumerated.
+			///
+			/// Useful for building a provider list at runtime — validating
+			/// configuration against the known set, or offering a choice —
+			/// which `from_lower_str` alone cannot do.
+			pub fn all() -> &'static [AdapterKind] {
+				&[
+					$( AdapterKind::$variant, )*
+					#[cfg(feature = "bedrock-sigv4")]
+					AdapterKind::BedrockSigv4,
+				]
 			}
 
 			pub fn from_lower_str(name: &str) -> Option<Self> {


### PR DESCRIPTION
## Problem

`AdapterKind` can be parsed from a string (`from_lower_str`) and rendered back to one (`as_lower_str`), but there is no way to ask *which adapters exist*.

Anything that needs the set has to hand-maintain a duplicate list:

- validating a configuration value against the known providers, with an error message that names the valid options
- offering a provider choice in a UI or CLI
- building a lookup keyed by adapter kind

I hit this writing Python bindings: to give `AdapterKind("not-a-provider")` an error message listing the valid names, I ended up with a 29-entry table copied out of `adapter_kind_str_maps!` plus a round-trip test whose only job is to fail when this crate renames something. That table should not exist.

## Change

The `adapter_kind_str_maps!` table already names every variant, so `all()` falls out of the existing macro — no second source of truth:

```rust
pub fn all() -> &'static [AdapterKind]
```

`Custom(_)` is excluded, since it is parameterized by an index rather than a fixed variant and cannot be enumerated. `BedrockSigv4` is included under its existing `#[cfg]`, matching how the other generated methods handle it.

## Verification

Three tests: every entry round-trips through `from_lower_str`, the list has no duplicates, and `Custom` is absent.

Full `cargo test --lib` passes (202 tests), `cargo fmt --check` clean. Purely additive.