### PR TITLE
client: ClientBuilder::with_provider_config for per-adapter endpoint/auth

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,7 +1,7 @@
 use crate::adapter::AdapterKind;
 use crate::chat::ChatOptions;
 use crate::resolver::{
-	AuthResolver, IntoAuthResolverFn, IntoModelMapperFn, IntoServiceTargetResolverFn, ModelMapper,
+	AuthResolver, IntoAuthResolverFn, IntoModelMapperFn, IntoServiceTargetResolverFn, ModelMapper, ProviderConfig,
 	ServiceTargetResolver,
 };
 use crate::webc::WebClient;
@@ -107,6 +107,36 @@ impl ClientBuilder {
 	pub fn with_adapter_kind(mut self, adapter_kind: AdapterKind) -> Self {
 		let client_config = self.config.get_or_insert_with(ClientConfig::default);
 		client_config.adapter_kind = Some(adapter_kind);
+		self
+	}
+
+	/// Append the endpoint and/or auth for one adapter kind.
+	///
+	/// Call once per provider this Client should reach; each call adds to
+	/// the list rather than replacing it:
+	///
+	/// ```rust
+	/// # use genai::Client;
+	/// # use genai::adapter::AdapterKind;
+	/// # use genai::resolver::{AuthData, Endpoint};
+	/// let client = Client::builder()
+	///     .append_provider_config(
+	///         AdapterKind::OpenAI,
+	///         (Endpoint::from_static("https://gateway.internal/v1/"), AuthData::from_env("GATEWAY_KEY")),
+	///     )
+	///     .append_provider_config(AdapterKind::Ollama, Endpoint::from_static("http://localhost:11434/v1/"))
+	///     .build();
+	/// ```
+	///
+	/// Precedence, lowest to highest: the adapter's built-in default, then
+	/// this configuration, then the resolvers.
+	pub fn append_provider_config(
+		mut self,
+		adapter_kind: AdapterKind,
+		provider_config: impl Into<ProviderConfig>,
+	) -> Self {
+		let config = self.config.take().unwrap_or_default();
+		self.config = Some(config.append_provider_config(adapter_kind, provider_config));
 		self
 	}
 }

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -2,8 +2,9 @@ use crate::adapter::{AdapterDispatcher, AdapterKind};
 use crate::chat::ChatOptions;
 use crate::client::{ModelSpec, ServiceTarget};
 use crate::embed::EmbedOptions;
-use crate::resolver::{AuthData, AuthResolver, Endpoint, ModelMapper, ServiceTargetResolver};
+use crate::resolver::{AuthData, AuthResolver, Endpoint, ModelMapper, ProviderConfig, ServiceTargetResolver};
 use crate::{Error, ModelIden, Result, WebConfig};
+use std::collections::HashMap;
 
 /// Configuration for building and customizing a `Client`.
 #[derive(Debug, Default, Clone)]
@@ -15,6 +16,7 @@ pub struct ClientConfig {
 	pub(super) chat_options: Option<ChatOptions>,
 	pub(super) embed_options: Option<EmbedOptions>,
 	pub(super) adapter_kind: Option<AdapterKind>,
+	pub(super) provider_configs: HashMap<AdapterKind, ProviderConfig>,
 }
 
 /// Chainable setters related to the ClientConfig.
