### PR TITLE
Pr/bedrock aws fixes

### DIFF
--- a/examples/c99-bedrock-api.rs
+++ b/examples/c99-bedrock-api.rs
@@ -4,10 +4,13 @@
 //! and no extra dependencies pulled in. It authenticates with a Bedrock API key passed in the
 //! `Authorization: Bearer` header.
 //!
-//! Required env vars:
-//!   - BEDROCK_API_KEY: a Bedrock API key (see
+//! Required env var — either of these names works:
+//!   - BEDROCK_API_KEY, OR
+//!   - AWS_BEARER_TOKEN_BEDROCK (the name AWS documents, see
 //!     https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html)
-//!   - AWS_REGION (optional): defaults to `us-east-1`. Model availability varies by region.
+//!
+//! Optional:
+//!   - AWS_REGION: defaults to `us-east-1`. Model availability varies by region.
 //!
 //! Run with: `cargo run --example c99-bedrock-api`
 
@@ -25,8 +28,8 @@ const NOVA_MODEL: &str = "bedrock_api::global.amazon.nova-2-lite-v1:0";
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 	tracing_subscriber::fmt().with_env_filter(EnvFilter::new("genai=debug")).init();
 
-	if std::env::var("BEDROCK_API_KEY").is_err() {
-		println!("Set BEDROCK_API_KEY to run this example.");
+	if std::env::var("BEDROCK_API_KEY").is_err() && std::env::var("AWS_BEARER_TOKEN_BEDROCK").is_err() {
+		println!("Set BEDROCK_API_KEY (or AWS_BEARER_TOKEN_BEDROCK) to run this example.");
 		return Ok(());
 	}
 

--- a/examples/c99-bedrock-sigv4.rs
+++ b/examples/c99-bedrock-sigv4.rs
@@ -5,7 +5,7 @@
 //!
 //! Credentials come from the AWS default chain: environment variables, shared credentials file,
 //! SSO session, IMDS, or an assumed role. No `API key` is needed — set up AWS credentials the
-//! same way you would for the AWS CLI.
+//! same way you would for the AWS CLI. Temporary credentials are refreshed before they expire.
 //!
 //! Run with: `cargo run --example c99-bedrock-sigv4 --features bedrock-sigv4`
 //!

--- a/src/adapter/adapters/bedrock/adapter_api.rs
+++ b/src/adapter/adapters/bedrock/adapter_api.rs
@@ -1,6 +1,7 @@
-//! Bedrock adapter backed by Bedrock's simple Bearer-token auth (`BEDROCK_API_KEY`).
+//! Bedrock adapter backed by Bedrock's simple Bearer-token auth.
 //!
-//! Requires the `bedrock-api` Cargo feature. Pulls in no new dependencies.
+//! Reads the token from `BEDROCK_API_KEY`, falling back to `AWS_BEARER_TOKEN_BEDROCK` — the name
+//! AWS documents.
 //!
 //! See: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html
 
@@ -19,6 +20,39 @@ pub struct BedrockApiAdapter;
 
 impl BedrockApiAdapter {
 	pub const API_KEY_DEFAULT_ENV_NAME: &'static str = "BEDROCK_API_KEY";
+
+	/// AWS's documented name for Bedrock bearer tokens; used as a fallback.
+	pub const API_KEY_AWS_ENV_NAME: &'static str = "AWS_BEARER_TOKEN_BEDROCK";
+
+	/// Candidate env vars, in priority order.
+	fn api_key_env_names() -> [&'static str; 2] {
+		[Self::API_KEY_DEFAULT_ENV_NAME, Self::API_KEY_AWS_ENV_NAME]
+	}
+
+	/// Resolves the token for this adapter's default env lookup: `BEDROCK_API_KEY` first, then
+	/// `AWS_BEARER_TOKEN_BEDROCK`. Any other `AuthData` (explicit key, custom env name, resolver
+	/// result) is used as-is.
+	fn resolve_api_key(auth: AuthData, model: &ModelIden) -> Result<String> {
+		let uses_adapter_default_env = matches!(
+			&auth,
+			AuthData::FromEnv(env_name) if env_name.as_str() == Self::API_KEY_DEFAULT_ENV_NAME
+		);
+
+		if !uses_adapter_default_env {
+			return get_api_key(auth, model);
+		}
+
+		if let Some(api_key) = first_set_env_var(|name| std::env::var(name)) {
+			return Ok(api_key);
+		}
+
+		Err(Error::Resolver {
+			model_iden: model.clone(),
+			resolver_error: crate::resolver::Error::ApiKeyEnvNotFound {
+				env_name: Self::api_key_env_names().join(" or "),
+			},
+		})
+	}
 
 	fn resolve_region() -> String {
 		std::env::var("AWS_REGION")
@@ -63,7 +97,7 @@ impl Adapter for BedrockApiAdapter {
 	) -> Result<WebRequestData> {
 		let ServiceTarget { endpoint, auth, model } = target;
 
-		let api_key = get_api_key(auth, &model)?;
+		let api_key = Self::resolve_api_key(auth, &model)?;
 		let payload = build_converse_payload(&model, chat_req, options_set)?;
 		let url = Self::get_service_url(&model, service_type, endpoint)?;
 
@@ -118,5 +152,51 @@ impl Adapter for BedrockApiAdapter {
 			adapter_kind: AdapterKind::BedrockApi,
 			feature: "embeddings".to_string(),
 		})
+	}
+}
+
+/// Returns the value of the first candidate env var set to a non-empty value.
+fn first_set_env_var(lookup: impl Fn(&str) -> std::result::Result<String, std::env::VarError>) -> Option<String> {
+	BedrockApiAdapter::api_key_env_names()
+		.into_iter()
+		.find_map(|name| lookup(name).ok().filter(|value| !value.is_empty()))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn prefers_the_genai_env_var() {
+		let key = first_set_env_var(|name| match name {
+			"BEDROCK_API_KEY" | "AWS_BEARER_TOKEN_BEDROCK" => Ok(format!("{name}-value")),
+			_ => Err(std::env::VarError::NotPresent),
+		});
+		assert_eq!(key.as_deref(), Some("BEDROCK_API_KEY-value"));
+	}
+
+	#[test]
+	fn falls_back_to_the_aws_env_var() {
+		let key = first_set_env_var(|name| match name {
+			"AWS_BEARER_TOKEN_BEDROCK" => Ok("aws-token".to_string()),
+			_ => Err(std::env::VarError::NotPresent),
+		});
+		assert_eq!(key.as_deref(), Some("aws-token"));
+	}
+
+	#[test]
+	fn no_env_var_set_yields_none() {
+		let key = first_set_env_var(|_| Err(std::env::VarError::NotPresent));
+		assert_eq!(key, None);
+	}
+
+	#[test]
+	fn empty_env_var_falls_through_to_the_next_candidate() {
+		let key = first_set_env_var(|name| match name {
+			"BEDROCK_API_KEY" => Ok(String::new()),
+			"AWS_BEARER_TOKEN_BEDROCK" => Ok("aws-token".to_string()),
+			_ => Err(std::env::VarError::NotPresent),
+		});
+		assert_eq!(key.as_deref(), Some("aws-token"));
 	}
 }

--- a/src/adapter/adapters/bedrock/adapter_sigv4.rs
+++ b/src/adapter/adapters/bedrock/adapter_sigv4.rs
@@ -68,7 +68,7 @@ impl Adapter for BedrockSigv4Adapter {
 		// 1. Resolve credentials, refreshing them when they are close to expiring.
 		let cached = tokio_block_on(get_credentials())?;
 
-		// 2. Determine region. Respect custom endpoint from ServiceTargetResolver.
+		// 2. Align the default endpoint with the region we sign for.
 		let endpoint = override_endpoint_region(endpoint, cached_region(&cached));
 
 		// 3. Build the Converse JSON payload.
@@ -129,12 +129,12 @@ impl Adapter for BedrockSigv4Adapter {
 	}
 }
 
-/// If the Endpoint's base URL is the default template with a placeholder region, substitute the
-/// cached region. If the user supplied a custom endpoint, leave it alone.
-fn override_endpoint_region(endpoint: Endpoint, cached_region: &str) -> Endpoint {
-	let base = endpoint.base_url();
-	if base.contains("bedrock-runtime..amazonaws.com") || base == "https://bedrock-runtime..amazonaws.com/" {
-		Endpoint::from_owned(BedrockSigv4Adapter::endpoint_for_region(cached_region))
+/// Rebuilds the default endpoint for the region we sign for (which may come from
+/// `~/.aws/config`); a user-supplied endpoint is left alone.
+fn override_endpoint_region(endpoint: Endpoint, signed_region: &str) -> Endpoint {
+	let env_default = BedrockSigv4Adapter::endpoint_for_region(&BedrockSigv4Adapter::resolve_region());
+	if endpoint.base_url() == env_default {
+		Endpoint::from_owned(BedrockSigv4Adapter::endpoint_for_region(signed_region))
 	} else {
 		endpoint
 	}
@@ -144,4 +144,52 @@ fn override_endpoint_region(endpoint: Endpoint, cached_region: &str) -> Endpoint
 /// blocks the calling worker thread.
 fn tokio_block_on<F: std::future::Future>(fut: F) -> F::Output {
 	tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// A region that differs from the ambient `AWS_REGION`, to keep the test deterministic.
+	fn region_different_from_env() -> &'static str {
+		if BedrockSigv4Adapter::resolve_region() == "eu-west-1" {
+			"us-west-2"
+		} else {
+			"eu-west-1"
+		}
+	}
+
+	/// The URL must target the region we sign for, else the signature carries one region while
+	/// the Host header points at another (`SignatureDoesNotMatch`).
+	#[test]
+	fn request_url_targets_the_region_we_sign_for() {
+		let signing_region = region_different_from_env();
+		let model = ModelIden::new(
+			AdapterKind::BedrockSigv4,
+			"us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+		);
+
+		let endpoint = BedrockSigv4Adapter::default_endpoint(AdapterKind::BedrockSigv4);
+		let endpoint = override_endpoint_region(endpoint, signing_region);
+		let url = BedrockSigv4Adapter::get_service_url(&model, ServiceType::Chat, endpoint)
+			.expect("the Bedrock Converse URL should build");
+
+		assert!(
+			url.contains(&format!("bedrock-runtime.{signing_region}.amazonaws.com")),
+			"request URL region != signing region; SigV4 would fail with SignatureDoesNotMatch. \
+			 signing_region={signing_region} url={url}"
+		);
+	}
+
+	/// A user-supplied endpoint must not be rewritten.
+	#[test]
+	fn user_supplied_endpoint_is_left_alone() {
+		let custom = Endpoint::from_static("https://vpce-0123.bedrock-runtime.eu-west-1.vpce.amazonaws.com/");
+		let endpoint = override_endpoint_region(custom, "us-east-1");
+
+		assert_eq!(
+			endpoint.base_url(),
+			"https://vpce-0123.bedrock-runtime.eu-west-1.vpce.amazonaws.com/"
+		);
+	}
 }

--- a/src/adapter/adapters/bedrock/adapter_sigv4.rs
+++ b/src/adapter/adapters/bedrock/adapter_sigv4.rs
@@ -65,7 +65,7 @@ impl Adapter for BedrockSigv4Adapter {
 			model,
 		} = target;
 
-		// 1. Resolve credentials (cached). Only truly async on the first call per process.
+		// 1. Resolve credentials, refreshing them when they are close to expiring.
 		let cached = tokio_block_on(get_credentials())?;
 
 		// 2. Determine region. Respect custom endpoint from ServiceTargetResolver.
@@ -140,8 +140,8 @@ fn override_endpoint_region(endpoint: Endpoint, cached_region: &str) -> Endpoint
 	}
 }
 
-/// Synchronously run a future on the current Tokio runtime. The adapter trait is sync; the
-/// credential cache only blocks on the very first call per process.
+/// Run a future to completion on the current Tokio runtime; the adapter trait is sync, so this
+/// blocks the calling worker thread.
 fn tokio_block_on<F: std::future::Future>(fut: F) -> F::Output {
 	tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut))
 }

