### PR TITLE
fix(openai_resp): propagate streaming error events

### DIFF
--- a/src/adapter/adapters/openai_resp/streamer.rs
+++ b/src/adapter/adapters/openai_resp/streamer.rs
@@ -113,6 +113,9 @@ enum RespStreamEvent {
 	#[serde(rename = "response.incomplete")]
 	ResponseIncomplete { response: RespResponse },
 
+	#[serde(rename = "error")]
+	Error,
+
 	#[serde(other)]
 	Unknown,
 }
@@ -405,6 +408,21 @@ impl futures::Stream for OpenAIRespStreamer {
 							};
 
 							return Poll::Ready(Some(Ok(InterStreamEvent::End(inter_stream_end))));
+						}
+
+						RespStreamEvent::Error => {
+							self.done = true;
+							// Unlike response.failed, this event carries the error fields
+							// directly. Preserve the whole payload for callers.
+							let body =
+								serde_json::from_str(&message.data).map_err(|serde_error| Error::StreamParse {
+									model_iden: self.options.model_iden.clone(),
+									serde_error,
+								})?;
+							return Poll::Ready(Some(Err(Error::ChatResponse {
+								model_iden: self.options.model_iden.clone(),
+								body,
+							})));
 						}
 
 						RespStreamEvent::Unknown => {

--- a/tests/data/yakbak/openai_resp/stream_error/response_000.txt
+++ b/tests/data/yakbak/openai_resp/stream_error/response_000.txt
@@ -1,0 +1,3 @@
+event: error
+data: {"type": "error", "code": "ERR_SOMETHING", "message": "Something went wrong", "param": null, "sequence_number": 1}
+

--- a/tests/data/yakbak/openai_resp/stream_error_after_delta/response_000.txt
+++ b/tests/data/yakbak/openai_resp/stream_error_after_delta/response_000.txt
@@ -1,0 +1,9 @@
+event: response.output_text.delta
+data: {"type": "response.output_text.delta", "item_id": "msg_test", "output_index": 0, "content_index": 0, "delta": "Partial answer", "sequence_number": 1}
+
+event: error
+data: {"type": "error", "code": null, "message": "Something went wrong", "param": "input", "sequence_number": 2}
+
+event: response.output_text.delta
+data: {"type": "response.output_text.delta", "item_id": "msg_test", "output_index": 0, "content_index": 0, "delta": "must not escape", "sequence_number": 3}
+

--- a/tests/tests_yakbak_openai_resp.rs
+++ b/tests/tests_yakbak_openai_resp.rs
@@ -5,6 +5,7 @@
 
 mod support;
 
+use futures::StreamExt;
 use genai::chat::*;
 use serde_json::json;
 use support::yakbak::replay_client;
@@ -524,4 +525,62 @@ eof_line: "*** End of File" LF
 				"definition": apply_patch_grammar,
 			})),
 	)
+}
+
+// Protocol fixtures, not live recordings. The first uses the exact error object
+// from https://developers.openai.com/api/reference/resources/responses/streaming-events/#error.
+// The second adds a preceding delta, nullable code, non-null param, and a trailing
+// delta to verify that a provider error terminates the stream.
+#[tokio::test]
+async fn test_yakbak_openai_resp_stream_error() -> TestResult<()> {
+	check_stream_error("stream_error", false).await
+}
+
+#[tokio::test]
+async fn test_yakbak_openai_resp_stream_error_after_delta() -> TestResult<()> {
+	check_stream_error("stream_error_after_delta", true).await
+}
+
+async fn check_stream_error(scenario: &str, partial: bool) -> TestResult<()> {
+	for capture in [false, true] {
+		let (client, _server) = replay_client("openai_resp", scenario).await?;
+		let options = ChatOptions::default().with_capture_content(capture);
+		let mut stream = client
+			.exec_chat_stream(
+				"openai_resp::gpt-5.4-mini",
+				ChatRequest::new(vec![ChatMessage::user("Hello")]),
+				Some(&options),
+			)
+			.await?
+			.stream;
+		assert!(matches!(stream.next().await, Some(Ok(ChatStreamEvent::Start))));
+		if partial {
+			assert!(matches!(
+				stream.next().await,
+				Some(Ok(ChatStreamEvent::Chunk(chunk))) if chunk.content == "Partial answer"
+			));
+		}
+		match stream.next().await {
+			Some(Err(genai::Error::ChatResponse { model_iden, body })) => {
+				assert_eq!(model_iden.adapter_kind, genai::adapter::AdapterKind::OpenAIResp);
+				assert_eq!(
+					body,
+					json!({
+						"type": "error",
+						"code": if partial { None } else { Some("ERR_SOMETHING") },
+						"message": "Something went wrong",
+						"param": if partial { Some("input") } else { None },
+						"sequence_number": if partial { 2 } else { 1 },
+					})
+				);
+			}
+			other => panic!("expected provider error, got {other:?}"),
+		}
+		assert!(
+			stream.next().await.is_none(),
+			"no success End or further chunks after error"
+		);
+		assert!(stream.next().await.is_none());
+	}
+	Ok(())
 }


### PR DESCRIPTION

The Responses API can send a top-level `type: "error"` SSE event. The adapter currently treats it as unknown, so callers can receive a successful End after a provider failure. Recognize this event, return the existing `Error::ChatResponse` with the complete JSON payload, and terminate the stream so no success End or subsequent content is emitted.

Adds two loopback replay regressions using the official error protocol example and a partial-output variant, with content capture enabled and disabled. Both fail before the fix. The fixtures are protocol-derived, not live recordings. Related streaming discussion: #170; this does not claim to close that issue's original warning report.

Validation: 306 library tests and all 18 tests across the five CI replay targets pass; default Clippy with warnings denied and changed-file rustfmt pass. Whole-repository formatting differences and an optional `otel` non-exhaustive match error also reproduce on the base revision. No live provider requests were run.

Implemented and tested with assistance from Codex GPT-6.
