### PR TITLE
+ bedrock_sigv4 - select the AWS profile per client via AuthData

### DIFF
--- a/docs/for-llm/api-reference-for-llm.md
+++ b/docs/for-llm/api-reference-for-llm.md
@@ -38,7 +38,7 @@ genai (crate root / lib.rs)
   - `vertex` (since v0.6.0) is Google Vertex AI Model Garden routing for Gemini and Anthropic models via the `vertex::` namespace.
   - `opencode_go` (since v0.6.0) is a curated open coding model proxy with dual-protocol routing via the `opencode_go::` namespace. Uses `OPENCODE_GO_API_KEY`.
   - `bedrock_api` (since v0.6.0) is AWS Bedrock Converse API, authenticated with a simple Bearer token from `BEDROCK_API_KEY`. Use via the `bedrock_api::` namespace.
-  - `bedrock_sigv4` (since v0.6.0) is AWS Bedrock Converse API, authenticated via SigV4 + standard AWS credential chain. Requires the `bedrock-sigv4` feature. Use via the `bedrock_sigv4::` namespace.
+  - `bedrock_sigv4` (since v0.6.0) is AWS Bedrock Converse API, authenticated via SigV4 + standard AWS credential chain. The AWS profile is selectable per client via `AuthData`; otherwise `AWS_PROFILE`, else `default`. Requires the `bedrock-sigv4` feature. Use via the `bedrock_sigv4::` namespace.
   - `open_router` (since v0.6.0) is OpenRouter OpenAI-compatible gateway. Uses `OPEN_ROUTER_API_KEY`. Use via the `open_router::` namespace.
   - `baidu` (since v0.6.0) is Baidu's OpenAI/Anthropic compatible proxies.
   - `aliyun` (since v0.6.0) is Aliyun's namespace-only OpenAI-compatible service.
@@ -575,6 +575,10 @@ Resolution order is `ModelMapper` -> `AuthResolver` -> adapter default endpoint 
 - `MultiKeys(HashMap<String, String>)`: Multiple credential pieces (adapter-specific, not yet used).
 - **Constructors**: `from_env(env_name)`, `from_single(value)`, `from_multi(data)`.
 - `single_key_value()`: Resolves to a single key string (reads env if `FromEnv`).
+- Adapter-specific semantics:
+  - `bedrock_sigv4`: the value is an AWS profile name (e.g. `dev`), not an API key; the credentials come from the AWS chain.
+    - Forms: `Key("<profile>")`, `FromEnv("<VAR>")`, or `MultiKeys({ "profile": "<name>" })`.
+    - Default: `None` or blank → `AWS_PROFILE`, else `default`; each profile caches its own credentials.
 
 ### `AuthResolver`
 

--- a/examples/c99-bedrock-sigv4.rs
+++ b/examples/c99-bedrock-sigv4.rs
@@ -11,9 +11,12 @@
 //!
 //! Required env vars (any of these set up via `aws configure` / SSO / IAM role / etc.):
 //!   - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN for STS credentials), OR
-//!   - AWS_PROFILE pointing at a profile in ~/.aws/credentials, OR
+//!   - AWS_PROFILE naming a profile in ~/.aws/config or ~/.aws/credentials, OR
 //!   - IMDS (on EC2 / ECS / EKS), OR
 //!   - SSO session
+//!
+//! The profile can also be selected in code, per client, via `AuthData::Key("<profile>")` in
+//! `ClientBuilder::append_provider_config(AdapterKind::BedrockSigv4, ..)`.
 //!
 //! Optional:
 //!   - AWS_REGION / AWS_DEFAULT_REGION: defaults to `us-east-1`. Model availability varies by

