### PR TITLE
fix(openai) - capture OpenRouter's reasoning_details and echo them on assistant messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
   - `^` Preserve signed thinking blocks and thought signatures across streaming and non-streaming tool turns. (PR #275)
 - OpenAI:
   - `-` Propagate Responses API streaming `error` events as `genai::Error::ChatResponse` and cleanly terminate the stream. (PR #296)
+  - `+` Capture OpenRouter's `reasoning_details` (signed, encrypted and summary reasoning blocks) as `Custom` parts on the non-streaming path and echo them verbatim, in order, on assistant messages, so a multi-turn tool round trip through OpenRouter keeps the model's continuity token; `reasoning_content` is still echoed beside them.
   - `+` Route GPT-6 models (such as `gpt-6-astra`) to the OpenAI Responses API adapter.
   - `+` Support OpenAI Responses freeform custom tools with grammar-constrained raw-string input. Custom tools serialize as `type: "custom"`, custom tool-call input streams incrementally, and round-trips as `custom_tool_call` / `custom_tool_call_output` items. (PR #266)
   - `^` Capture `cache_write_tokens` from prompt-cache usage and normalize it to `Usage.prompt_tokens_details.cache_creation_tokens` for Chat Completions and Responses API payloads.

--- a/src/adapter/adapters/openai/adapter_impl.rs
+++ b/src/adapter/adapters/openai/adapter_impl.rs
@@ -1,7 +1,8 @@
 use super::OpenAIStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
-	ChatOptionsSet, ChatRequest, ChatResponse, ChatStream, ChatStreamResponse, MessageContent, StopReason, ToolCall,
+	ChatOptionsSet, ChatRequest, ChatResponse, ChatStream, ChatStreamResponse, ContentPart, MessageContent, StopReason,
+	ToolCall,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{EventSourceStream, WebClient, WebResponse};
@@ -100,6 +101,22 @@ impl Adapter for OpenAIAdapter {
 						.flatten()
 				})
 				.map(|s| s.trim().to_string());
+
+			// -- Capture reasoning_details as Custom parts, verbatim (OpenRouter)
+			// OpenRouter returns the provider's own reasoning blocks — signed text
+			// (Anthropic), encrypted content (OpenAI), summaries — as a `reasoning_details`
+			// array beside the plaintext `reasoning`, and requires that array back
+			// verbatim and in order for a multi-turn tool round trip to keep the
+			// model's continuity token. Each entry is carried as a `Custom` part, the
+			// same way an unrecognised Anthropic block is, so nothing in it is lost;
+			// the request side echoes them into `reasoning_details` again. They lead
+			// the content, ahead of the text and tool calls, which is the order they
+			// were produced in.
+			if let Ok(Some(details)) = first_choice.x_take::<Option<Vec<Value>>>("/message/reasoning_details") {
+				for detail in details.into_iter().filter(|detail| detail.is_object()) {
+					content.push(ContentPart::from_custom(detail, Some(model_iden.clone())));
+				}
+			}
 
 			// -- Push eventual text message
 			if let Ok(Some(mut text_content)) = first_choice.x_take::<Option<String>>("/message/content") {
@@ -316,5 +333,69 @@ mod tests {
 			.expect("chat response");
 
 		assert_eq!(response.stop_reason, None);
+	}
+
+	/// OpenRouter returns the provider's own reasoning blocks — signed text,
+	/// encrypted content, summaries — as `reasoning_details` beside the
+	/// plaintext `reasoning`, and needs them back verbatim on the next turn.
+	/// Each entry becomes a `Custom` part, ahead of the text and tool calls,
+	/// tagged with the model; the plaintext still lands in `reasoning_content`.
+	#[test]
+	fn test_to_chat_response_captures_reasoning_details_as_custom_parts() {
+		// -- Setup & Fixtures
+		let web_response = WebResponse {
+			status: StatusCode::OK,
+			body: serde_json::json!({
+				"id": "gen-test",
+				"model": "anthropic/claude-sonnet-4-6",
+				"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+				"choices": [{
+					"finish_reason": "tool_calls",
+					"message": {
+						"role": "assistant",
+						"content": "",
+						"reasoning": "Read the file first.",
+						"reasoning_details": [
+							{"type": "reasoning.text", "text": "Read the file first.", "signature": "sig-1", "format": "anthropic-claude-v1", "index": 0},
+							{"type": "reasoning.encrypted", "data": "opaque-bytes", "format": "openai-responses-v1", "index": 1}
+						],
+						"tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"/runbook\"}"}}]
+					}
+				}]
+			}),
+		};
+		let model = ModelIden::new(AdapterKind::OpenRouter, "anthropic/claude-sonnet-4-6");
+
+		// -- Exec
+		let response =
+			OpenAIAdapter::to_chat_response(model, web_response, ChatOptionsSet::default()).expect("chat response");
+
+		// -- Check
+		assert_eq!(response.reasoning_content.as_deref(), Some("Read the file first."));
+		let parts = response.content.parts();
+		let kinds: Vec<&str> = parts
+			.iter()
+			.map(|part| match part {
+				ContentPart::Custom(custom) => custom.typ().unwrap_or("custom"),
+				ContentPart::ToolCall(_) => "tool_call",
+				ContentPart::Text(_) => "text",
+				_ => "other",
+			})
+			.collect();
+		assert_eq!(
+			kinds,
+			["reasoning.text", "reasoning.encrypted", "tool_call"],
+			"every entry, in order, ahead of the tool call; an empty content string adds no text part"
+		);
+		let ContentPart::Custom(signed) = &parts[0] else {
+			panic!("first part is the signed block");
+		};
+		assert_eq!(signed.data()["signature"], "sig-1");
+		assert_eq!(signed.data()["format"], "anthropic-claude-v1");
+		assert_eq!(
+			signed.model_iden.as_ref().map(|m| m.model_name.to_string()).as_deref(),
+			Some("anthropic/claude-sonnet-4-6"),
+			"tagged with the model that produced it"
+		);
 	}
 }

