### PR TITLE
! client - make Client buildng fallible (see issue #291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### API Breaking Changes
 
+- `!` API CHANGE: `Client::new()` construction and `ClientBuilder::build()` are now fallible, returning `Result<Client>`. 
+  - `Client::default()` has been removed and replaced by `Client::new() -> Result<Client>`. 
+  - This eliminates internal `.expect(...)` panics during HTTP client initialization, aligning with genai's zero-panic strategy. (PR #292)
 - `!` API CHANGE: `ReasoningEffort::None` is renamed to `ReasoningEffort::Zero`, avoiding confusion with `Option::None`. The canonical keyword is now `"zero"` (was `"none"`), `as_keyword()` and `Display` emit `"zero"`, and `from_keyword()` still accepts `"none"` as a backward-compatible alias.
 - `!` API CHANGE: `JsonSpec::schema_with_additional_properties_false` is removed. Provider adapters now sanitize schemas as required by their target API. `JsonSchemaDialect` and `sanitize_json_schema(...)` are available for explicit schema sanitization.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ GENAI_1_API_KEY=sk-your-api-key
 ```
 
 ```rust
-let client = Client::default();
+let client = Client::new()?;
 let chat_res = client.exec_chat("genai_1::my-model", chat_req, None).await?;
 ```
 
@@ -46,7 +46,7 @@ OMLX_API_KEY=your-api-key
 Then target the model with the `omlx::` namespace:
 
 ```rust
-let client = Client::default();
+let client = Client::new()?;
 let chat_res = client.exec_chat("omlx::my-model", chat_req, None).await?;
 ```
 
@@ -56,7 +56,7 @@ Also supports custom endpoints and auth with `ServiceTargetResolver` (see [examp
 ```rust
 
 // Can talk to any models / providers
-let client = Client::default();
+let client = Client::new()?;
 
 let question = "Why is the sky red?";
 
@@ -258,7 +258,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		ChatMessage::user(question),
 	]);
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let print_options = PrintChatStreamOptions::from_print_events(false);
 

