### PR TITLE
fix(chat): preserve per-call thought signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@
   - Exposes `genai::adapter::gemini_ix` helper types (`EnrichedEvent`, `UrlCitation`, `GroundingToolCount`) for decoding search grounding citations and server-side tool metadata via `ChatFrameSink`.
 
 ### Additions & Fixes
- 
+
+- `-` Chat - Preserve each tool call's thought signatures when converting `Vec<ToolCall>` into an assistant message, avoiding duplicate OpenAI Responses reasoning items and incorrect Gemini signature pairing. ([#306](https://github.com/jeremychone/rust-genai/issues/306))
 - `-` ChatOptions - Allow partial deserialization without `stop_sequences`, defaulting it to an empty vector. (PR #285)
 - `+` Adapter - Add `AdapterKind::all()` to enumerate built-in adapters, excluding `Custom`. (PR #286)
 - `+` Error - Add `Error::status()` and `webc::Error::status()` accessors for HTTP status inspection. (PR #287)

--- a/docs/for-llm/api-reference-for-llm.md
+++ b/docs/for-llm/api-reference-for-llm.md
@@ -221,7 +221,7 @@ Stateful OpenAI Responses session support is available through `previous_respons
 - `with_reasoning_content(reasoning: Option<String>)`: Appends `ContentPart::ReasoningContent` when provided. Since v0.6.0.
 - `assistant_tool_calls_with_thoughts(calls, thoughts)`: For continuing tool exchanges where thoughts must precede tool calls. Since v0.6.0.
 - `size()`: Approximate in-memory size in bytes.
-- `From<Vec<ToolCall>>`: Creates assistant message with tool calls (auto-prepends thoughts if present on first call). Updated in v0.6.0 for thought-signature tool handoff support.
+- `From<Vec<ToolCall>>`: Creates an assistant message with tool calls, preserving thought signatures on their respective calls. Use `assistant_tool_calls_with_thoughts(...)` for separate turn-level signatures that must precede the calls.
 - `From<ToolResponse>`: Creates tool-role message.
 - `From<Vec<ToolResponse>>`: Creates a tool-role multipart message.
 

--- a/src/chat/chat_message.rs
+++ b/src/chat/chat_message.rs
@@ -172,15 +172,12 @@ pub enum ChatRole {
 // region:    --- Froms
 
 /// Creates an assistant message containing the provided tool calls.
+///
+/// Thought signatures remain attached to their respective calls. Use
+/// [`ChatMessage::assistant_tool_calls_with_thoughts`] when the signatures are
+/// separate turn-level content that should precede the calls.
 impl From<Vec<ToolCall>> for ChatMessage {
 	fn from(tool_calls: Vec<ToolCall>) -> Self {
-		if let Some(first) = tool_calls.first()
-			&& let Some(thoughts) = &first.thought_signatures
-		{
-			let mut parts: Vec<ContentPart> = thoughts.iter().cloned().map(ContentPart::ThoughtSignature).collect();
-			parts.extend(tool_calls.into_iter().map(ContentPart::ToolCall));
-			return ChatMessage::assistant(MessageContent::from_parts(parts));
-		}
 		Self {
 			role: ChatRole::Assistant,
 			content: MessageContent::from(tool_calls),
@@ -202,3 +199,108 @@ impl From<Vec<ToolResponse>> for ChatMessage {
 }
 
 // endregion: --- Froms
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::adapter::{AdapterDispatcher, AdapterKind, ServiceType};
+	use crate::chat::{ChatOptionsSet, ChatRequest};
+	use crate::resolver::AuthData;
+	use crate::{ModelIden, ServiceTarget};
+	use serde_json::json;
+
+	type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>;
+
+	fn signed_tool_calls() -> Vec<ToolCall> {
+		vec![
+			ToolCall {
+				call_id: "call-1".to_string(),
+				fn_name: "first".to_string(),
+				fn_arguments: json!({}),
+				thought_signatures: Some(vec!["sig-1a".to_string(), "sig-1b".to_string()]),
+			},
+			ToolCall {
+				call_id: "call-2".to_string(),
+				fn_name: "second".to_string(),
+				fn_arguments: json!({}),
+				thought_signatures: Some(vec!["sig-2".to_string()]),
+			},
+		]
+	}
+
+	#[test]
+	fn from_tool_calls_keeps_signatures_on_their_calls() {
+		let message = ChatMessage::from(signed_tool_calls());
+		let parts = message.content.parts();
+
+		assert_eq!(parts.len(), 2);
+		assert!(matches!(
+			&parts[0],
+			ContentPart::ToolCall(call)
+				if call.thought_signatures.as_deref()
+					== Some(["sig-1a".to_string(), "sig-1b".to_string()].as_slice())
+		));
+		assert!(matches!(
+			&parts[1],
+			ContentPart::ToolCall(call)
+				if call.thought_signatures.as_deref() == Some(["sig-2".to_string()].as_slice())
+		));
+	}
+
+	#[test]
+	fn from_tool_calls_does_not_duplicate_openai_reasoning_items() -> Result<()> {
+		let adapter_kind = AdapterKind::OpenAIResp;
+		let target = ServiceTarget {
+			model: ModelIden::new(adapter_kind, "gpt-5.6"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: AdapterDispatcher::default_endpoint(adapter_kind),
+		};
+		let request = ChatRequest::new(vec![ChatMessage::user("go"), ChatMessage::from(signed_tool_calls())]);
+
+		let web_request =
+			AdapterDispatcher::to_web_request_data(target, ServiceType::Chat, request, ChatOptionsSet::default())?;
+		let input = web_request.payload["input"].as_array().ok_or("input should be an array")?;
+		let signatures = input
+			.iter()
+			.filter(|item| item["type"] == "reasoning")
+			.filter_map(|item| item["encrypted_content"].as_str())
+			.collect::<Vec<_>>();
+
+		assert_eq!(signatures, ["sig-1a", "sig-1b", "sig-2"]);
+		Ok(())
+	}
+
+	#[test]
+	fn from_tool_calls_keeps_gemini_signatures_with_their_calls() -> Result<()> {
+		let adapter_kind = AdapterKind::Gemini;
+		let target = ServiceTarget {
+			model: ModelIden::new(adapter_kind, "gemini-3-pro"),
+			auth: AuthData::from_single("test-key"),
+			endpoint: AdapterDispatcher::default_endpoint(adapter_kind),
+		};
+		let request = ChatRequest::new(vec![ChatMessage::user("go"), ChatMessage::from(signed_tool_calls())]);
+
+		let web_request =
+			AdapterDispatcher::to_web_request_data(target, ServiceType::Chat, request, ChatOptionsSet::default())?;
+		let contents = web_request.payload["contents"]
+			.as_array()
+			.ok_or("contents should be an array")?;
+		let model_turn = contents
+			.iter()
+			.find(|content| content["role"] == "model")
+			.ok_or("model turn should be present")?;
+		let parts = model_turn["parts"].as_array().ok_or("parts should be an array")?;
+		let rendered = parts
+			.iter()
+			.map(|part| {
+				(
+					part["functionCall"]["name"].as_str().unwrap_or("-"),
+					part["thoughtSignature"].as_str().unwrap_or("-"),
+				)
+			})
+			.collect::<Vec<_>>();
+
+		assert_eq!(rendered, [("first", "sig-1a"), ("second", "sig-2")]);
+		Ok(())
+	}
+}

--- a/src/chat/chat_stream.rs
+++ b/src/chat/chat_stream.rs
@@ -241,8 +241,8 @@ impl From<InterStreamEnd> for StreamEnd {
 			.filter_map(|part| part.as_thought_signature().map(str::to_string))
 			.collect::<Vec<_>>();
 		if !mirrored_signatures.is_empty() {
-			// Also attach thoughts to the first tool call so that
-			// ChatMessage::from(Vec<ToolCall>) can auto-prepend them.
+			// Also attach thoughts to the first tool call so callers that retain only
+			// captured tool calls can still preserve the provider continuation data.
 			if let Some(tool_calls) = captured_tool_calls.as_mut()
 				&& let Some(first_call) = tool_calls.first_mut()
 			{

--- a/src/chat/tool/tool_call.rs
+++ b/src/chat/tool/tool_call.rs
@@ -15,14 +15,12 @@ pub struct ToolCall {
 	/// Kept as `serde_json::Value` so callers can deserialize into their own types.
 	pub fn_arguments: Value,
 
-	/// Convenience mirror of the canonical `ContentPart::ThoughtSignature` values that
-	/// should precede tool calls in the assistant turn.
+	/// Thought signatures associated with this tool call.
 	///
-	/// When present on the first tool call in a batch, `ChatMessage::from(Vec<ToolCall>)`
-	/// will automatically include these as leading `ThoughtSignature` parts in the
-	/// assistant message content. This enables simple continuations like:
-	/// `append_message(tool_calls).append_message(tool_response)` without having to
-	/// manually inject thoughts.
+	/// `ChatMessage::from(Vec<ToolCall>)` preserves these on each call so adapters can
+	/// serialize them with the corresponding tool invocation. For turn-level signatures
+	/// that should precede all calls as `ContentPart::ThoughtSignature` values, use
+	/// `ChatMessage::assistant_tool_calls_with_thoughts`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub thought_signatures: Option<Vec<String>>,
 }


### PR DESCRIPTION
## Summary

`ChatMessage::from(Vec<ToolCall>)` currently copies the first call’s thought signatures into leading content parts while leaving them on the call. OpenAI Responses then serializes the first set twice, and Gemini can pair a later signature with the first call.

Keep signatures on their respective `ToolCall` values. Callers with separate turn-level signatures can continue to use `assistant_tool_calls_with_thoughts`.

Adds conversion and adapter-payload regressions covering both reported failure modes, and updates the API documentation.

Fixes #306.

## Validation

- `cargo test --lib` (323 passed)
- replay suites for OpenAI Responses, Gemini, Gemini Interactions, Anthropic, GitHub Copilot, Ollama Cloud, and AIHubMix (31 passed)
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Prepared and tested with assistance from OpenAI Codex. No live provider requests were run.