### PR TITLE
. pr-followup #303 - usage details zero-as-none

### DIFF
--- a/src/adapter/adapters/anthropic/adapter_shared.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared.rs
@@ -79,7 +79,8 @@ impl AnthropicAdapter {
 			.get("output_tokens_details")
 			.and_then(|details| details.get("thinking_tokens"))
 			.and_then(Value::as_i64)
-			.map(|tokens| tokens as i32);
+			.map(|tokens| tokens as i32)
+			.filter(|&tokens| tokens > 0);
 
 		// Parse cache_creation breakdown if present (TTL-specific breakdown)
 		let cache_creation_details = usage_value.get("cache_creation").and_then(parse_cache_creation_details);

--- a/src/adapter/adapters/anthropic/adapter_shared_tests.rs
+++ b/src/adapter/adapters/anthropic/adapter_shared_tests.rs
@@ -918,3 +918,30 @@ fn test_non_stream_usage_without_thinking_share_has_no_completion_details() {
 	assert!(response.usage.completion_tokens_details.is_none());
 	assert_eq!(response.usage.completion_tokens, Some(4));
 }
+
+#[test]
+fn test_non_stream_usage_zero_thinking_tokens_is_none() -> Result<()> {
+	// -- Setup & Fixtures
+	let response = AnthropicAdapter::build_chat_response(
+		ModelIden::new(AdapterKind::Anthropic, "fixture-model"),
+		WebResponse {
+			status: StatusCode::OK,
+			body: json!({
+				"model": "fixture-model",
+				"content": [{"type": "text", "text": "ok"}],
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 10,
+					"output_tokens": 5,
+					"output_tokens_details": {"thinking_tokens": 0}
+				}
+			}),
+		},
+	)?;
+
+	// -- Exec & Check
+	assert!(response.usage.completion_tokens_details.is_none());
+	assert_eq!(response.usage.completion_tokens, Some(5));
+
+	Ok(())
+}


### PR DESCRIPTION
# PR - . pr-followup #303 - usage details zero-as-none

Follow-up to PR #303 (issue #300).

## Summary

In PR #303, `usage.output_tokens_details.thinking_tokens` was mapped to `completion_tokens_details.reasoning_tokens` for the Anthropic non-streaming adapter path.

This follow-up ensures that if Anthropic returns `output_tokens_details.thinking_tokens` with a count of `0`, it is treated as `None` rather than `Some(0)`. This aligns with genai's zero-as-none normalization convention across usage details (such as `PromptTokensDetails` and `zero_as_none` deserializers), ensuring an empty `CompletionTokensDetails` struct is not instantiated when no thinking tokens were used.

## Changes

- In `src/adapter/adapters/anthropic/adapter_shared.rs`, filtered out non-positive values via `.filter(|&tokens| tokens > 0)` when extracting `thinking_tokens`.
- In `src/adapter/adapters/anthropic/adapter_shared_tests.rs`, added `test_non_stream_usage_zero_thinking_tokens_is_none`.