--- a/docs/for-llm/api-reference-for-llm.md
+++ b/docs/for-llm/api-reference-for-llm.md
@@ -692,7 +692,7 @@ Example:
 ```rust
 use genai::Client;
 
-let client = Client::default();
+let client = Client::new()?;
 // Set environment variables:
 //   GENAI_1_ENDPOINT=https://my-api.example.com/v1/
 //   GENAI_1_API_KEY=sk-...

--- a/docs/migration/migration-v_0_6_to_0_7.md
+++ b/docs/migration/migration-v_0_6_to_0_7.md
@@ -2,6 +2,30 @@
 
 ## API Breaking Changes
 
+### Fallible `Client` construction and builder
+
+`Client` building is now fallible to enforce genai's zero-panic strategy, eliminating internal `.expect(...)` calls during `reqwest` client initialization. `Client::default()` has been removed to align with **genai's zero-panic strategy**.
+
+- `Client::new()` now returns `Result<Client>`
+- `ClientBuilder::build()` now returns `Result<Client>`.
+- `Client::default()` has been removed.
+
+Sorry for the inconvenience, but this was a necessary update.
+
+**Now:**
+
+```rust
+let client = Client::new()?;
+let client = Client::builder().with_chat_options(options).build()?;
+```
+
+**Before:**
+
+```rust
+let client = Client::default();
+let client = Client::builder().with_chat_options(options).build();
+```
+
 ### `ReasoningEffort::None` renamed to `ReasoningEffort::Zero`
 
 `ReasoningEffort::None` has been renamed to `ReasoningEffort::Zero` to avoid confusion with `Option::None`. The canonical keyword is now `"zero"`. `from_keyword()` still accepts `"none"` as a backward-compatible alias.

--- a/examples/c00-readme.rs
+++ b/examples/c00-readme.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		ChatMessage::user(question),
 	]);
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let print_options = PrintChatStreamOptions::from_print_events(false);
 

--- a/examples/c01-conv.rs
+++ b/examples/c01-conv.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		"Why is it red sometimes?",
 	];
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
 	// This is similar to sending initial system chat messages (which will be cumulative with system chat messages)

--- a/examples/c02-auth.rs
+++ b/examples/c02-auth.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	);
 
 	// -- Build the new client with this adapter_config
-	let client = Client::builder().with_auth_resolver(auth_resolver).build();
+	let client = Client::builder().with_auth_resolver(auth_resolver).build()?;
 
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
 

--- a/examples/c03-mapper.rs
+++ b/examples/c03-mapper.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	});
 
 	// -- Build the new client with this client_config
-	let client = Client::builder().with_model_mapper(model_mapper).build();
+	let client = Client::builder().with_model_mapper(model_mapper).build()?;
 
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
 

--- a/examples/c04-chat-options.rs
+++ b/examples/c04-chat-options.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		ClientConfig::default().with_chat_options(ChatOptions::default().with_temperature(0.0).with_top_p(0.99));
 
 	// -- Build the new client with this client_config
-	let client = Client::builder().with_config(client_config).build();
+	let client = Client::builder().with_config(client_config).build()?;
 
 	// -- Build the chat request
 	let chat_req = ChatRequest::new(vec![ChatMessage::user(question)]);

--- a/examples/c05-model-names.rs
+++ b/examples/c05-model-names.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		AdapterKind::AtlasCloud,
 	];
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	for &kind in KINDS {
 		println!("\n--- Models for {kind}");

--- a/examples/c06-model-spec.rs
+++ b/examples/c06-model-spec.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let question = "Why is the sky red? (be concise)";
 
 	// -- Build the new client with this client_config
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build the chat request
 	let chat_req = ChatRequest::new(vec![ChatMessage::user(question)]);

--- a/examples/c06-target-resolver.rs
+++ b/examples/c06-target-resolver.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	);
 
 	// -- Build the new client with this adapter_config
-	let client = Client::builder().with_service_target_resolver(target_resolver).build();
+	let client = Client::builder().with_service_target_resolver(target_resolver).build()?;
 
 	// -- Normalize the eventual reasoning content (fireworks use the <think></think> style)
 	let chat_options = ChatOptions::default().with_normalize_reasoning_content(true);

--- a/examples/c07-image.rs
+++ b/examples/c07-image.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		// .with_max_level(tracing::Level::DEBUG) // To enable all sub-library tracing
 		.init();
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
 	chat_req = chat_req

--- a/examples/c08-image-gen.rs
+++ b/examples/c08-image-gen.rs
@@ -9,7 +9,7 @@ const MODEL: &str = "gemini-3-pro-image-preview"; // Or other Gemini model that 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	// Reads GEMINI_API_KEY from environment variable by default
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let prompt = "Generate a picture of a cat, cartoon style, 512x512 resolution";
 	println!("Prompt: {prompt}");

--- a/examples/c09-cache-ttl.rs
+++ b/examples/c09-cache-ttl.rs
@@ -60,7 +60,7 @@ fn get_or_zero(val: Option<i32>) -> i32 {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let mut all_passed = true;
 
 	// -- Request 1: Cache creation

--- a/examples/c10-aihubmix.rs
+++ b/examples/c10-aihubmix.rs
@@ -13,7 +13,7 @@ const MODEL: &str = "aihubmix::gpt-4o-mini";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let chat_req = ChatRequest::default()
 		.with_system("You are a helpful assistant.")

--- a/examples/c11-openai-resp-reasoning-roundtrip.rs
+++ b/examples/c11-openai-resp-reasoning-roundtrip.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let client = Client::builder()
 		.with_adapter_kind(AdapterKind::OpenAIResp)
 		.with_auth_resolver(auth_resolver)
-		.build();
+		.build()?;
 
 	let options = ChatOptions::default()
 		.with_capture_content(true)

--- a/examples/c12-otel.rs
+++ b/examples/c12-otel.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		.with_span_events(FmtSpan::CLOSE)
 		.init();
 
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::new(vec![
 		ChatMessage::system("Answer in one short sentence."),
 		ChatMessage::user("Why is the sky blue?"),

--- a/examples/c20-tooluse.rs
+++ b/examples/c20-tooluse.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		// .with_max_level(tracing::Level::DEBUG) // To enable all sub-library tracing
 		.init();
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// 1. Define a tool for getting weather information
 	let weather_tool = Tool::new("get_weather")

--- a/examples/c21-tooluse-streaming.rs
+++ b/examples/c21-tooluse-streaming.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		// .with_max_level(tracing::Level::DEBUG) // To enable all sub-library tracing
 		.init();
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	println!("--- Model: {MODEL}");
 

--- a/examples/c22-tooluse-deterministic.rs
+++ b/examples/c22-tooluse-deterministic.rs
@@ -6,7 +6,7 @@ const MODEL: &str = "gemini-3-flash-preview";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let weather_tool = Tool::new("get_weather")
 		.with_description("Get the current weather for a location")

--- a/examples/c23-tool-web-search.rs
+++ b/examples/c23-tool-web-search.rs
@@ -21,7 +21,7 @@ and source link.";
 	let options = genai::chat::ChatOptions::default().with_capture_raw_body(true);
 	let client = genai::Client::builder()
 		.with_config(ClientConfig::default().with_chat_options(options))
-		.build();
+		.build()?;
 
 	// -- Set web search tool (enable one)
 	// Manual for google

--- a/examples/c24-tool-custom-grammar.rs
+++ b/examples/c24-tool-custom-grammar.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			},
 		));
 	}
-	let client = client_builder.build();
+	let client = client_builder.build()?;
 
 	println!("--- Model: {MODEL}");
 

--- a/examples/c25-frame-sink.rs
+++ b/examples/c25-frame-sink.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let sink: Arc<dyn ChatFrameSink> = counter.clone();
 	let options = ChatOptions::default().with_capture_usage(true).with_raw_frame_sink_arc(sink);
 
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::from_user(question)
 		.append_tool(Tool::new(ToolName::WebSearch).with_config(WebSearchConfig::default()));
 

--- a/examples/c99-baidu.rs
+++ b/examples/c99-baidu.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	tracing_subscriber::fmt::init();
 
 	// Create a client with default configuration
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// Example 1: Using glm models (chat)
 	println!("=== Example 1: Using glm-5 ===");

--- a/examples/c99-bedrock-api.rs
+++ b/examples/c99-bedrock-api.rs
@@ -30,7 +30,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 		return Ok(());
 	}
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Example 1: Claude via Bedrock Converse
 	println!("--- Claude on Bedrock ---");

--- a/examples/c99-bedrock-sigv4.rs
+++ b/examples/c99-bedrock-sigv4.rs
@@ -41,7 +41,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 	tracing_subscriber::fmt().with_env_filter(EnvFilter::new("genai=debug")).init();
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Example 1: Claude via Bedrock Converse + SigV4
 	println!("--- Claude on Bedrock (SigV4) ---");

--- a/examples/c99-github-copilot.rs
+++ b/examples/c99-github-copilot.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		ChatMessage::user(question),
 	]);
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let adapter_kind = client.resolve_service_target(MODEL).await?.model.adapter_kind;
 

--- a/examples/c99-google-gcp.rs
+++ b/examples/c99-google-gcp.rs
@@ -63,7 +63,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 	let auth_resolver = AuthResolver::from_resolver_async_fn(resolve_fn);
 
 	// -- Create Chat Client
-	let client = Client::builder().with_auth_resolver(auth_resolver).build();
+	let client = Client::builder().with_auth_resolver(auth_resolver).build()?;
 
 	// -- Example 1: Gemini on Vertex AI
 	println!("--- Gemini on Vertex AI ---");

--- a/examples/c99-ollama-cloud.rs
+++ b/examples/c99-ollama-cloud.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		ChatMessage::user(question),
 	]);
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let adapter_kind = client.resolve_service_target(MODEL).await?.model.adapter_kind;
 

--- a/examples/c99-zai.rs
+++ b/examples/c99-zai.rs
@@ -9,7 +9,7 @@ use genai::chat::{ChatMessage, ChatRequest};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-	let client = Client::builder().build();
+	let client = Client::builder().build()?;
 
 	// Test cases demonstrating automatic endpoint routing
 	let test_cases = vec![

--- a/examples/e01-embed-basic.rs
+++ b/examples/e01-embed-basic.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		// .with_max_level(tracing::Level::DEBUG) // To enable all sub-library tracing
 		.init();
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	println!("=== GenAI Embedding Examples ===\n");
 

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -6,6 +6,7 @@ use crate::resolver::{
 };
 use crate::webc::WebClient;
 use crate::{Client, ClientConfig, WebConfig};
+use crate::{Error, Result};
 use std::sync::Arc;
 
 /// Builder for `Client`.
@@ -112,7 +113,7 @@ impl ClientBuilder {
 
 impl ClientBuilder {
 	/// Build a `Client`.
-	pub fn build(self) -> Client {
+	pub fn build(self) -> Result<Client> {
 		let config = self.config.unwrap_or_default();
 
 		// Create WebClient based on configuration
@@ -121,20 +122,26 @@ impl ClientBuilder {
 			web_client
 		} else if let Some(req_config) = config.web_config() {
 			// Create WebClient with reqwest configuration
-			let mut builder = reqwest::Client::builder();
-			builder = req_config.apply_to_builder(builder);
-			let reqwest_client = builder.build().expect("Failed to build reqwest client");
-			WebClient::from_reqwest_client(reqwest_client)
+			let mut reqwest_builder = reqwest::Client::builder();
+			reqwest_builder = req_config.apply_to_builder(reqwest_builder);
+			WebClient::from_reqwest_client(build_reqwest(reqwest_builder)?)
 		} else {
 			// Use default WebClient with performance optimizations
 			let default_config = super::web_config::WebConfig::default();
-			let mut builder = reqwest::Client::builder();
-			builder = default_config.apply_to_builder(builder);
-			let reqwest_client = builder.build().expect("Failed to build reqwest client");
-			WebClient::from_reqwest_client(reqwest_client)
+			let mut reqwest_builder = reqwest::Client::builder();
+			reqwest_builder = default_config.apply_to_builder(reqwest_builder);
+			WebClient::from_reqwest_client(build_reqwest(reqwest_builder)?)
 		};
 
 		let inner = super::ClientInner { web_client, config };
-		Client { inner: Arc::new(inner) }
+
+		Ok(Client { inner: Arc::new(inner) })
 	}
+}
+
+fn build_reqwest(reqwest_builder: reqwest::ClientBuilder) -> Result<reqwest::Client> {
+	let reqwest_client = reqwest_builder
+		.build()
+		.map_err(|e| Error::ClientBuildFail { cause: e.to_string() })?;
+	Ok(reqwest_client)
 }

--- a/src/client/client_types.rs
+++ b/src/client/client_types.rs
@@ -1,5 +1,5 @@
 use crate::webc::WebClient;
-use crate::{ClientBuilder, ClientConfig};
+use crate::{ClientBuilder, ClientConfig, Result};
 use std::sync::Arc;
 
 /// Client for sending AI requests to supported providers.
@@ -15,21 +15,16 @@ pub struct Client {
 
 // region:    --- Client Constructors
 
-impl Default for Client {
-	/// Creates a [`Client`] with default configuration.
-	///
-	/// Equivalent to `Client::builder().build()`.
-	fn default() -> Self {
-		Client::builder().build()
-	}
-}
-
 impl Client {
 	/// Returns a builder for configuring and constructing a [`Client`].
 	///
 	/// Equivalent to calling [`ClientBuilder::default()`].
 	pub fn builder() -> ClientBuilder {
 		ClientBuilder::default()
+	}
+
+	pub fn new() -> Result<Client> {
+		Client::builder().build()
 	}
 }
 

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -294,6 +294,8 @@ mod tests {
 	use super::*;
 	use crate::resolver::{AuthData, AuthResolver, Endpoint, ServiceTargetResolver};
 
+	type TestResult = core::result::Result<(), Box<dyn std::error::Error>>;
+
 	/// Build a ClientConfig bound to the given adapter, with an
 	/// auth/service-target resolver pair gated on that same adapter —
 	/// mirroring the real-world configuration shape this feature is meant
@@ -443,16 +445,18 @@ mod tests {
 	}
 
 	#[test]
-	fn bound_client_exposes_adapter_kind_via_getter() {
+	fn bound_client_exposes_adapter_kind_via_getter() -> TestResult {
 		// `Client::adapter_kind()` is the introspection getter a
 		// caller uses to read the bound provider back off a built
 		// Client (without having to carry the AdapterKind alongside
 		// it). Set path returns Some, unset path returns None.
-		let bound = crate::Client::builder().with_adapter_kind(AdapterKind::OpenAI).build();
+		let bound = crate::Client::builder().with_adapter_kind(AdapterKind::OpenAI).build()?;
 		assert_eq!(bound.adapter_kind(), Some(AdapterKind::OpenAI));
 
-		let unbound = crate::Client::default();
+		let unbound = crate::Client::new()?;
 		assert_eq!(unbound.adapter_kind(), None);
+
+		Ok(())
 	}
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,9 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
 	// -- Chat Input
 	#[display("Chat Request has no messages. (for model {model_iden}")]
-	ChatReqHasNoMessages { model_iden: ModelIden },
+	ChatReqHasNoMessages {
+		model_iden: ModelIden,
+	},
 
 	#[display("Last chat request message is not of Role 'user' (Actual role '{actual_role}') for model '{model_iden}'")]
 	LastChatMessageIsNotUser {
@@ -27,42 +29,66 @@ pub enum Error {
 	},
 
 	#[display("Role '{role}' not supported for model '{model_iden}'")]
-	MessageRoleNotSupported { model_iden: ModelIden, role: ChatRole },
+	MessageRoleNotSupported {
+		model_iden: ModelIden,
+		role: ChatRole,
+	},
 
 	#[display("Content type not supported for model '{model_iden}'.\nCause: {cause}")]
-	MessageContentTypeNotSupported { model_iden: ModelIden, cause: &'static str },
+	MessageContentTypeNotSupported {
+		model_iden: ModelIden,
+		cause: &'static str,
+	},
 
 	#[display("JSON mode requested but no instruction/prompt provided.")]
 	JsonModeWithoutInstruction,
 
 	#[display("Failed to parse verbosity. Actual: '{actual}'")]
-	VerbosityParsing { actual: String },
+	VerbosityParsing {
+		actual: String,
+	},
 
 	#[display("Failed to parse reasoning. Actual: '{actual}'")]
-	ReasoningParsingError { actual: String },
+	ReasoningParsingError {
+		actual: String,
+	},
 
 	#[display("Failed to parse service tier. Actual: '{actual}'")]
-	ServiceTierParsing { actual: String },
+	ServiceTierParsing {
+		actual: String,
+	},
 
 	#[display("Failed to parse prompt cache retention. Actual: '{actual}'")]
-	PromptCacheRetentionParsing { actual: String },
+	PromptCacheRetentionParsing {
+		actual: String,
+	},
 
 	// -- Chat Output
 	#[display("No chat response from model '{model_iden}'")]
-	NoChatResponse { model_iden: ModelIden },
+	NoChatResponse {
+		model_iden: ModelIden,
+	},
 
 	#[display("Invalid JSON response element: {info}")]
-	InvalidJsonResponseElement { info: &'static str },
+	InvalidJsonResponseElement {
+		info: &'static str,
+	},
 
 	// -- Auth
 	#[display("Model '{model_iden}' requires an API key.")]
-	RequiresApiKey { model_iden: ModelIden },
+	RequiresApiKey {
+		model_iden: ModelIden,
+	},
 
 	#[display("No authentication resolver found for model '{model_iden}'.")]
-	NoAuthResolver { model_iden: ModelIden },
+	NoAuthResolver {
+		model_iden: ModelIden,
+	},
 
 	#[display("No authentication data available for model '{model_iden}'.")]
-	NoAuthData { model_iden: ModelIden },
+	NoAuthData {
+		model_iden: ModelIden,
+	},
 
 	// -- ModelMapper
 	#[display("Model mapping failed for '{model_iden}'.\nCause: {cause}")]
@@ -138,10 +164,16 @@ Cause:\n{cause}
 
 	// -- Adapter Support
 	#[display("Adapter '{adapter_kind}' does not support feature '{feature}'")]
-	AdapterNotSupported { adapter_kind: AdapterKind, feature: String },
+	AdapterNotSupported {
+		adapter_kind: AdapterKind,
+		feature: String,
+	},
 
 	#[display("Cache breakpoint requested for model '{model_iden}', but {scope} has no eligible OpenAI content block.")]
-	CacheBreakpointNoEligibleContent { model_iden: ModelIden, scope: &'static str },
+	CacheBreakpointNoEligibleContent {
+		model_iden: ModelIden,
+		scope: &'static str,
+	},
 
 	#[display(
 		"Client is bound to adapter '{bound}' but model '{model}' resolved to adapter '{requested}'. \
@@ -159,6 +191,12 @@ Drop the `::` namespace prefix or `ModelSpec::Iden`, or build a Client without \
 
 	#[display("Internal error: {_0}")]
 	Internal(String),
+
+	// -- Client Error
+	#[display("Failed to build client.\nCause: {cause}")]
+	ClientBuildFail {
+		cause: String,
+	},
 
 	// -- Externals
 	#[display("JSON value extension error: {_0}")]

--- a/src/webc/web_client.rs
+++ b/src/webc/web_client.rs
@@ -11,8 +11,10 @@ pub struct WebClient {
 }
 
 // Implements Default with performance optimizations
-impl Default for WebClient {
-	fn default() -> Self {
+impl WebClient {
+	// TODO: Needs to understand why this one is not used. Either remove or use.
+	#[allow(unused)]
+	pub fn new() -> Result<Self> {
 		use std::time::Duration;
 		let reqwest_client = reqwest::Client::builder()
 			.tcp_nodelay(true)
@@ -23,8 +25,9 @@ impl Default for WebClient {
 			.http2_keep_alive_while_idle(true)
 			.http2_adaptive_window(true)
 			.build()
-			.expect("Failed to build default reqwest client");
-		WebClient { reqwest_client }
+			.map_err(Error::Reqwest)?;
+
+		Ok(WebClient { reqwest_client })
 	}
 }
 

--- a/tests/support/common_tests.rs
+++ b/tests/support/common_tests.rs
@@ -28,7 +28,7 @@ pub async fn common_test_chat_simple_ok(model: &str, checks: Option<Check>) -> T
 	validate_checks(checks.clone(), Check::REASONING_CONTENT | Check::REASONING_USAGE)?;
 
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
@@ -69,7 +69,7 @@ pub async fn common_test_chat_reasoning_ok(
 	checks: Option<Check>,
 ) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages (deactivate to see the differences)
 		ChatMessage::system("Answer in one sentence. But make think hard to make sure it is not a trick question."),
@@ -122,7 +122,7 @@ pub async fn common_test_chat_reasoning_ok(
 pub async fn common_test_chat_verbosity_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
 	let chat_client_options = ChatOptions::default().with_reasoning_effort(ReasoningEffort::Low);
-	let client = Client::builder().with_chat_options(chat_client_options).build();
+	let client = Client::builder().with_chat_options(chat_client_options).build()?;
 	let chat_req = ChatRequest::new(vec![
 		//
 		ChatMessage::user("Why is the sky blue?"),
@@ -150,7 +150,7 @@ pub async fn common_test_chat_verbosity_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_chat_top_system_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages (deactivate to see the differences)
 		ChatMessage::user("Why is the sky blue?"),
@@ -169,7 +169,7 @@ pub async fn common_test_chat_top_system_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_chat_multi_system_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages (deactivate to see the differences)
 		ChatMessage::system("Be very concise"),
@@ -203,7 +203,7 @@ pub async fn common_test_chat_json_mode_ok(model: &str, checks: Option<Check>) -
 	validate_checks(checks.clone(), Check::USAGE)?;
 
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages (de/activate to see the differences)
 		ChatMessage::system(
@@ -249,7 +249,7 @@ pub async fn common_test_chat_json_structured_ok(model: &str, checks: Option<Che
 	validate_checks(checks.clone(), Check::USAGE)?;
 
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages (de/activate to see the differences)
 		ChatMessage::system(
@@ -316,7 +316,7 @@ Reply in a JSON format."#,
 
 pub async fn common_test_chat_temperature_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_simple();
 	let chat_options = ChatOptions::default().with_temperature(0.);
 
@@ -334,7 +334,7 @@ pub async fn common_test_chat_temperature_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_chat_stop_sequences_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = ChatRequest::from_user("What is the capital of England?");
 	let chat_options = ChatOptions::default().with_stop_sequences(vec!["London".to_string()]);
 
@@ -354,7 +354,7 @@ pub async fn common_test_chat_reasoning_normalize_ok(model: &str) -> TestResult<
 	// -- Setup & Fixtures
 	let client = Client::builder()
 		.with_chat_options(ChatOptions::default().with_normalize_reasoning_content(true))
-		.build();
+		.build()?;
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
@@ -395,7 +395,7 @@ pub async fn common_test_chat_reasoning_normalize_ok(model: &str) -> TestResult<
 
 pub async fn common_test_chat_cache_implicit_simple_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let big_content = get_big_content()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages (deactivate to see the differences)
@@ -440,7 +440,7 @@ pub async fn common_test_chat_cache_implicit_simple_ok(model: &str) -> TestResul
 
 pub async fn common_test_chat_cache_explicit_user_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 
 	let big_content = get_big_content()?;
 	let chat_req = ChatRequest::new(vec![
@@ -480,7 +480,7 @@ pub async fn common_test_chat_cache_explicit_user_ok(model: &str) -> TestResult<
 
 pub async fn common_test_chat_cache_explicit_system_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let big_content = get_big_content()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages (deactivate to see the differences)
@@ -522,7 +522,7 @@ pub async fn common_test_chat_cache_explicit_system_ok(model: &str) -> TestResul
 /// Note: 1h TTL is only supported on Claude 4.5 models (Opus 4.5, Sonnet 4.5, Haiku 4.5).
 pub async fn common_test_chat_cache_explicit_1h_ttl_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let big_content = get_big_content()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages
@@ -566,7 +566,7 @@ pub async fn common_test_chat_stream_cache_explicit_1h_ttl_ok(model: &str) -> Te
 	// -- Setup & Fixtures
 	let client = Client::builder()
 		.with_chat_options(ChatOptions::default().with_capture_usage(true))
-		.build();
+		.build()?;
 	let big_content = get_big_content()?;
 	let chat_req = ChatRequest::new(vec![
 		// -- Messages
@@ -614,7 +614,7 @@ pub async fn common_test_chat_stream_simple_ok(model: &str, checks: Option<Check
 	validate_checks(checks.clone(), Check::REASONING_CONTENT)?;
 
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
@@ -666,7 +666,7 @@ pub async fn common_test_chat_stream_capture_content_ok(model: &str) -> TestResu
 	// -- Setup & Fixtures
 	let client = Client::builder()
 		.with_chat_options(ChatOptions::default().with_capture_content(true))
-		.build();
+		.build()?;
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
@@ -714,7 +714,7 @@ pub async fn common_test_chat_stream_capture_all_ok(model: &str, checks: Option<
 		chat_options = chat_options.with_reasoning_effort(ReasoningEffort::Medium);
 	}
 
-	let client = Client::builder().with_chat_options(chat_options).build();
+	let client = Client::builder().with_chat_options(chat_options).build()?;
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
@@ -805,7 +805,7 @@ pub async fn common_test_chat_stream_frame_sink_ok(model: &str) -> TestResult<()
 	let spy = Arc::new(FrameSpy::default());
 	let sink: Arc<dyn ChatFrameSink> = spy.clone();
 	let chat_options = ChatOptions::default().with_raw_frame_sink_arc(sink);
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
@@ -834,7 +834,7 @@ pub async fn common_test_chat_stream_frame_sink_ok(model: &str) -> TestResult<()
 /// `complete_check` if for LLMs that are better at giving back the unit and weather.
 pub async fn common_test_chat_stream_tool_capture_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_tool_simple();
 	let mut chat_options = ChatOptions::default().with_capture_tool_calls(true);
 
@@ -868,7 +868,7 @@ pub async fn common_test_chat_stream_tool_capture_ok(model: &str) -> TestResult<
 
 pub async fn common_test_chat_image_url_ok(model: &str) -> TestResult<()> {
 	// -- Setup
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build & Exec
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
@@ -888,7 +888,7 @@ pub async fn common_test_chat_image_url_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_chat_image_b64_ok(model: &str) -> TestResult<()> {
 	// -- Setup
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build & Exec
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
@@ -909,7 +909,7 @@ pub async fn common_test_chat_image_b64_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_chat_image_file_ok(model: &str) -> TestResult<()> {
 	// -- Setup
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build & Exec
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
@@ -935,7 +935,7 @@ pub async fn common_test_chat_audio_b64_ok(model: &str) -> TestResult<()> {
 	}
 
 	// -- Setup
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build & Exec
 	let mut chat_req = ChatRequest::default().with_system("Transcribe the audio");
@@ -963,7 +963,7 @@ pub async fn common_test_chat_video_b64_ok(model: &str) -> TestResult<()> {
 	}
 
 	// -- Setup
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build & Exec
 	// NOTE: Might not extract audio
@@ -988,7 +988,7 @@ pub async fn common_test_chat_video_b64_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_chat_pdf_b64_ok(model: &str) -> TestResult<()> {
 	// -- Setup
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build & Exec
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
@@ -1009,7 +1009,7 @@ pub async fn common_test_chat_pdf_b64_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_chat_multi_binary_b64_ok(model: &str) -> TestResult<()> {
 	// -- Setup
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Build & Exec
 	let mut chat_req = ChatRequest::default().with_system("Answer in one sentence");
@@ -1041,7 +1041,7 @@ Can you tell me what those images and files are about.
 /// `complete_check` if for LLMs that are better at giving back the unit and weather.
 pub async fn common_test_tool_simple_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_tool_simple();
 
 	// -- Exec
@@ -1062,7 +1062,7 @@ pub async fn common_test_tool_simple_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_tool_full_flow_ok(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let mut chat_req = seed_chat_req_tool_simple();
 
 	// -- Exec first request to get the tool calls
@@ -1103,7 +1103,7 @@ pub async fn common_test_tool_full_flow_ok(model: &str) -> TestResult<()> {
 pub async fn common_test_resolver_auth_ok(model: &str, auth_data: AuthData) -> TestResult<()> {
 	// -- Setup & Fixtures
 	let auth_resolver = AuthResolver::from_resolver_fn(move |model_iden: ModelIden| Ok(Some(auth_data)));
-	let client = Client::builder().with_auth_resolver(auth_resolver).build();
+	let client = Client::builder().with_auth_resolver(auth_resolver).build()?;
 	let chat_req = seed_chat_req_simple();
 
 	// -- Exec
@@ -1123,7 +1123,7 @@ pub async fn common_test_resolver_auth_ok(model: &str, auth_data: AuthData) -> T
 // region:    --- List
 
 pub async fn common_test_list_models(adapter_kind: AdapterKind, contains: &str) -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Exec
 	let models = client.all_model_names(adapter_kind, None).await?;
@@ -1144,7 +1144,7 @@ pub async fn common_test_embed_single_simple_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_embed_single_simple_ok_with_usage_check(model: &str, expect_usage: bool) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let text = "Hello, world!";
 
 	// -- Exec
@@ -1195,7 +1195,7 @@ pub async fn common_test_embed_single_with_options_ok_with_usage_check(
 	expect_usage: bool,
 ) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let text = "Test with options";
 
 	let options = EmbedOptions::new()
@@ -1235,7 +1235,7 @@ pub async fn common_test_embed_batch_simple_ok(model: &str) -> TestResult<()> {
 
 pub async fn common_test_embed_batch_simple_ok_with_usage_check(model: &str, expect_usage: bool) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let texts = vec!["First text".to_string(), "Second text".to_string(), "Third text".to_string()];
 
 	// -- Exec
@@ -1297,7 +1297,7 @@ pub async fn common_test_embed_provider_specific_options_ok_with_usage_check(
 	expect_usage: bool,
 ) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let text = "Test with provider-specific options";
 
 	let mut options = EmbedOptions::new()
@@ -1339,7 +1339,7 @@ pub async fn common_test_embed_provider_specific_options_ok_with_usage_check(
 
 pub async fn common_test_embed_empty_batch_should_fail(model: &str) -> TestResult<()> {
 	// -- Setup & Fixtures
-	let client = Client::default();
+	let client = Client::new()?;
 	let texts: Vec<String> = vec![];
 
 	// -- Exec

--- a/tests/support/yakbak/mod.rs
+++ b/tests/support/yakbak/mod.rs
@@ -39,7 +39,7 @@ pub async fn replay_client(provider: &str, scenario: &str) -> TestResult<(Client
 				})
 			},
 		))
-		.build();
+		.build()?;
 
 	Ok((client, server))
 }
@@ -66,7 +66,7 @@ pub async fn record_client(provider: &str, scenario: &str, backend_url: &str) ->
 				})
 			},
 		))
-		.build();
+		.build()?;
 
 	Ok((client, server))
 }

--- a/tests/tests_p_custom.rs
+++ b/tests/tests_p_custom.rs
@@ -21,7 +21,7 @@ async fn test_chat_simple_ok() -> TestResult<()> {
 async fn test_list_models() -> TestResult<()> {
 	// common_tests::common_test_list_models(AdapterKind::DeepSeek, "deepseek-v4-flash").await
 
-	let client = Client::default();
+	let client = Client::new()?;
 
 	// -- Exec
 	let models = client.all_model_names(AdapterKind::Custom(1), None).await?;

--- a/tests/tests_p_gemini.rs
+++ b/tests/tests_p_gemini.rs
@@ -138,7 +138,7 @@ async fn test_tool_deterministic_history_gemini_3_ok() -> TestResult<()> {
 	use genai::chat::{ChatMessage, ChatRequest, Tool, ToolCall, ToolResponse};
 	use serde_json::json;
 
-	let client = genai::Client::default();
+	let client = genai::Client::new()?;
 
 	let weather_tool = Tool::new("get_weather").with_schema(json!({
 		"type": "object",
@@ -185,7 +185,7 @@ async fn test_tool_google_web_search_ok() -> TestResult<()> {
 	use serde_json::json;
 
 	// -- Fixtures & Setup
-	let client = genai::Client::default();
+	let client = genai::Client::new()?;
 	let web_search_tool = Tool::new("googleSearch").with_config(json!({}));
 	let chat_req =
 		ChatRequest::from_user("What is the latest version of Rust? (be concise)").append_tool(web_search_tool);

--- a/tests/tests_p_gemini_image.rs
+++ b/tests/tests_p_gemini_image.rs
@@ -5,7 +5,7 @@ const MODEL: &str = "gemini-3-pro-image-preview";
 
 #[tokio::test]
 async fn test_p_gemini_image_generation() -> Result<(), Box<dyn std::error::Error>> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let prompt = "Generate a small icon of a star";
 	let chat_req = ChatRequest::new(vec![ChatMessage::user(prompt)]);
 

--- a/tests/tests_p_ollama_reasoning.rs
+++ b/tests/tests_p_ollama_reasoning.rs
@@ -76,7 +76,7 @@ async fn test_chat_stream_capture_content_ok() -> TestResult<()> {
 #[tokio::test]
 #[serial(ollama)]
 async fn test_chat_stream_reasoning_chunk_ok() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_simple();
 
 	let chat_res = client.exec_chat_stream(MODEL_QWEN3, chat_req, None).await?;
@@ -101,7 +101,7 @@ async fn test_chat_stream_reasoning_chunk_ok() -> TestResult<()> {
 #[tokio::test]
 #[serial(ollama)]
 async fn test_chat_stream_non_empty_chunk_deepseek_ok() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let chat_req = seed_chat_req_simple();
 
 	let chat_res = client.exec_chat_stream(MODEL, chat_req, None).await?;

--- a/tests/tests_p_openai_embeddings.rs
+++ b/tests/tests_p_openai_embeddings.rs
@@ -45,7 +45,7 @@ async fn test_embed_batch_empty_should_fail() -> TestResult<()> {
 
 #[tokio::test]
 async fn test_embed_request_single_ok() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let embed_req = EmbedRequest::from_text("Direct EmbedRequest test");
 
 	let response = client.exec_embed(MODEL, embed_req, None).await?;
@@ -61,7 +61,7 @@ async fn test_embed_request_single_ok() -> TestResult<()> {
 
 #[tokio::test]
 async fn test_embed_request_batch_ok() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let embed_req = EmbedRequest::from_texts(vec![
 		"Batch request text 1".to_string(),
 		"Batch request text 2".to_string(),
@@ -85,7 +85,7 @@ async fn test_embed_request_batch_ok() -> TestResult<()> {
 
 #[tokio::test]
 async fn test_embed_different_models_ok() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let text = "Compare embedding models";
 
 	// Test small model
@@ -110,7 +110,7 @@ async fn test_embed_different_models_ok() -> TestResult<()> {
 
 #[tokio::test]
 async fn test_embed_invalid_model_should_fail() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let text = "Test with invalid model";
 
 	let result = client.embed("invalid-embedding-model", text, None).await;
@@ -125,7 +125,7 @@ async fn test_embed_invalid_model_should_fail() -> TestResult<()> {
 
 #[tokio::test]
 async fn test_embed_empty_text_should_work() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let text = "";
 
 	// Empty text should still work (though may have minimal dimensions)
@@ -146,7 +146,7 @@ async fn test_embed_empty_text_should_work() -> TestResult<()> {
 
 #[tokio::test]
 async fn test_embed_response_methods_ok() -> TestResult<()> {
-	let client = Client::default();
+	let client = Client::new()?;
 	let texts = vec!["First".to_string(), "Second".to_string()];
 
 	let response = client.embed_batch(MODEL, texts, None).await?;
@@ -180,7 +180,7 @@ async fn test_embed_response_methods_ok() -> TestResult<()> {
 #[tokio::test]
 async fn test_embed_with_openai_specific_options_ok() -> TestResult<()> {
 	// OpenAI supports encoding_format and user parameters
-	let client = Client::default();
+	let client = Client::new()?;
 	let text = "Test with OpenAI-specific options";
 
 	let options = EmbedOptions::new()


### PR DESCRIPTION
Related to #291


Eliminates production `.expect(...)` panics by making client initialization return a `Result`.

#### Key Changes

- Replaced panic-prone `reqwest::ClientBuilder::build().expect(...)` calls in `ClientBuilder` and `WebClient`.
- Removed `Client::default()`, replaced with fallible `Client::new() -> Result<Client>`.
- Updated `ClientBuilder::build() -> Result<Client>`.
- Removed `WebClient::default()`, kept fallible `WebClient::new() -> Result<Self>`.
- Added `Error::ClientBuildFail { cause }` to capture reqwest initialization failures.

#### Usage

```rust
// Before
let client = Client::default();

// After
let client = Client::new()?;
let client = Client::builder().build()?;
```
