### PR TITLE
fix(anthropic) - map output_tokens_details.thinking_tokens to completion_tokens_details.reasoning_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   - Fable and Mythos omit `thinking`, because it is always on and cannot be explicitly disabled.
   - The Anthropic `-zero` model suffix is canonical, while `-none` remains a backward-compatible alias. Both map to `Zero` and are stripped.
   - `^` Preserve signed thinking blocks and thought signatures across streaming and non-streaming tool turns. Rebuilds thinking blocks ahead of text and tool calls, adds `ChatResponse::into_assistant_message_for_tool_use`, and safely omits unpaired thinking blocks. (PR #275)
+  - `-` Map `usage.output_tokens_details.thinking_tokens` to `completion_tokens_details.reasoning_tokens` on the non-streaming path, so the thinking share of `output_tokens` reads the same way as for the OpenAI and Gemini adapters; `completion_tokens` is unchanged, since Anthropic's `output_tokens` already includes it.
 - Gemini:
   - `^` Map `ReasoningEffort::Zero` to a budget of `0`, which might be rejected by the provider on some models.
 - OpenAI and Bedrock:

--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -6,8 +6,9 @@ use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{
 	Binary, BinarySource, CacheControl, CacheCreationDetails, ChatOptionsSet, ChatRequest, ChatResponse,
-	ChatResponseFormat, ChatRole, ContentPart, JsonSchemaDialect, MessageContent, PromptTokensDetails, ReasoningEffort,
-	StopReason, Tool, ToolCall, ToolChoice, ToolConfig, ToolName, Usage, sanitize_json_schema,
+	ChatResponseFormat, ChatRole, CompletionTokensDetails, ContentPart, JsonSchemaDialect, MessageContent,
+	PromptTokensDetails, ReasoningEffort, StopReason, Tool, ToolCall, ToolChoice, ToolConfig, ToolName, Usage,
+	sanitize_json_schema,
 };
 use crate::resolver::{AuthData, Endpoint};
 use crate::webc::{WebClient, WebResponse};
@@ -69,6 +70,16 @@ impl AnthropicAdapter {
 		let cache_creation_input_tokens: i32 = usage_value.x_take("cache_creation_input_tokens").unwrap_or(0);
 		let cache_read_input_tokens: i32 = usage_value.x_take("cache_read_input_tokens").unwrap_or(0);
 		let completion_tokens: i32 = usage_value.x_take("output_tokens").ok().unwrap_or(0);
+		// Anthropic reports the thinking share of `output_tokens` as
+		// `output_tokens_details.thinking_tokens` (adaptive thinking). It maps to
+		// `completion_tokens_details.reasoning_tokens`, the field the OpenAI and Gemini
+		// adapters fill, so the split reads the same across adapters. `output_tokens`
+		// already includes it, so `completion_tokens` needs no normalization.
+		let thinking_tokens = usage_value
+			.get("output_tokens_details")
+			.and_then(|details| details.get("thinking_tokens"))
+			.and_then(Value::as_i64)
+			.map(|tokens| tokens as i32);
 
 		// Parse cache_creation breakdown if present (TTL-specific breakdown)
 		let cache_creation_details = usage_value.get("cache_creation").and_then(parse_cache_creation_details);
@@ -98,8 +109,12 @@ impl AnthropicAdapter {
 			prompt_tokens_details,
 
 			completion_tokens: Some(completion_tokens),
-			// for now, None for Anthropic
-			completion_tokens_details: None,
+			completion_tokens_details: thinking_tokens.map(|reasoning_tokens| CompletionTokensDetails {
+				accepted_prediction_tokens: None,
+				rejected_prediction_tokens: None,
+				reasoning_tokens: Some(reasoning_tokens),
+				audio_tokens: None,
+			}),
 
 			total_tokens: Some(total_tokens),
 		}

--- a/src/adapter/adapters/anthropic/adapter_shared_tests.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared_tests.rs
@@ -862,3 +862,59 @@ fn build_characterization_payload(model_name: &str, reasoning_effort: Option<Rea
 }
 
 // endregion: --- Support
+
+/// Anthropic reports the thinking share of `output_tokens` as
+/// `usage.output_tokens_details.thinking_tokens`. It must land in
+/// `completion_tokens_details.reasoning_tokens` — the field the OpenAI and Gemini
+/// adapters already fill — with `completion_tokens` untouched, since Anthropic's
+/// `output_tokens` already includes the thinking share.
+#[test]
+fn test_non_stream_usage_maps_thinking_tokens_to_reasoning_tokens() {
+	let response = AnthropicAdapter::build_chat_response(
+		ModelIden::new(AdapterKind::Anthropic, "fixture-model"),
+		WebResponse {
+			status: StatusCode::OK,
+			body: json!({
+				"model": "fixture-model",
+				"content": [{"type": "text", "text": "301"}],
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 485,
+					"output_tokens": 189,
+					"output_tokens_details": {"thinking_tokens": 182}
+				}
+			}),
+		},
+	)
+	.expect("Anthropic response should parse");
+
+	let details = response
+		.usage
+		.completion_tokens_details
+		.expect("the thinking share is reported");
+	assert_eq!(details.reasoning_tokens, Some(182));
+	assert_eq!(response.usage.completion_tokens, Some(189));
+	assert_eq!(response.usage.prompt_tokens, Some(485));
+}
+
+/// Without `output_tokens_details`, nothing is invented: the details stay `None`
+/// rather than becoming a zero.
+#[test]
+fn test_non_stream_usage_without_thinking_share_has_no_completion_details() {
+	let response = AnthropicAdapter::build_chat_response(
+		ModelIden::new(AdapterKind::Anthropic, "fixture-model"),
+		WebResponse {
+			status: StatusCode::OK,
+			body: json!({
+				"model": "fixture-model",
+				"content": [{"type": "text", "text": "ok"}],
+				"stop_reason": "end_turn",
+				"usage": {"input_tokens": 3, "output_tokens": 4}
+			}),
+		},
+	)
+	.expect("Anthropic response should parse");
+
+	assert!(response.usage.completion_tokens_details.is_none());
+	assert_eq!(response.usage.completion_tokens, Some(4));
+}


### PR DESCRIPTION
Fixes #300.

Anthropic reports the thinking share of `output_tokens` as `usage.output_tokens_details.thinking_tokens`, and `into_usage` dropped it (`completion_tokens_details: None`, "for now"). It now lands in `completion_tokens_details.reasoning_tokens`, the field the OpenAI and Gemini adapters already fill, so the thought-versus-spoken split reads the same way across the three adapters.

**Change.** `into_usage` reads `output_tokens_details.thinking_tokens` when present and builds a `CompletionTokensDetails` with only `reasoning_tokens` set. `completion_tokens` is untouched: Anthropic's `output_tokens` already includes the thinking share, unlike OpenAI's `completion_tokens`, so there is no re-summing. When the field is absent the details stay `None` — nothing is invented.

**Tests.** `test_non_stream_usage_maps_thinking_tokens_to_reasoning_tokens` (fails without the change) and `test_non_stream_usage_without_thinking_share_has_no_completion_details`. The existing Anthropic suites pass unchanged.

**Scope.** Non-streaming path. The streamer's `message_delta.usage` handling is unchanged; whether Anthropic sends `output_tokens_details` on that path is not verified here. CHANGELOG entry under Anthropic.