### PR TITLE
error: Error::status() accessor

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -170,6 +170,33 @@ Drop the `::` namespace prefix or `ModelSpec::Iden`, or build a Client without \
 	SerdeJson(serde_json::Error),
 }
 
+/// Accessors
+impl Error {
+	/// The HTTP status the provider responded with, when the failure came
+	/// from an HTTP response.
+	///
+	/// The status is already carried by the error, but reaching it means
+	/// knowing that a failed chat call arrives as
+	/// `WebModelCall { webc_error: webc::Error::ResponseFailedStatus { .. } }`,
+	/// that adapter-level calls use `WebAdapterCall` instead, and that
+	/// `HttpError` is a third, separate shape. Callers that want to branch
+	/// on 429 or 5xx should not have to know any of that.
+	///
+	/// Returns `None` for failures with no HTTP response behind them:
+	/// connection and timeout errors, resolver failures, request
+	/// validation, stream parsing.
+	///
+	/// Retry policy stays with the caller — this only reports what the
+	/// provider said.
+	pub fn status(&self) -> Option<StatusCode> {
+		match self {
+			Error::HttpError { status, .. } => Some(*status),
+			Error::WebModelCall { webc_error, .. } | Error::WebAdapterCall { webc_error, .. } => webc_error.status(),
+			_ => None,
+		}
+	}
+}
+
 // region:    --- Error Boilerplate
 
 // The Display trait is now derived via derive_more::Display
@@ -182,3 +209,94 @@ Drop the `::` namespace prefix or `ModelSpec::Iden`, or build a Client without \
 impl std::error::Error for Error {}
 
 // endregion: --- Error Boilerplate
+
+// region:    --- Tests
+
+#[cfg(test)]
+mod tests {
+	type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
+
+	use super::*;
+	use reqwest::header::HeaderMap;
+
+	fn webc_status_error(status: u16) -> webc::Error {
+		webc::Error::ResponseFailedStatus {
+			status: StatusCode::from_u16(status).expect("valid status code"),
+			body: "body".to_string(),
+			headers: Box::new(HeaderMap::new()),
+		}
+	}
+
+	#[test]
+	fn test_error_status_from_web_model_call() -> Result<()> {
+		// -- Setup & Fixtures
+		let error = Error::WebModelCall {
+			model_iden: ModelIden::new(AdapterKind::OpenAI, "gpt-4o"),
+			webc_error: webc_status_error(429),
+		};
+
+		// -- Exec & Check
+		assert_eq!(error.status(), Some(StatusCode::TOO_MANY_REQUESTS));
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_error_status_from_web_adapter_call() -> Result<()> {
+		// -- Setup & Fixtures
+		let error = Error::WebAdapterCall {
+			adapter_kind: AdapterKind::OpenAI,
+			webc_error: webc_status_error(503),
+		};
+
+		// -- Exec & Check
+		assert_eq!(error.status(), Some(StatusCode::SERVICE_UNAVAILABLE));
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_error_status_from_http_error() -> Result<()> {
+		// -- Setup & Fixtures
+		let error = Error::HttpError {
+			status: StatusCode::BAD_GATEWAY,
+			canonical_reason: "Bad Gateway".to_string(),
+			body: "body".to_string(),
+			headers: Box::new(HeaderMap::new()),
+		};
+
+		// -- Exec & Check
+		assert_eq!(error.status(), Some(StatusCode::BAD_GATEWAY));
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_error_status_none_without_a_response() -> Result<()> {
+		// -- Setup & Fixtures
+		let error = Error::NoAuthData {
+			model_iden: ModelIden::new(AdapterKind::OpenAI, "gpt-4o"),
+		};
+
+		// -- Exec & Check
+		assert_eq!(error.status(), None);
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_webc_error_status_none_for_non_status_failures() -> Result<()> {
+		// -- Setup & Fixtures
+		let error = webc::Error::ResponseFailedNotJson {
+			content_type: "text/html".to_string(),
+			body: "<html></html>".to_string(),
+		};
+
+		// -- Exec & Check
+		assert_eq!(error.status(), None);
+
+		Ok(())
+	}
+}
+
+// endregion: --- Tests

--- a/src/webc/error.rs
+++ b/src/webc/error.rs
@@ -32,6 +32,23 @@ pub enum Error {
 	Reqwest(reqwest::Error),
 }
 
+/// Accessors
+impl Error {
+	/// The HTTP status behind this error, when there is one.
+	///
+	/// `ResponseFailedStatus` carries it directly; a `Reqwest` error may
+	/// also carry one (for instance from `error_for_status`). Everything
+	/// else — a non-JSON body, an unparsable body, a connection failure —
+	/// has no status to report.
+	pub fn status(&self) -> Option<StatusCode> {
+		match self {
+			Error::ResponseFailedStatus { status, .. } => Some(*status),
+			Error::Reqwest(reqwest_error) => reqwest_error.status(),
+			_ => None,
+		}
+	}
+}
+
 // region:    --- Error Boilerplate
 
 // NOTE: The manual Display implementation is removed as derive_more::Display handles it.


### PR DESCRIPTION
## Problem

The HTTP status a provider responded with is already carried by the error, but reaching it requires knowing the internal shape:

```rust
match &err {
    Error::WebModelCall { webc_error: webc::Error::ResponseFailedStatus { status, .. }, .. } => Some(*status),
    Error::WebAdapterCall { webc_error: webc::Error::ResponseFailedStatus { status, .. }, .. } => Some(*status),
    Error::HttpError { status, .. } => Some(*status),
    _ => None,
}
```

Three variants, two layers, and the `WebAdapterCall` arm is easy to miss entirely — it only shows up on `all_model_names`, so a caller who tests against chat calls will ship without it.

Every consumer that wants to distinguish "rate limited, back off" from "bad request, fix it" has to write this, and any that gets it subtly wrong fails in exactly the situation it was written for.

## Change

```rust
impl Error {
    pub fn status(&self) -> Option<StatusCode>
}

impl webc::Error {
    pub fn status(&self) -> Option<StatusCode>
}
```

`None` for failures with no HTTP response behind them: connection and timeout errors, resolver failures, request validation, stream parsing.

Deliberately *not* included: any notion of which statuses are retryable. That is policy and belongs to the application — this only reports what the provider said. It pairs with the response headers `HttpError` already carries (#280), so a retry layer can read both the status and `retry-after` without matching on variants.

## Verification

Five tests covering `WebModelCall`, `WebAdapterCall`, `HttpError`, a non-HTTP error, and a non-status `webc::Error`.

Full `cargo test --lib` passes, `cargo fmt --check` clean. Purely additive.