### PR TITLE
fix(client): apply the ServiceTargetResolver when resolving adapter config

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -132,11 +132,21 @@ impl ClientConfig {
 	/// Resolves auth and endpoint for the given adapter kind.
 	///
 	/// Used by `Client::all_model_names()` where no specific model name is available.
+	///
+	/// Both resolvers see a `ModelIden` with an empty model name, since
+	/// listing models is not about any one model. The `ServiceTargetResolver`
+	/// is run for the same reason the `AuthResolver` is: a Client pointed at
+	/// a private endpoint must not fall back to the adapter's public default
+	/// here, or it would send that Client's credentials to the wrong host.
 	pub(crate) async fn resolve_adapter_config(&self, adapter_kind: AdapterKind) -> Result<(AuthData, Endpoint)> {
 		let model = ModelIden::new(adapter_kind, "");
-		let auth = self.run_auth_resolver(model).await?;
+		let auth = self.run_auth_resolver(model.clone()).await?;
 		let endpoint = AdapterDispatcher::default_endpoint(adapter_kind);
-		Ok((auth, endpoint))
+
+		let service_target = ServiceTarget { model, auth, endpoint };
+		let service_target = self.run_service_target_resolver(service_target).await?;
+
+		Ok((service_target.auth, service_target.endpoint))
 	}
 
 	/// Resolves a ServiceTarget for the given model.
@@ -312,6 +322,40 @@ mod tests {
 					Ok(service_target)
 				},
 			))
+	}
+
+	#[tokio::test]
+	async fn adapter_config_applies_service_target_resolver() {
+		// `all_model_names` resolves through here, with no model name to go
+		// on. The AuthResolver was already honored; the ServiceTargetResolver
+		// must be too, or a Client configured for a private endpoint would
+		// list models from the adapter's public default — and send the
+		// credential the AuthResolver just supplied along with it.
+		let config = bound_config(AdapterKind::OpenAI, "https://custom.example/v1");
+
+		let (auth, endpoint) = config
+			.resolve_adapter_config(AdapterKind::OpenAI)
+			.await
+			.expect("adapter config should resolve");
+
+		assert_eq!(endpoint.base_url(), "https://custom.example/v1");
+		assert!(matches!(auth, AuthData::Key(_)));
+	}
+
+	#[tokio::test]
+	async fn adapter_config_falls_back_to_the_default_endpoint() {
+		// No service-target resolver attached: the adapter default stands.
+		let config = ClientConfig::default();
+
+		let (_auth, endpoint) = config
+			.resolve_adapter_config(AdapterKind::OpenAI)
+			.await
+			.expect("adapter config should resolve");
+
+		assert_eq!(
+			endpoint.base_url(),
+			AdapterDispatcher::default_endpoint(AdapterKind::OpenAI).base_url()
+		);
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Problem

`Client::all_model_names()` resolves its endpoint and auth through `ClientConfig::resolve_adapter_config`, which runs the **AuthResolver** but not the **ServiceTargetResolver**:

```rust
pub(crate) async fn resolve_adapter_config(&self, adapter_kind: AdapterKind) -> Result<(AuthData, Endpoint)> {
    let model = ModelIden::new(adapter_kind, "");
    let auth = self.run_auth_resolver(model).await?;
    let endpoint = AdapterDispatcher::default_endpoint(adapter_kind);   // <-- resolver never runs
    Ok((auth, endpoint))
}
```

A Client configured to reach a private endpoint that way — a local vLLM, an OpenAI-compatible gateway — therefore lists models from the adapter's **public default** instead, and sends it the credential the AuthResolver just supplied for the private host.

It fails in the worst direction: silently, and with a successful-looking result. I found it because a test suite that should have been fully offline made a live request to `api.openai.com`; the client under test had been configured with a `ServiceTargetResolver` pointing at a local fake, and `all_model_names` ignored it.

```rust
let client = Client::builder()
    .with_auth_resolver(/* key for the private gateway */)
    .with_service_target_resolver(/* endpoint: https://gateway.internal/v1/ */)
    .build();

client.all_model_names(AdapterKind::OpenAI, ()).await?;
// -> queries https://api.openai.com/v1/models, with the gateway's key
```

## Change

Build the `ServiceTarget` the same way `resolve_service_target` does and run the resolver, then take its auth and endpoint.

Both resolvers already see a `ModelIden` with an empty model name here — listing models is not about any one model, and that convention is already established for the AuthResolver on the line above. This just extends the same treatment to the second resolver.

## Verification

Two tests, using the existing `bound_config` helper: a configured resolver is honored, and the adapter default still stands when no resolver is attached. The first fails on `main` (`left: "https://api.openai.com/v1/"`, `right: "https://custom.example/v1"`) and passes with the change.

Full `cargo test --lib` passes (201 tests), `cargo fmt --check` clean.

## Note on scope

The alternative reading is that `all_model_names` already takes a `ProviderConfig` argument, so callers *can* pass the endpoint explicitly. But the default path silently disagreeing with how every other call on the same Client routes is the surprising part — and the failure mode is credentials going to an unintended host, which seems worth closing regardless.