--- a/src/adapter/adapters/bedrock/mod.rs
+++ b/src/adapter/adapters/bedrock/mod.rs
@@ -9,7 +9,7 @@
 //! * `BedrockSigv4Adapter` — opt-in via the `bedrock-sigv4` Cargo feature. Full AWS credential
 //!   chain + SigV4 request signing via `aws-config` and `aws-sigv4`. Best for workloads that
 //!   already use AWS credentials (env, profile, SSO, IMDS, AssumeRole). Pulls in the AWS SDK
-//!   smithy/hyper dep tree.
+//!   smithy/hyper dep tree. Temporary credentials are refreshed before they expire.
 //!
 //! Both adapters use the Converse API which normalizes chat requests across Bedrock's
 //! publishers (Anthropic, Amazon Nova, Meta Llama, Mistral, Cohere, AI21).

--- a/src/adapter/adapters/bedrock/sigv4.rs
+++ b/src/adapter/adapters/bedrock/sigv4.rs
@@ -1,39 +1,90 @@
 //! SigV4 signing + credential resolution for Bedrock.
 //!
-//! Credentials are resolved once via `aws-config`'s default chain (env → profile → SSO → IMDS →
-//! AssumeRole) and cached in a `OnceCell`. Signing itself happens per-request via `aws-sigv4`.
+//! Credentials come from `aws-config`'s default chain (env → profile → SSO → IMDS → AssumeRole)
+//! and are cached until shortly before they expire; signing is per-request via `aws-sigv4`.
+//!
+//! The cache mirrors the AWS SDK's identity cache: expire `REFRESH_BUFFER` early, fall back to
+//! `DEFAULT_EXPIRATION` when no expiry is reported, deduplicate concurrent refreshes, and jitter
+//! to avoid lockstep. Without it, a long-lived process would keep signing with credentials that
+//! expired an hour after start-up (`provide_credentials()` returns a frozen snapshot).
 
 use crate::Headers;
 use crate::{Error, Result};
 use aws_credential_types::Credentials;