--- a/src/adapter/adapters/openai/adapter_shared.rs
+++ b/src/adapter/adapters/openai/adapter_shared.rs
@@ -6,7 +6,8 @@ use crate::adapter::adapters::openai::OpenAIAdapter;
 use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::{AdapterDispatcher, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
-	BinarySource, CacheControl, ChatOptionsSet, ChatRequest, ChatRole, ContentPart, ReasoningEffort, ToolChoice, Usage,
+	BinarySource, CacheControl, ChatOptionsSet, ChatRequest, ChatRole, ContentPart, CustomPart, ReasoningEffort,
+	ToolChoice, Usage,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::WebClient;
@@ -417,6 +418,7 @@ impl OpenAIAdapter {
 					let mut texts: Vec<String> = Vec::new();
 					let mut tool_calls: Vec<Value> = Vec::new();
 					let mut reasoning_parts: Vec<String> = Vec::new();
+					let mut reasoning_details: Vec<Value> = Vec::new();
 					for part in msg.content {
 						match part {
 							ContentPart::Text(text) => texts.push(text),
@@ -438,7 +440,13 @@ impl OpenAIAdapter {
 							ContentPart::Binary(_) => (),
 							ContentPart::ToolResponse(_) => (),
 							ContentPart::ThoughtSignature(_) => {}
-							// Custom are ignored for this logic
+							// OpenRouter's reasoning blocks, captured verbatim by the response path,
+							// go back verbatim: a signed or encrypted block cannot be rebuilt from
+							// the plaintext, and the gateway requires the original sequence.
+							ContentPart::Custom(custom) if is_reasoning_detail(&custom) => {
+								reasoning_details.push(custom.data)
+							}
+							// Other Custom parts are ignored for this logic
 							ContentPart::Custom(_) => {}
 						}
 					}
@@ -461,6 +469,12 @@ impl OpenAIAdapter {
 					//       but we join defensively in case multiple parts are present.
 					if !reasoning_parts.is_empty() {
 						message.x_insert("reasoning_content", reasoning_parts.join("\n"))?;
+					}
+					// Echo reasoning_details back for OpenRouter, which needs the provider's
+					// signed/encrypted blocks — not just the plaintext — to keep a model's
+					// continuity across a tool round trip. Both fields may be present at once.
+					if !reasoning_details.is_empty() {
+						message.x_insert("reasoning_details", reasoning_details)?;
 					}
 					messages.push(message);
 				}
@@ -618,3 +632,9 @@ fn apply_chat_cache_breakpoint(_model_iden: &ModelIden, content: &mut [Value], _
 mod tests;
 
 // endregion: --- Tests
+
+/// Is this `Custom` part one of OpenRouter's `reasoning_details` entries
+/// (`reasoning.text`, `reasoning.encrypted`, `reasoning.summary`, …)?
+fn is_reasoning_detail(custom: &CustomPart) -> bool {
+	custom.typ().is_some_and(|typ| typ.starts_with("reasoning."))
+}

--- a/src/adapter/adapters/openai/adapter_shared_tests.rs
+++ b/src/adapter/adapters/openai/adapter_shared_tests.rs
@@ -179,6 +179,88 @@ fn test_no_reasoning_content_when_absent() -> Result<()> {
 	Ok(())
 }
 
+/// OpenRouter needs `reasoning_details` back verbatim and in order for a
+/// multi-turn tool round trip to keep the model's continuity token: a signed
+/// or encrypted block cannot be rebuilt from the plaintext. The entries the
+/// response path captured as `Custom` parts go out again as the same array,
+/// beside the plaintext `reasoning_content` echo.
+#[test]
+fn test_reasoning_details_echoed_verbatim_on_assistant_message() -> Result<()> {
+	// -- Setup & Fixtures
+	let signed = json!({
+		"type": "reasoning.text",
+		"text": "Read the file first.",
+		"signature": "sig-1",
+		"format": "anthropic-claude-v1",
+		"index": 0
+	});
+	let encrypted = json!({
+		"type": "reasoning.encrypted",
+		"data": "opaque-bytes",
+		"format": "openai-responses-v1",
+		"index": 1
+	});
+	let tool_call = ToolCall {
+		call_id: "call_1".to_string(),
+		fn_name: "read_file".to_string(),
+		fn_arguments: json!({"path": "/runbook"}),
+		thought_signatures: None,
+	};
+	let assistant_msg = ChatMessage::assistant(MessageContent::from_parts(vec![
+		ContentPart::from_custom(signed.clone(), None),
+		ContentPart::from_custom(encrypted.clone(), None),
+		ContentPart::ReasoningContent("Read the file first.".to_string()),
+		ContentPart::ToolCall(tool_call),
+	]));
+	let chat_req = ChatRequest::new(vec![ChatMessage::user("Read /runbook."), assistant_msg]);
+
+	// -- Exec
+	let parts = OpenAIAdapter::into_openai_request_parts(&test_model(), chat_req, None)?;
+
+	// -- Check
+	let assistant_json = parts
+		.messages
+		.get(1)
+		.ok_or_else(|| std::io::Error::other("assistant message should be present"))?;
+	assert_eq!(
+		assistant_json["reasoning_details"],
+		json!([signed, encrypted]),
+		"every entry, verbatim, in order"
+	);
+	assert_eq!(
+		assistant_json["reasoning_content"], "Read the file first.",
+		"the plaintext echo stays beside it"
+	);
+	assert_eq!(assistant_json["tool_calls"][0]["id"], "call_1");
+
+	Ok(())
+}
+
+/// A `Custom` part that is not a reasoning block stays ignored on this wire,
+/// as before: only entries whose `type` starts with `reasoning.` are echoed.
+#[test]
+fn test_custom_parts_that_are_not_reasoning_blocks_are_not_echoed() -> Result<()> {
+	// -- Setup & Fixtures
+	let assistant_msg = ChatMessage::assistant(MessageContent::from_parts(vec![
+		ContentPart::from_custom(json!({"type": "server_tool_use", "id": "srv_1"}), None),
+		ContentPart::Text("Done.".to_string()),
+	]));
+	let chat_req = ChatRequest::new(vec![ChatMessage::user("Hi"), assistant_msg]);
+
+	// -- Exec
+	let parts = OpenAIAdapter::into_openai_request_parts(&test_model(), chat_req, None)?;
+
+	// -- Check
+	let assistant_json = parts
+		.messages
+		.get(1)
+		.ok_or_else(|| std::io::Error::other("assistant message should be present"))?;
+	assert!(assistant_json.get("reasoning_details").is_none());
+	assert_eq!(assistant_json["content"], "Done.");
+
+	Ok(())
+}
+
 #[test]
 fn test_gpt_5_6_chat_completion_defaults_to_explicit_cache_mode() -> Result<()> {
 	// -- Setup & Fixtures


### PR DESCRIPTION
Fixes #298.

OpenRouter returns a provider's own reasoning blocks — Anthropic's signed text, OpenAI's encrypted content, summaries — as a `reasoning_details` array beside the plaintext `reasoning`, and requires that array back verbatim and in order for a multi-turn tool round trip to keep the model's continuity token; plaintext `reasoning_content` is only enough for models that return raw reasoning strings. The adapter read the plaintext and nothing else, so through OpenRouter a signed or encrypted block was dropped on decode and the next request went out without it. The gateway accepts that request and the model continues without its prior reasoning, so nothing errors.

**Change.** On decode, each `reasoning_details` entry becomes a `ContentPart::Custom` (verbatim, tagged with the model), ahead of the text and tool calls — the same treatment an unrecognised Anthropic block already gets. On encode, `Custom` parts whose `type` starts with `reasoning.` go out again as `reasoning_details`, in order, beside the existing `reasoning_content` echo. Other `Custom` parts stay ignored on this wire. Verbatim rather than typed because the round trip needs `format`, `id` and `index` back unchanged and the sequence untouched.

**Verified live** against `anthropic/claude-sonnet-4-6` and `moonshotai/kimi-k3` through OpenRouter on 2026-09-05: sending both fields together on a replayed assistant turn is accepted, and with `reasoning_details` present the signature is carried; with plaintext only it is not.

**Tests.** `test_to_chat_response_captures_reasoning_details_as_custom_parts` (decode: both entry types, in order, ahead of the tool call, model-tagged, plaintext still in `reasoning_content`), `test_reasoning_details_echoed_verbatim_on_assistant_message` (encode: byte-identical array beside `reasoning_content`), `test_custom_parts_that_are_not_reasoning_blocks_are_not_echoed`. The first two fail without the change.

**Scope.** Non-streaming path only; `delta.reasoning_details` in the streamer is a follow-up. No Anthropic or Gemini behaviour changes. CHANGELOG entry under OpenAI.