@@ -24,6 +26,34 @@ impl ClientConfig {
 	/// Called before `service_target_resolver`; if set, it will receive this value.
 	pub fn with_auth_resolver(mut self, auth_resolver: AuthResolver) -> Self {
 		self.auth_resolver = Some(auth_resolver);
+		self
+	}
+
+	/// Append the endpoint and/or auth for one adapter kind.
+	///
+	/// Call once per provider a Client should be able to reach; each call
+	/// adds to the list rather than replacing it. This is the declarative
+	/// form of what an `AuthResolver` or `ServiceTargetResolver` closure
+	/// would otherwise have to do by hand for the common "this provider
+	/// lives here, with this key" case.
+	///
+	/// Precedence, lowest to highest: the adapter's built-in default, then
+	/// this configuration, then the resolvers — so a resolver can still
+	/// override a statically configured provider, and configuring one
+	/// provider never affects any other.
+	pub fn append_provider_config(
+		mut self,
+		adapter_kind: AdapterKind,
+		provider_config: impl Into<ProviderConfig>,
+	) -> Self {
+		let ProviderConfig { endpoint, auth } = provider_config.into();
+		let entry = self.provider_configs.entry(adapter_kind).or_default();
+		if endpoint.is_some() {
+			entry.endpoint = endpoint;
+		}
+		if auth.is_some() {
+			entry.auth = auth;
+		}
 		self
 	}
 
@@ -101,6 +131,11 @@ impl ClientConfig {
 		self.auth_resolver.as_ref()
 	}
 
+	/// Returns the configured [`ProviderConfig`] for an adapter kind, if any.
+	pub fn provider_config(&self, adapter_kind: AdapterKind) -> Option<&ProviderConfig> {
+		self.provider_configs.get(&adapter_kind)
+	}
+
 	/// Returns the ServiceTargetResolver, if set.
 	pub fn service_target_resolver(&self) -> Option<&ServiceTargetResolver> {
 		self.service_target_resolver.as_ref()
@@ -141,7 +176,7 @@ impl ClientConfig {
 	pub(crate) async fn resolve_adapter_config(&self, adapter_kind: AdapterKind) -> Result<(AuthData, Endpoint)> {
 		let model = ModelIden::new(adapter_kind, "");
 		let auth = self.run_auth_resolver(model.clone()).await?;
-		let endpoint = AdapterDispatcher::default_endpoint(adapter_kind);
+		let endpoint = self.default_endpoint(adapter_kind);
 
 		let service_target = ServiceTarget { model, auth, endpoint };
 		let service_target = self.run_service_target_resolver(service_target).await?;
@@ -164,7 +199,7 @@ impl ClientConfig {
 
 		// -- Get the default endpoint
 		// For now, just get the default endpoint; the `resolve_target` will allow overriding it.
-		let endpoint = AdapterDispatcher::default_endpoint(model.adapter_kind);
+		let endpoint = self.default_endpoint(model.adapter_kind);
 
 		// -- Create the default service target
 		let service_target = ServiceTarget {
@@ -202,13 +237,31 @@ impl ClientConfig {
 						model_iden: model.clone(),
 						resolver_error: err,
 					})?
-					// default the resolver resolves to nothing
-					.unwrap_or_else(|| AdapterDispatcher::default_auth(model.adapter_kind));
+					// default when the resolver resolves to nothing
+					.unwrap_or_else(|| self.default_auth(model.adapter_kind));
 
 				Ok(auth_data)
 			}
-			None => Ok(AdapterDispatcher::default_auth(model.adapter_kind)),
+			None => Ok(self.default_auth(model.adapter_kind)),
 		}
+	}
+
+	/// The auth to use when no resolver supplied one: the configured
+	/// [`ProviderConfig`] if there is one, else the adapter's default.
+	fn default_auth(&self, adapter_kind: AdapterKind) -> AuthData {
+		self.provider_configs
+			.get(&adapter_kind)
+			.and_then(|config| config.auth.clone())
+			.unwrap_or_else(|| AdapterDispatcher::default_auth(adapter_kind))
+	}
+
+	/// The endpoint to seed a [`ServiceTarget`] with before the
+	/// [`ServiceTargetResolver`] runs.
+	fn default_endpoint(&self, adapter_kind: AdapterKind) -> Endpoint {
+		self.provider_configs
+			.get(&adapter_kind)
+			.and_then(|config| config.endpoint.clone())
+			.unwrap_or_else(|| AdapterDispatcher::default_endpoint(adapter_kind))
 	}
 
 	/// Resolves a [`ServiceTarget`] via the [`ServiceTargetResolver`] (if any).
@@ -358,6 +411,81 @@ mod tests {
 			endpoint.base_url(),
 			AdapterDispatcher::default_endpoint(AdapterKind::OpenAI).base_url()
 		);
+	}
+
+	#[tokio::test]
+	async fn provider_config_supplies_endpoint_and_auth() {
+		// -- Setup & Fixtures
+		let config = ClientConfig::default().append_provider_config(
+			AdapterKind::OpenAI,
+			(
+				Endpoint::from_static("https://gateway.internal/v1/"),
+				AuthData::from_single("gateway-key"),
+			),
+		);
+
+		// -- Exec
+		let target = config
+			.resolve_model_spec(ModelSpec::Iden(ModelIden::new(AdapterKind::OpenAI, "gpt-4o")))
+			.await
+			.expect("should resolve");
+
+		// -- Check
+		assert_eq!(target.endpoint.base_url(), "https://gateway.internal/v1/");
+		assert!(matches!(target.auth, AuthData::Key(ref key) if key == "gateway-key"));
+	}
+
+	#[tokio::test]
+	async fn provider_config_is_scoped_to_its_adapter() {
+		// Configuring one provider must not leak into another.
+		let config = ClientConfig::default().append_provider_config(
+			AdapterKind::OpenAI,
+			Endpoint::from_static("https://gateway.internal/v1/"),
+		);
+
+		let target = config
+			.resolve_model_spec(ModelSpec::Iden(ModelIden::new(
+				AdapterKind::Anthropic,
+				"claude-sonnet-4-6",
+			)))
+			.await
+			.expect("should resolve");
+
+		assert_eq!(
+			target.endpoint.base_url(),
+			AdapterDispatcher::default_endpoint(AdapterKind::Anthropic).base_url()
+		);
+	}
+
+	#[tokio::test]
+	async fn resolvers_still_win_over_provider_config() {
+		// The static configuration seeds the target; the dynamic hook keeps
+		// the final say.
+		let config = bound_config(AdapterKind::OpenAI, "https://from-resolver/v1")
+			.append_provider_config(AdapterKind::OpenAI, Endpoint::from_static("https://from-config/v1/"));
+
+		let target = config
+			.resolve_model_spec(ModelSpec::Iden(ModelIden::new(AdapterKind::OpenAI, "gpt-4o")))
+			.await
+			.expect("should resolve");
+
+		assert_eq!(target.endpoint.base_url(), "https://from-resolver/v1");
+	}
+
+	#[tokio::test]
+	async fn provider_config_applies_to_adapter_config_resolution() {
+		// `all_model_names` resolves through here, with no model name.
+		let config = ClientConfig::default().append_provider_config(
+			AdapterKind::OpenAI,
+			Endpoint::from_static("https://gateway.internal/v1/"),
+		);
+
+		let (_auth, endpoint) = config
+			.resolve_adapter_config(AdapterKind::OpenAI)
+			.await
+			.expect("should resolve");
+
+		assert_eq!(endpoint.base_url(), "https://gateway.internal/v1/");
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
> **Ordering note:** this touches `resolve_adapter_config`, as does #288, so
> whichever lands second needs a trivial rebase — the two changes are adjacent,
> not contradictory (#288 makes that function run the `ServiceTargetResolver`;
> this one makes the endpoint it starts from configurable). Happy to rebase on
> request, in either order. Kept as its own PR rather than bundling the two,
> since they are independent changes; GitHub's stacked PRs can't help here, as
> they ["require all branches to be in the same repository. Cross-fork stacks
> are not supported."](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs)

## Problem

`ProviderConfig` already exists, and `all_model_names` already takes one — but there is no way to attach one to a `Client`.

So pointing an adapter at a different endpoint with a different key (a gateway, a local vLLM, a regional deployment) means hand-writing two resolvers whose entire job is to compare adapter kinds:

```rust
let key = key.clone();
builder = builder
    .with_auth_resolver(AuthResolver::from_resolver_fn(move |iden: ModelIden| {
        if iden.adapter_kind == kind { Ok(Some(AuthData::from_single(key.clone()))) }
        else { Ok(None) }
    }))
    .with_service_target_resolver(ServiceTargetResolver::from_resolver_fn(
        move |mut t: ServiceTarget| {
            if t.model.adapter_kind == kind { t.endpoint = endpoint.clone(); }
            Ok(t)
        },
    ));
```

And because a `Client` holds one resolver of each kind, doing it for a *second* provider means folding both into a single closure that dispatches on adapter kind — reimplementing, in every downstream project, the lookup table this change stores directly.

## Change

```rust
Client::builder()
    .with_provider_config(
        AdapterKind::OpenAI,
        (Endpoint::from_static("https://gateway.internal/v1/"), AuthData::from_env("GATEWAY_KEY")),
    )
    .with_provider_config(AdapterKind::Ollama, Endpoint::from_static("http://localhost:11434/v1/"))
    .build()
```

Repeatable, and it accepts anything `Into<ProviderConfig>` — so the existing `Endpoint`, `AuthData`, and tuple conversions all work.

**Precedence, lowest to highest: the adapter's built-in default → this configuration → the resolvers.** Resolvers keep the final say, so nothing that works today changes behaviour; configuring one provider never affects another.

It seeds both `resolve_service_target` and `resolve_adapter_config`, so chat calls and `all_model_names` agree on where a given provider lives.

## Verification

Four tests: endpoint and auth are supplied; configuration is scoped to its own adapter; a resolver still overrides it; and it applies to the no-model `resolve_adapter_config` path too.

`cargo test --lib` passes (203 tests) and `cargo fmt --check` is clean. The new doctest passes; the two failing doctests (`Tool::schema`, `zai`) already fail on `main` and are untouched here.