+use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
 use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, sign};
 use aws_sigv4::sign::v4;
-use std::time::SystemTime;
-use tokio::sync::OnceCell;
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
+use std::time::{Duration, SystemTime};
+use tokio::sync::{Mutex, OnceCell};
 
 /// Service name for SigV4 scope; matches the service expected by `bedrock-runtime`.
 pub(super) const BEDROCK_SERVICE: &str = "bedrock";
 
-/// Cached credential provider + resolved region.
-///
-/// `aws-config` performs async IO for some providers (IMDS, SSO), so we resolve lazily.
-static CREDS_CACHE: OnceCell<CachedCreds> = OnceCell::const_new();
+/// Treat credentials as expired this long before their real expiration.
+/// Mirrors `DEFAULT_BUFFER_TIME` in the AWS SDK's identity cache.
+const REFRESH_BUFFER: Duration = Duration::from_secs(10);
 
+/// TTL when the provider reports no expiration (e.g. static env credentials).
+/// Mirrors `DEFAULT_EXPIRATION` in the AWS SDK's identity cache.
+const DEFAULT_EXPIRATION: Duration = Duration::from_secs(15 * 60);
+
+/// Credential provider + region, resolved once per process.
+static AWS_CONFIG: OnceCell<AwsConfig> = OnceCell::const_new();
+
+/// Expiry-aware credentials cache; `None` until the first resolution.
+static CREDS_CACHE: Mutex<Option<CachedCreds>> = Mutex::const_new(None);
+
+struct AwsConfig {
+	provider: SharedCredentialsProvider,
+	region: String,
+}
+
+/// Resolved credentials and the region they were resolved for.
 #[derive(Clone)]
 pub(super) struct CachedCreds {
 	pub creds: Credentials,
 	pub region: String,
+	/// Expiration (or default TTL) plus jitter; cache bookkeeping only.
+	deadline: SystemTime,
 }
 
