### PR TITLE
feat(error): expose response headers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -199,6 +199,20 @@ impl Error {
 			_ => None,
 		}
 	}
+
+	/// Response headers returned with a failed HTTP status, when available.
+	///
+	/// This is the companion to [`Error::status`]. It lets callers implement
+	/// their own retry policy while honoring provider headers such as
+	/// `retry-after`, `retry-after-ms`, and `x-should-retry` without matching
+	/// internal error variants.
+	pub fn headers(&self) -> Option<&HeaderMap> {
+		match self {
+			Error::HttpError { headers, .. } => Some(headers),
+			Error::WebModelCall { webc_error, .. } | Error::WebAdapterCall { webc_error, .. } => webc_error.headers(),
+			_ => None,
+		}
+	}
 }
 
 // region:    --- Error Boilerplate
@@ -221,7 +235,7 @@ mod tests {
 	type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>; // For tests.
 
 	use super::*;
-	use reqwest::header::HeaderMap;
+	use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
 
 	fn webc_status_error(status: u16) -> webc::Error {
 		webc::Error::ResponseFailedStatus {
@@ -298,6 +312,57 @@ mod tests {
 
 		// -- Exec & Check
 		assert_eq!(error.status(), None);
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_error_headers_from_web_model_call() -> Result<()> {
+		let mut headers = HeaderMap::new();
+		headers.insert(RETRY_AFTER, HeaderValue::from_static("7"));
+		let error = Error::WebModelCall {
+			model_iden: ModelIden::new(AdapterKind::OpenAI, "gpt-4o"),
+			webc_error: webc::Error::ResponseFailedStatus {
+				status: StatusCode::TOO_MANY_REQUESTS,
+				body: "body".to_string(),
+				headers: Box::new(headers),
+			},
+		};
+
+		assert_eq!(
+			error.headers().and_then(|headers| headers.get(RETRY_AFTER)),
+			Some(&HeaderValue::from_static("7"))
+		);
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_error_headers_from_http_error() -> Result<()> {
+		let mut headers = HeaderMap::new();
+		headers.insert(RETRY_AFTER, HeaderValue::from_static("11"));
+		let error = Error::HttpError {
+			status: StatusCode::SERVICE_UNAVAILABLE,
+			canonical_reason: "Service Unavailable".to_string(),
+			body: "body".to_string(),
+			headers: Box::new(headers),
+		};
+
+		assert_eq!(
+			error.headers().and_then(|headers| headers.get(RETRY_AFTER)),
+			Some(&HeaderValue::from_static("11"))
+		);
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_error_headers_none_without_a_response() -> Result<()> {
+		let error = Error::NoAuthData {
+			model_iden: ModelIden::new(AdapterKind::OpenAI, "gpt-4o"),
+		};
+
+		assert!(error.headers().is_none());
 
 		Ok(())
 	}

--- a/src/webc/error.rs
+++ b/src/webc/error.rs
@@ -47,6 +47,19 @@ impl Error {
 			_ => None,
 		}
 	}
+
+	/// Response headers returned with a failed HTTP status, when available.
+	///
+	/// These headers commonly carry provider retry guidance such as
+	/// `retry-after`, `retry-after-ms`, and `x-should-retry`. Errors produced
+	/// before a response is received, and `reqwest::Error`, do not retain a
+	/// response header map here.
+	pub fn headers(&self) -> Option<&HeaderMap> {
+		match self {
+			Error::ResponseFailedStatus { headers, .. } => Some(headers),
+			_ => None,
+		}
+	}
 }
 
 // region:    --- Error Boilerplate
@@ -59,5 +72,27 @@ impl Error {
 // }
 
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use reqwest::header::{HeaderValue, RETRY_AFTER};
+
+	#[test]
+	fn response_status_headers_are_exposed() {
+		let mut headers = HeaderMap::new();
+		headers.insert(RETRY_AFTER, HeaderValue::from_static("5"));
+		let error = Error::ResponseFailedStatus {
+			status: StatusCode::TOO_MANY_REQUESTS,
+			body: "slow down".to_string(),
+			headers: Box::new(headers),
+		};
+
+		assert_eq!(
+			error.headers().and_then(|headers| headers.get(RETRY_AFTER)),
+			Some(&HeaderValue::from_static("5"))
+		);
+	}
+}
 
 // endregion: --- Error Boilerplate


### PR DESCRIPTION
`genai::Error::status()` lets downstream callers classify provider failures, but retry policy also needs the response headers retained by `HttpError` and `webc::Error::ResponseFailedStatus`. Without a public accessor, callers cannot honor `Retry-After`, `retry-after-ms`, or `x-should-retry` without matching internal variants.

This adds borrowed `headers()` accessors to `webc::Error` and `genai::Error`, covering both model/adapter web errors and direct `HttpError` values. Errors without a retained response header map return `None`.

Validation:

- `cargo fmt --check`
- `cargo test error::tests`
- `cargo test webc::error::tests`