--- a/src/adapter/adapter_kind.rs
+++ b/src/adapter/adapter_kind.rs
@@ -106,7 +106,8 @@ pub enum AdapterKind {
 	BedrockApi,
 
 	/// AWS Bedrock Converse API, authenticated via SigV4 + the AWS credential chain
-	/// (env, profile, SSO, IMDS, AssumeRole).
+	/// (env, profile, SSO, IMDS, AssumeRole). `AuthData` carries an AWS profile name
+	/// (`Key`/`FromEnv`/`MultiKeys`); `None` follows `AWS_PROFILE`, else `default`.
 	/// Namespace: `bedrock_sigv4::anthropic.claude-sonnet-4-5-20250929-v1:0`.
 	/// Requires the `bedrock-sigv4` Cargo feature.
 	#[cfg(feature = "bedrock-sigv4")]

--- a/src/adapter/adapters/bedrock/adapter_api.rs
+++ b/src/adapter/adapters/bedrock/adapter_api.rs
@@ -6,7 +6,9 @@
 //! See: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html
 
 use crate::adapter::adapters::bedrock::converse::{build_converse_payload, parse_converse_response};
-use crate::adapter::adapters::bedrock::shared::{BEDROCK_RUNTIME_HOST_PREFIX, async_stream_bytes, build_service_url};
+use crate::adapter::adapters::bedrock::shared::{
+	BEDROCK_RUNTIME_HOST_PREFIX, DEFAULT_REGION, async_stream_bytes, build_service_url, region_from_env,
+};
 use crate::adapter::adapters::bedrock::streamer::BedrockStreamer;
 use crate::adapter::adapters::support::get_api_key;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
@@ -55,9 +57,7 @@ impl BedrockApiAdapter {
 	}
 
 	fn resolve_region() -> String {
-		std::env::var("AWS_REGION")
-			.or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
-			.unwrap_or_else(|_| "us-east-1".to_string())
+		region_from_env().unwrap_or_else(|| DEFAULT_REGION.to_string())
 	}
 
 	fn endpoint_for_region(region: &str) -> String {

--- a/src/adapter/adapters/bedrock/adapter_sigv4.rs
+++ b/src/adapter/adapters/bedrock/adapter_sigv4.rs
@@ -3,8 +3,10 @@
 //! Requires the `bedrock-sigv4` Cargo feature.
 
 use crate::adapter::adapters::bedrock::converse::{build_converse_payload, parse_converse_response};
-use crate::adapter::adapters::bedrock::shared::{BEDROCK_RUNTIME_HOST_PREFIX, async_stream_bytes, build_service_url};
-use crate::adapter::adapters::bedrock::sigv4::{cached_region, get_credentials, sign_request};
+use crate::adapter::adapters::bedrock::shared::{
+	BEDROCK_RUNTIME_HOST_PREFIX, DEFAULT_REGION, async_stream_bytes, build_service_url, region_from_env,
+};
+use crate::adapter::adapters::bedrock::sigv4::{get_credentials, profile_from_auth, sign_request};
 use crate::adapter::adapters::bedrock::streamer::BedrockStreamer;
 use crate::adapter::{Adapter, AdapterKind, ServiceType, WebRequestData};
 use crate::chat::{ChatOptionsSet, ChatRequest, ChatResponse, ChatStream, ChatStreamResponse};
@@ -17,9 +19,7 @@ pub struct BedrockSigv4Adapter;
 
 impl BedrockSigv4Adapter {
 	fn resolve_region() -> String {
-		std::env::var("AWS_REGION")
-			.or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
-			.unwrap_or_else(|_| "us-east-1".to_string())
+		region_from_env().unwrap_or_else(|| DEFAULT_REGION.to_string())
 	}
 
 	pub(super) fn endpoint_for_region(region: &str) -> String {
@@ -36,7 +36,8 @@ impl Adapter for BedrockSigv4Adapter {
 	}
 
 	fn default_auth(_kind: AdapterKind) -> AuthData {
-		// Credentials come from the AWS default chain at request time.
+		// Credentials come from the AWS chain at request time; a profile can be selected per client
+		// via `ProviderConfig`/`AuthData`, which reaches us as `ServiceTarget::auth`.
 		AuthData::None
 	}
 
@@ -59,17 +60,14 @@ impl Adapter for BedrockSigv4Adapter {
 		chat_req: ChatRequest,
 		options_set: ChatOptionsSet<'_, '_>,
 	) -> Result<WebRequestData> {
-		let ServiceTarget {
-			endpoint,
-			auth: _,
-			model,
-		} = target;
+		let ServiceTarget { endpoint, auth, model } = target;
 
-		// 1. Resolve credentials, refreshing them when they are close to expiring.
-		let cached = tokio_block_on(get_credentials())?;
+		// 1. Resolve the selected AWS profile (if any) and its credentials, refreshing if needed.
+		let profile = profile_from_auth(&auth)?;
+		let cached = tokio_block_on(get_credentials(profile.as_deref()))?;
 
 		// 2. Align the default endpoint with the region we sign for.
-		let endpoint = override_endpoint_region(endpoint, cached_region(&cached));
+		let endpoint = override_endpoint_region(endpoint, &cached.region);
 
 		// 3. Build the Converse JSON payload.
 		let payload = build_converse_payload(&model, chat_req, options_set)?;
@@ -79,7 +77,7 @@ impl Adapter for BedrockSigv4Adapter {
 
 		// 5. Sign the request — we serialize the body for the payload hash.
 		let body_bytes = serde_json::to_vec(&payload)?;
-		let headers = sign_request(&cached.creds, cached_region(&cached), &url, &body_bytes)?;
+		let headers = sign_request(&cached.creds, &cached.region, &url, &body_bytes)?;
 
 		Ok(WebRequestData { url, headers, payload })
 	}

--- a/src/adapter/adapters/bedrock/mod.rs
+++ b/src/adapter/adapters/bedrock/mod.rs
@@ -8,8 +8,10 @@
 //!
 //! * `BedrockSigv4Adapter` — opt-in via the `bedrock-sigv4` Cargo feature. Full AWS credential
 //!   chain + SigV4 request signing via `aws-config` and `aws-sigv4`. Best for workloads that
-//!   already use AWS credentials (env, profile, SSO, IMDS, AssumeRole). Pulls in the AWS SDK
-//!   smithy/hyper dep tree. Temporary credentials are refreshed before they expire.
+//!   already use AWS credentials (env, profile, SSO, IMDS, AssumeRole). `AuthData` carries an AWS
+//!   profile name (`Key`/`FromEnv`/`MultiKeys`; `None` follows `AWS_PROFILE`, else `default`), and
+//!   each profile caches its own credentials and region. Temporary credentials are refreshed before
+//!   they expire.
 //!
 //! Both adapters use the Converse API which normalizes chat requests across Bedrock's
 //! publishers (Anthropic, Amazon Nova, Meta Llama, Mistral, Cohere, AI21).

--- a/src/adapter/adapters/bedrock/shared.rs
+++ b/src/adapter/adapters/bedrock/shared.rs
@@ -9,6 +9,16 @@ use reqwest::RequestBuilder;
 /// prefix and `.amazonaws.com`.
 pub(super) const BEDROCK_RUNTIME_HOST_PREFIX: &str = "bedrock-runtime";
 
+/// Region used when neither `aws-config` nor the environment provides one.
+pub(super) const DEFAULT_REGION: &str = "us-east-1";
+
+/// Region from the environment: `AWS_REGION`, else `AWS_DEFAULT_REGION`.
+pub(super) fn region_from_env() -> Option<String> {
+	std::env::var("AWS_REGION")
+		.ok()
+		.or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+}
+
 /// Curated snapshot of model IDs. Dynamic listing requires the `bedrock` (control plane) API,
 /// not `bedrock-runtime`, so we return a hard-coded list here.
 pub(super) fn curated_model_names() -> Vec<String> {

--- a/src/adapter/adapters/bedrock/sigv4.rs
+++ b/src/adapter/adapters/bedrock/sigv4.rs
@@ -1,26 +1,34 @@
 //! SigV4 signing + credential resolution for Bedrock.
 //!
-//! Credentials come from `aws-config`'s default chain (env → profile → SSO → IMDS → AssumeRole)
-//! and are cached until shortly before they expire; signing is per-request via `aws-sigv4`.
+//! Credentials come from `aws-config`'s default chain (env → profile → SSO → IMDS → AssumeRole) and
+//! are cached per AWS profile until shortly before they expire; signing is per-request via
+//! `aws-sigv4`. The profile is selected per client as `AuthData::Key("<profile>")` (see
+//! [`profile_from_auth`]); `AuthData::None` follows `AWS_PROFILE`, else `default`.
 //!
 //! The cache mirrors the AWS SDK's identity cache: expire `REFRESH_BUFFER` early, fall back to
 //! `DEFAULT_EXPIRATION` when no expiry is reported, deduplicate concurrent refreshes, and jitter
 //! to avoid lockstep. Without it, a long-lived process would keep signing with credentials that
 //! expired an hour after start-up (`provide_credentials()` returns a frozen snapshot).
 
+use super::shared::{DEFAULT_REGION, region_from_env};
 use crate::Headers;
+use crate::resolver::AuthData;
 use crate::{Error, Result};
 use aws_credential_types::Credentials;
 use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
 use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, sign};
 use aws_sigv4::sign::v4;
+use std::collections::HashMap;
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hasher};
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, SystemTime};
-use tokio::sync::{Mutex, OnceCell};
 
 /// Service name for SigV4 scope; matches the service expected by `bedrock-runtime`.
 pub(super) const BEDROCK_SERVICE: &str = "bedrock";
+
+/// `AuthData::MultiKeys` entry naming the AWS profile.
+const PROFILE_AUTH_KEY: &str = "profile";
 
 /// Treat credentials as expired this long before their real expiration.
 /// Mirrors `DEFAULT_BUFFER_TIME` in the AWS SDK's identity cache.
@@ -30,84 +38,137 @@ const REFRESH_BUFFER: Duration = Duration::from_secs(10);
 /// Mirrors `DEFAULT_EXPIRATION` in the AWS SDK's identity cache.
 const DEFAULT_EXPIRATION: Duration = Duration::from_secs(15 * 60);
 
-/// Credential provider + region, resolved once per process.
-static AWS_CONFIG: OnceCell<AwsConfig> = OnceCell::const_new();
+/// AWS profile selector: a named profile, or `None` for the ambient chain.
+type ProfileKey = Option<String>;
 
-/// Expiry-aware credentials cache; `None` until the first resolution.
-static CREDS_CACHE: Mutex<Option<CachedCreds>> = Mutex::const_new(None);
+/// Credentials cached per AWS profile, refreshed in place when they expire.
+///
+/// The cache is keyed by profile name alone, so every client that selects one profile also shares
+/// its region (the profile's `region` setting, else `AWS_REGION`).
+static CREDS_CACHE: LazyLock<Mutex<HashMap<ProfileKey, CachedCreds>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
-struct AwsConfig {
-	provider: SharedCredentialsProvider,
-	region: String,
-}
-
-/// Resolved credentials and the region they were resolved for.
+/// Credentials for one AWS profile: what to sign with, the region they are valid for, and the
+/// provider + deadline that keep them fresh.
 #[derive(Clone)]
 pub(super) struct CachedCreds {
-	pub creds: Credentials,
-	pub region: String,
+	pub(super) creds: Credentials,
+	pub(super) region: String,
+	/// Refreshes these credentials; cache plumbing, not for callers.
+	provider: SharedCredentialsProvider,
 	/// Expiration (or default TTL) plus jitter; cache bookkeeping only.
 	deadline: SystemTime,
 }
 
-/// Returns credentials + region, refreshing them when they are close to expiring.
+/// Returns `profile`'s credentials and region, refreshing them when they are close to expiring.
 ///
-/// Holding the lock across the refresh deduplicates concurrent callers, as the AWS SDK's
-/// `ExpiringCache::get_or_load` does.
-pub(super) async fn get_credentials() -> Result<CachedCreds> {
-	let config = get_aws_config().await?;
+/// `profile` is an AWS named profile; `None` follows the ambient chain (`AWS_PROFILE`, else
+/// `default`). A failed refresh keeps the previous entry, so the next call retries.
+pub(super) async fn get_credentials(profile: Option<&str>) -> Result<CachedCreds> {
+	let key = normalize_profile(profile);
 	let now = SystemTime::now();
 
-	let mut cache = CREDS_CACHE.lock().await;
-
-	// Fast path: the cached credentials are still fresh.
-	if let Some(cached) = cache.as_ref()
+	// Fast path: a fresh entry is served without waiting for any fetch in flight.
+	if let Some(cached) = cached_for(&key)
 		&& !expired(cached.deadline, now)
 	{
-		return Ok(cached.clone());
+		return Ok(cached);
 	}
 
-	// Slow path: refresh.
-	let creds = fetch_credentials(config).await?;
+	// Slow path, resolved outside the lock: reuse this profile's provider if one is cached, else
+	// load its config. Re-fetching from that provider is what refreshes temporary credentials
+	// (SSO, AssumeRole, `credential_process`, IMDS).
+	let (provider, region) = match cached_for(&key) {
+		Some(cached) => (cached.provider.clone(), cached.region.clone()),
+		None => load_aws_config(key.as_deref()).await?,
+	};
+
+	let creds = provider
+		.provide_credentials()
+		.await
+		.map_err(|err| creds_err(key.as_deref(), err))?;
+
 	let cached = CachedCreds {
 		deadline: deadline(creds.expiry(), now, jitter_fraction()),
 		creds,
-		region: config.region.clone(),
+		region,
+		provider,
 	};
-	cache.replace(cached.clone());
+	store(key, cached.clone());
 
 	Ok(cached)
 }
 
-async fn get_aws_config() -> Result<&'static AwsConfig> {
-	AWS_CONFIG.get_or_try_init(load_aws_config).await
+/// The cached credentials for a profile, if any.
+fn cached_for(key: &ProfileKey) -> Option<CachedCreds> {
+	CREDS_CACHE.lock().unwrap_or_else(|err| err.into_inner()).get(key).cloned()
 }
 
-async fn load_aws_config() -> Result<AwsConfig> {
+/// Caches a profile's credentials.
+fn store(key: ProfileKey, cached: CachedCreds) {
+	CREDS_CACHE.lock().unwrap_or_else(|err| err.into_inner()).insert(key, cached);
+}
+
+/// Normalizes a profile selector: blank means the ambient chain, like an empty `AWS_PROFILE`.
+fn normalize_profile(profile: Option<&str>) -> ProfileKey {
+	profile.map(str::trim).filter(|profile| !profile.is_empty()).map(str::to_owned)
+}
+
+/// Extracts the AWS profile a caller selected, from the auth data resolved into `ServiceTarget`:
+///
+/// - `AuthData::None` → ambient chain (`AWS_PROFILE`, else `default`)
+/// - `AuthData::Key("dev")` → profile `dev`
+/// - `AuthData::FromEnv("MY_PROFILE")` → the profile named by that environment variable
+/// - `AuthData::MultiKeys({ "profile": "dev" })` → profile `dev`, and a missing `profile` entry is
+///   an error, since `MultiKeys` is the explicit form
+///
+/// A blank value means "no profile", like an empty `AWS_PROFILE`. `RequestOverride` keeps the
+/// ambient chain, since the client applies that override to the final request itself.
+pub(super) fn profile_from_auth(auth: &AuthData) -> Result<ProfileKey> {
+	let profile = match auth {
+		AuthData::None | AuthData::RequestOverride { .. } => None,
+		AuthData::MultiKeys(keys) => Some(
+			keys.get(PROFILE_AUTH_KEY)
+				.ok_or_else(|| aws_err(format!("AuthData::MultiKeys requires a '{PROFILE_AUTH_KEY}' entry")))?
+				.to_owned(),
+		),
+		// The single-valued forms (`Key`, `FromEnv`).
+		single => Some(
+			single
+				.single_key_value()
+				.map_err(|err| aws_err(format!("AWS profile lookup failed: {err}")))?,
+		),
+	};
+
+	Ok(normalize_profile(profile.as_deref()))
+}
+
+/// Loads `aws-config`'s chain for `profile`, returning `(provider, region)`.
+async fn load_aws_config(profile: Option<&str>) -> Result<(SharedCredentialsProvider, String)> {
 	use aws_config::BehaviorVersion;
 
-	let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+	let mut loader = aws_config::defaults(BehaviorVersion::latest());
+	if let Some(profile) = profile {
+		loader = loader.profile_name(profile);
+	}
+	let config = loader.load().await;
 
 	let region = config
 		.region()
 		.map(|r| r.as_ref().to_string())
-		.or_else(|| std::env::var("AWS_REGION").ok())
-		.or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
-		.unwrap_or_else(|| "us-east-1".to_string());
+		.or_else(region_from_env)
+		.unwrap_or_else(|| DEFAULT_REGION.to_string());
 
 	let provider = config
 		.credentials_provider()
 		.ok_or_else(|| aws_err("AWS credentials (no provider found in default chain)"))?;
 
-	Ok(AwsConfig { provider, region })
+	Ok((provider, region))
 }
 
-async fn fetch_credentials(config: &AwsConfig) -> Result<Credentials> {
-	config
-		.provider
-		.provide_credentials()
-		.await
-		.map_err(|err| aws_err(format!("AWS credential resolution failed: {err}")))
+/// Credential-resolution failure, naming the profile when the caller selected one.
+fn creds_err(profile: Option<&str>, err: impl std::fmt::Display) -> Error {
+	let for_profile = profile.map(|profile| format!(" for profile '{profile}'")).unwrap_or_default();
+	aws_err(format!("AWS credential resolution failed{for_profile}: {err}"))
 }
 
 /// `true` once `now` is within `REFRESH_BUFFER` of the deadline.
@@ -130,12 +191,6 @@ fn jitter_fraction() -> f64 {
 	hasher.write_u64(0);
 	// Top 53 bits give a uniform value in [0, 1).
 	((hasher.finish() >> 11) as f64 / (1_u64 << 53) as f64) * 0.5
-}
-
-/// Extract the region from an already-loaded credentials snapshot.
-/// Callers that need a request-time override should pass it to [`sign_request`] directly.
-pub(super) fn cached_region(cached: &CachedCreds) -> &str {
-	&cached.region
 }
 
 /// Sign a POST request (url + JSON body) for Bedrock Runtime and return the resulting
@@ -196,9 +251,7 @@ fn sign_err(msg: String) -> Error {
 fn url_host(url: &str) -> Option<&str> {
 	// Minimal host extraction: strip scheme, take up to first '/' or ':' or end.
 	let without_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
-	let end = without_scheme
-		.find(|c: char| c == '/' || c == ':' || c == '?')
-		.unwrap_or(without_scheme.len());
+	let end = without_scheme.find(['/', ':', '?']).unwrap_or(without_scheme.len());
 	let host = &without_scheme[..end];
 	if host.is_empty() { None } else { Some(host) }
 }
@@ -206,6 +259,10 @@ fn url_host(url: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use aws_credential_types::provider;
+	use std::sync::Arc;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+	use tokio::sync::Notify;
 
 	fn epoch_secs(secs: u64) -> SystemTime {
 		SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
@@ -275,4 +332,248 @@ mod tests {
 			);
 		}
 	}
+
+	#[test]
+	fn blank_profile_selects_the_ambient_chain() {
+		assert_eq!(normalize_profile(None), None);
+		// An empty `AWS_PROFILE` is ignored by the AWS CLI and aws-config, so a blank value here
+		// must not become a profile named "".
+		assert_eq!(normalize_profile(Some("")), None);
+		assert_eq!(normalize_profile(Some("   ")), None);
+		assert_eq!(normalize_profile(Some(" dev ")), Some("dev".to_string()));
+	}
+
+	#[test]
+	fn profile_comes_from_the_auth_data() {
+		assert_eq!(profile_from_auth(&AuthData::None).unwrap(), None);
+		assert_eq!(
+			profile_from_auth(&AuthData::Key("dev".to_string())).unwrap(),
+			Some("dev".to_string())
+		);
+		assert_eq!(profile_from_auth(&AuthData::Key(" ".to_string())).unwrap(), None);
+		assert_eq!(
+			profile_from_auth(&AuthData::from_multi(HashMap::from([(
+				PROFILE_AUTH_KEY.to_string(),
+				"prod".to_string()
+			)])))
+			.unwrap(),
+			Some("prod".to_string())
+		);
+	}
+
+	#[test]
+	fn multi_keys_without_a_profile_is_an_error() {
+		let auth = AuthData::from_multi(HashMap::new());
+		assert!(profile_from_auth(&auth).is_err(), "a profile key is required");
+	}
+
+	#[test]
+	fn request_override_keeps_the_ambient_chain() {
+		// The client applies `RequestOverride` to the final request, so it selects no profile here.
+		let auth = AuthData::RequestOverride {
+			url: String::new(),
+			headers: Headers::default(),
+		};
+		assert_eq!(profile_from_auth(&auth).unwrap(), None);
+	}
+
+	#[test]
+	fn env_auth_reads_the_profile_from_the_named_variable() {
+		// `PATH` is set in every environment, so this covers the env-name path without mutating the
+		// process environment (which the crate's `unsafe_code = "forbid"` lint rules out).
+		let value = std::env::var("PATH").expect("PATH must be set");
+
+		let profile = profile_from_auth(&AuthData::from_env("PATH")).expect("PATH is set");
+
+		let expected = value.trim();
+		let expected = (!expected.is_empty()).then(|| expected.to_owned());
+		assert_eq!(profile, expected);
+	}
+
+	#[test]
+	fn env_auth_for_a_missing_variable_is_an_error() {
+		let auth = AuthData::from_env("GENAI_TEST_NO_SUCH_PROFILE_ENV");
+		assert!(profile_from_auth(&auth).is_err());
+	}
+
+	// region:    --- Errors
+
+	#[test]
+	fn credential_errors_name_the_profile() {
+		let named = creds_err(Some("dev"), "boom");
+		assert!(named.to_string().contains("profile 'dev'"), "{named}");
+		assert!(named.to_string().contains("boom"), "{named}");
+
+		// Nothing to name when the ambient chain was used.
+		let ambient = creds_err(None, "boom");
+		assert!(!ambient.to_string().contains("profile"), "{ambient}");
+	}
+
+	// endregion: --- Errors
+
+	// region:    --- Cache behavior
+
+	/// Hands out fixed credentials and counts how often it was asked, so a test can tell a cached
+	/// credential from a freshly fetched one.
+	#[derive(Debug)]
+	struct CountingProvider {
+		access_key: &'static str,
+		calls: Arc<AtomicUsize>,
+	}
+
+	impl ProvideCredentials for CountingProvider {
+		fn provide_credentials<'a>(&'a self) -> provider::future::ProvideCredentials<'a>
+		where
+			Self: 'a,
+		{
+			self.calls.fetch_add(1, Ordering::SeqCst);
+			let creds = Credentials::new(self.access_key, "secret", None, None, "genai-test");
+			provider::future::ProvideCredentials::ready(Ok(creds))
+		}
+	}
+
+	/// Inserts a fresh cache entry, so cache behavior is testable without touching AWS.
+	fn seed(
+		profile: Option<&str>,
+		access_key: &'static str,
+		region: &'static str,
+		calls: &Arc<AtomicUsize>,
+	) -> ProfileKey {
+		let provider = SharedCredentialsProvider::new(CountingProvider {
+			access_key,
+			calls: calls.clone(),
+		});
+
+		seed_entry(profile, access_key, region, provider)
+	}
+
+	/// Inserts a fresh cache entry backed by `provider`.
+	fn seed_entry(
+		profile: Option<&str>,
+		access_key: &'static str,
+		region: &'static str,
+		provider: SharedCredentialsProvider,
+	) -> ProfileKey {
+		let key = normalize_profile(profile);
+		store(
+			key.clone(),
+			CachedCreds {
+				creds: Credentials::new(access_key, "secret", None, None, "genai-test"),
+				region: region.to_string(),
+				provider,
+				deadline: deadline(None, SystemTime::now(), 0.0),
+			},
+		);
+
+		key
+	}
+
+	/// Expires an entry, instead of waiting out its TTL.
+	fn expire(key: &ProfileKey) {
+		let mut cached = cached_for(key).expect("the entry was just seeded");
+		cached.deadline = SystemTime::UNIX_EPOCH;
+		store(key.clone(), cached);
+	}
+
+	#[tokio::test]
+	async fn fresh_credentials_are_served_from_the_cache() {
+		let calls = Arc::new(AtomicUsize::new(0));
+		seed(Some("test-fresh"), "AKIACACHED", "eu-west-1", &calls);
+
+		let cached = get_credentials(Some("test-fresh")).await.expect("cached credentials");
+
+		assert_eq!(cached.creds.access_key_id(), "AKIACACHED");
+		assert_eq!(cached.region, "eu-west-1");
+		assert_eq!(calls.load(Ordering::SeqCst), 0, "a fresh entry must not re-fetch");
+	}
+
+	#[tokio::test]
+	async fn expired_credentials_are_refreshed_in_place() {
+		let calls = Arc::new(AtomicUsize::new(0));
+		let key = seed(Some("test-refresh"), "AKIAOLD", "eu-west-1", &calls);
+		expire(&key);
+
+		let refreshed = get_credentials(Some("test-refresh")).await.expect("refreshed credentials");
+
+		assert_eq!(calls.load(Ordering::SeqCst), 1, "an expired entry must re-fetch");
+		assert_eq!(
+			refreshed.creds.access_key_id(),
+			"AKIAOLD",
+			"the cached provider is reused"
+		);
+		assert_eq!(refreshed.region, "eu-west-1", "the profile's region survives a refresh");
+	}
+
+	#[tokio::test]
+	async fn each_profile_keeps_its_own_credentials() {
+		let calls = Arc::new(AtomicUsize::new(0));
+		seed(Some("test-dev"), "AKIADEV", "eu-west-1", &calls);
+		seed(Some("test-prod"), "AKIAPROD", "us-east-1", &calls);
+
+		let dev = get_credentials(Some("test-dev")).await.expect("dev credentials");
+		let prod = get_credentials(Some("test-prod")).await.expect("prod credentials");
+
+		assert_eq!(dev.creds.access_key_id(), "AKIADEV");
+		assert_eq!(prod.creds.access_key_id(), "AKIAPROD");
+		assert_ne!(dev.region, prod.region, "profiles must not share a region");
+		assert_eq!(calls.load(Ordering::SeqCst), 0, "seeded entries need no fetch");
+	}
+
+	/// Parks inside `provide_credentials` until released, to hold one fetch in flight.
+	#[derive(Debug)]
+	struct BlockingProvider {
+		entered: Arc<Notify>,
+		release: Arc<Notify>,
+	}
+
+	impl ProvideCredentials for BlockingProvider {
+		fn provide_credentials<'a>(&'a self) -> provider::future::ProvideCredentials<'a>
+		where
+			Self: 'a,
+		{
+			let entered = self.entered.clone();
+			let release = self.release.clone();
+
+			provider::future::ProvideCredentials::new(async move {
+				entered.notify_one();
+				release.notified().await;
+				Ok(Credentials::new("AKIASLOW", "secret", None, None, "genai-test"))
+			})
+		}
+	}
+
+	/// The lock is never held across a fetch, so a fetch in flight must not stall another profile.
+	#[tokio::test]
+	async fn a_slow_fetch_does_not_block_another_profile() {
+		let entered = Arc::new(Notify::new());
+		let release = Arc::new(Notify::new());
+
+		let slow_key = seed_entry(
+			Some("test-slow"),
+			"AKIASLOW",
+			"eu-west-1",
+			SharedCredentialsProvider::new(BlockingProvider {
+				entered: entered.clone(),
+				release: release.clone(),
+			}),
+		);
+		expire(&slow_key);
+
+		let calls = Arc::new(AtomicUsize::new(0));
+		seed(Some("test-other"), "AKIAFAST", "us-east-1", &calls);
+
+		let slow = tokio::spawn(async move { get_credentials(Some("test-slow")).await });
+		entered.notified().await;
+
+		let other = tokio::time::timeout(Duration::from_secs(5), get_credentials(Some("test-other")))
+			.await
+			.expect("another profile must resolve while a fetch is in flight")
+			.expect("the cached credentials should be usable");
+		assert_eq!(other.creds.access_key_id(), "AKIAFAST");
+
+		release.notify_one();
+		slow.await.expect("task should not panic").expect("slow profile should resolve");
+	}
+
+	// endregion: --- Cache behavior
 }

--- a/src/otel/error.rs
+++ b/src/otel/error.rs
@@ -52,6 +52,7 @@ pub fn error_type(error: &Error) -> String {
 		Error::CacheBreakpointNoEligibleContent { .. } => "cache_breakpoint_no_eligible_content".to_string(),
 
 		// -- Internals / externals
+		Error::ClientBuildFail { .. } => "client_build_fail".to_string(),
 		Error::Internal(_) => "internal".to_string(),
 		Error::JsonValueExt(_) => "json_value_ext".to_string(),
 		Error::SerdeJson(_) => "serde_json".to_string(),
@@ -127,6 +128,16 @@ mod tests {
 		assert_eq!(
 			error_type(&Error::JsonModeWithoutInstruction),
 			"json_mode_without_instruction"
+		);
+	}
+
+	#[test]
+	fn test_otel_error_type_client_build_fail() {
+		assert_eq!(
+			error_type(&Error::ClientBuildFail {
+				cause: "boom".to_string()
+			}),
+			"client_build_fail"
 		);
 	}
 }

--- a/src/resolver/auth_data.rs
+++ b/src/resolver/auth_data.rs
@@ -3,6 +3,10 @@ use crate::resolver::{Error, Result};
 use std::collections::HashMap;
 
 /// `AuthData` specifies either how or the key itself for an authentication resolver call.
+///
+/// The value is adapter-specific: most adapters read it as an API key, whereas `bedrock_sigv4`
+/// (the `bedrock-sigv4` feature) reads it as an AWS profile name, since its credentials come from
+/// the AWS chain instead.
 #[derive(Clone)]
 pub enum AuthData {
 	/// Specify the environment name to get the key value from.
@@ -18,8 +22,7 @@ pub enum AuthData {
 	},
 
 	/// The key names/values when a credential has multiple pieces of credential information.
-	/// This will be adapter-specific.
-	/// NOTE: Not used yet.
+	/// This will be adapter-specific; `bedrock_sigv4` expects a `profile` entry.
 	MultiKeys(HashMap<String, String>),
 
 	None,

--- a/tests/tests_p_bedrock_sigv4.rs
+++ b/tests/tests_p_bedrock_sigv4.rs
@@ -1,0 +1,28 @@
+#![cfg(feature = "bedrock-sigv4")]
+
+//! Live smoke test for `bedrock_sigv4` with an explicitly selected AWS profile.
+//!
+//! Needs the `bedrock-sigv4` feature and AWS credentials for the chosen profile; set
+//! `BEDROCK_SIGV4_TEST_PROFILE` to pick it (defaults to `default`).
+//!
+//! Run with: `cargo test --features bedrock-sigv4 --test tests_p_bedrock_sigv4 -- --nocapture`
+
+mod support;
+
+use crate::support::{TestResult, common_tests};
+use genai::resolver::AuthData;
+use serial_test::serial;
+
+// Cross-region inference profile prefix: newer Bedrock models are only reachable through one.
+const MODEL: &str = "bedrock_sigv4::us.amazon.nova-lite-v1:0";
+
+/// The profile is selected in code; a second client could use a different one in the same process.
+#[tokio::test(flavor = "multi_thread")]
+#[serial(bedrock_sigv4)]
+async fn test_chat_with_selected_profile_ok() -> TestResult<()> {
+	// -- Setup & Fixtures
+	let profile = std::env::var("BEDROCK_SIGV4_TEST_PROFILE").unwrap_or_else(|_| "default".to_string());
+
+	// -- Exec & Check
+	common_tests::common_test_resolver_auth_ok(MODEL, AuthData::Key(profile)).await
+}


### PR DESCRIPTION
## What

`bedrock_sigv4` now reads `AuthData` as an AWS profile name, so a caller can choose the account per client:

    let dev = Client::builder()
        .append_provider_config(AdapterKind::BedrockSigv4, AuthData::Key("dev".to_string()))
        .build()?;

`Key("<profile>")`, `FromEnv("<VAR>")`, and `MultiKeys({ "profile": "<name>" })` all work. `None` or a blank value keeps today's behavior (`AWS_PROFILE`, else `default`); `RequestOverride` is untouched.

Previously the profile came from `AWS_PROFILE`, resolved once per process, so two clients in one process could not use different profiles.

The process-wide credential cache became a per-profile cache: each profile keeps its own provider, region, and credentials, and still refreshes them before expiry. 

Tests cover profile extraction and the cache (fresh reuse, refresh in place, one profile's fetch not blocking another), plus a live smoke test in `tests/tests_p_bedrock_sigv4.rs`. `cargo test --features bedrock-sigv4 --lib`, clippy under the same features, and `cargo test --features "bedrock-sigv4,otel" --no-run` are green.

## Notes

- Includes one incidental fix: `Error::ClientBuildFail` was missing from the OTel `error.type` mapping,
  so `otel` + `bedrock-sigv4` did not compile. 