-/// Returns cached credentials + region, loading them on first use.
+/// Returns credentials + region, refreshing them when they are close to expiring.
+///
+/// Holding the lock across the refresh deduplicates concurrent callers, as the AWS SDK's
+/// `ExpiringCache::get_or_load` does.
 pub(super) async fn get_credentials() -> Result<CachedCreds> {
-	let cached = CREDS_CACHE.get_or_try_init(load_credentials_uncached).await?;
-	Ok(cached.clone())
+	let config = get_aws_config().await?;
+	let now = SystemTime::now();
+
+	let mut cache = CREDS_CACHE.lock().await;
+
+	// Fast path: the cached credentials are still fresh.
+	if let Some(cached) = cache.as_ref()
+		&& !expired(cached.deadline, now)
+	{
+		return Ok(cached.clone());
+	}
+
+	// Slow path: refresh.
+	let creds = fetch_credentials(config).await?;
+	let cached = CachedCreds {
+		deadline: deadline(creds.expiry(), now, jitter_fraction()),
+		creds,
+		region: config.region.clone(),
+	};
+	cache.replace(cached.clone());
+
+	Ok(cached)
 }
 
-async fn load_credentials_uncached() -> Result<CachedCreds> {
+async fn get_aws_config() -> Result<&'static AwsConfig> {
+	AWS_CONFIG.get_or_try_init(load_aws_config).await
+}
+
+async fn load_aws_config() -> Result<AwsConfig> {
 	use aws_config::BehaviorVersion;
-	use aws_credential_types::provider::ProvideCredentials;
 
 	let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
 
@@ -44,17 +95,41 @@ async fn load_credentials_uncached() -> Result<CachedCreds> {
 		.or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
 		.unwrap_or_else(|| "us-east-1".to_string());
 
-	let provider = config.credentials_provider().ok_or_else(|| Error::AdapterNotSupported {
-		adapter_kind: crate::adapter::AdapterKind::BedrockSigv4,
-		feature: "AWS credentials (no provider found in default chain)".to_string(),
-	})?;
+	let provider = config
+		.credentials_provider()
+		.ok_or_else(|| aws_err("AWS credentials (no provider found in default chain)"))?;
 
-	let creds = provider.provide_credentials().await.map_err(|err| Error::AdapterNotSupported {
-		adapter_kind: crate::adapter::AdapterKind::BedrockSigv4,
-		feature: format!("AWS credential resolution failed: {err}"),
-	})?;
+	Ok(AwsConfig { provider, region })
+}
 
-	Ok(CachedCreds { creds, region })
+async fn fetch_credentials(config: &AwsConfig) -> Result<Credentials> {
+	config
+		.provider
+		.provide_credentials()
+		.await
+		.map_err(|err| aws_err(format!("AWS credential resolution failed: {err}")))
+}
+
+/// `true` once `now` is within `REFRESH_BUFFER` of the deadline.
+/// Mirrors the AWS SDK's expiration check.
+fn expired(deadline: SystemTime, now: SystemTime) -> bool {
+	deadline.checked_sub(REFRESH_BUFFER).is_none_or(|refresh_at| now >= refresh_at)
+}
+
+/// Provider expiration, or a default TTL, plus jitter.
+/// Mirrors how the AWS SDK stores `expiration + jitter`.
+fn deadline(expiry: Option<SystemTime>, now: SystemTime, jitter_fraction: f64) -> SystemTime {
+	let base = expiry.unwrap_or(now + DEFAULT_EXPIRATION);
+	base + REFRESH_BUFFER.mul_f64(jitter_fraction)
+}
+
+/// A random fraction in `[0.0, 0.5)`, the range the AWS SDK multiplies into its buffer.
+fn jitter_fraction() -> f64 {
+	// `RandomState` is seeded from OS entropy, so no `rand` dependency is needed.
+	let mut hasher = RandomState::new().build_hasher();
+	hasher.write_u64(0);
+	// Top 53 bits give a uniform value in [0, 1).
+	((hasher.finish() >> 11) as f64 / (1_u64 << 53) as f64) * 0.5
 }
 
 /// Extract the region from an already-loaded credentials snapshot.
@@ -104,6 +179,13 @@ pub(super) fn sign_request(creds: &Credentials, region: &str, url: &str, body: &
 	Ok(Headers::from(genai_headers_vec))
 }
 
+fn aws_err(feature: impl Into<String>) -> Error {
+	Error::AdapterNotSupported {
+		adapter_kind: crate::adapter::AdapterKind::BedrockSigv4,
+		feature: feature.into(),
+	}
+}
+
 fn sign_err(msg: String) -> Error {
 	Error::AdapterNotSupported {
 		adapter_kind: crate::adapter::AdapterKind::BedrockSigv4,
@@ -125,6 +207,10 @@ fn url_host(url: &str) -> Option<&str> {
 mod tests {
 	use super::*;
 
+	fn epoch_secs(secs: u64) -> SystemTime {
+		SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+	}
+
 	#[test]
 	fn extracts_host_from_url() {
 		assert_eq!(
@@ -136,5 +222,57 @@ mod tests {
 			Some("bedrock-runtime.us-east-1.amazonaws.com")
 		);
 		assert_eq!(url_host("http://localhost:4566/model/x/converse"), Some("localhost"));
+	}
+
+	#[test]
+	fn expired_only_within_the_buffer() {
+		let now = epoch_secs(1_000);
+
+		// Still outside the buffer: reuse the cached credentials.
+		assert!(!expired(epoch_secs(1_060), now));
+		// Inside the buffer: refresh before they actually expire.
+		assert!(expired(epoch_secs(1_010), now));
+		// Exactly at the buffer boundary.
+		assert!(expired(epoch_secs(1_000), now));
+		// Already past the real expiration.
+		assert!(expired(epoch_secs(999), now));
+	}
+
+	#[test]
+	fn deadline_uses_default_expiration_when_provider_reports_none() {
+		let now = epoch_secs(1_000);
+		// Static env credentials have no expiry, so they still get a TTL.
+		assert_eq!(deadline(None, now, 0.0), now + DEFAULT_EXPIRATION);
+	}
+
+	#[test]
+	fn deadline_uses_provider_expiration_when_present() {
+		let now = epoch_secs(1_000);
+		let expiry = epoch_secs(4_600);
+		assert_eq!(deadline(Some(expiry), now, 0.0), expiry);
+	}
+
+	#[test]
+	fn deadline_jitter_never_exceeds_half_the_buffer() {
+		let now = epoch_secs(1_000);
+		let expiry = epoch_secs(4_600);
+		let upper = expiry + REFRESH_BUFFER.div_f64(2.0);
+
+		for _ in 0..1_000 {
+			let with_jitter = deadline(Some(expiry), now, jitter_fraction());
+			assert!(with_jitter >= expiry, "jitter must not shorten the deadline");
+			assert!(with_jitter < upper, "jitter must stay below half the buffer");
+		}
+	}
+
+	#[test]
+	fn jitter_fraction_is_in_the_aws_sdk_range() {
+		for _ in 0..1_000 {
+			let fraction = jitter_fraction();
+			assert!(
+				(0.0..0.5).contains(&fraction),
+				"jitter fraction out of range: {fraction}"
+			);
+		}
 	}
 }


### PR DESCRIPTION
Three independent fixes for the AWS Bedrock adapters. Each has a regression test that fails without it.

**1. `bedrock_sigv4` — refresh credentials before they expire.**
`provide_credentials()` returns an immutable snapshot, but it was cached in a `OnceCell` for the life of the process. Temporary credentials (STS, IMDS, SSO) expired roughly an hour in, after which every request failed with a signature error until restart — unrecoverable, because the cache was a private `static` and this adapter discards `AuthData`. The cache now mirrors the AWS SDK's identity cache: treat credentials as expired 10 seconds early, fall back to a 15-minute TTL when the provider reports no expiry, deduplicate concurrent refreshes, and jitter them.

**2. `bedrock_api` — accept `AWS_BEARER_TOKEN_BEDROCK`.**
Only `BEDROCK_API_KEY` was read, while AWS documents `AWS_BEARER_TOKEN_BEDROCK` — the name the AWS SDKs use — so following the AWS docs silently found no key. Both are accepted now, `BEDROCK_API_KEY` first, and an empty value falls through instead of shadowing the other. An explicit `AuthData` (key, custom env var, or resolver result) is still used as-is.

**3. `bedrock_sigv4` — build the request URL for the region we sign for.**
Two independent lookups fed one signed request: the endpoint came from `resolve_region()` (env only, defaulting to `us-east-1`), while the SigV4 credential scope came from `aws-config`, which also reads the profile region in `~/.aws/config` and IMDS. With a profile-only region, the request went to the `us-east-1` host signed for `eu-west-1`, and AWS answered `SignatureDoesNotMatch`. The reconciling `override_endpoint_region` matched a literal `bedrock-runtime..amazonaws.com` placeholder that no code path produces, so it never ran; it now rebuilds the endpoint when it recognises its own env-derived default, and leaves user-supplied endpoints (VPC endpoint, proxy, gateway) alone.

**Tests.** New unit tests cover the refresh deadline/buffer/jitter, the env-var precedence, and the URL/signing-region alignment — the last one fails against the previous implementation.

**Scope.** 6 files, Bedrock adapters only. The `bedrock_sigv4` `block_in_place` runtime requirement is unchanged.

Validation:

- `cargo test --features bedrock-sigv4 --lib` — 335 passed
- `cargo check --features bedrock-sigv4 --all-targets`
- `rustfmt --check` on the changed files
- `git diff --check`